### PR TITLE
fix tests

### DIFF
--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -2261,11 +2261,12 @@ def _should_persist_tile_embeddings(model, execution: ExecutionOptions) -> bool:
 
 
 def _resolved_process_list_output_variant(model) -> str | None:
+    requested_output_variant = getattr(model, "_output_variant", None)
     if not hasattr(model, "name") or model.name not in encoder_registry:
-        return model._output_variant if hasattr(model, "_output_variant") else None
+        return requested_output_variant
     resolved = resolve_encoder_output(
         model.name,
-        requested_output_variant=model._output_variant,
+        requested_output_variant=requested_output_variant,
     )
     return str(resolved["output_variant"])
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -176,6 +176,8 @@ def test_collect_distributed_pipeline_artifacts_runs_stage_collects_and_updates(
         persist_tile_embeddings,
         persist_hierarchical_embeddings,
         include_slide_embeddings,
+        encoder_name,
+        output_variant,
         tile_artifacts,
         hierarchical_artifacts,
         slide_artifacts,
@@ -186,6 +188,8 @@ def test_collect_distributed_pipeline_artifacts_runs_stage_collects_and_updates(
             "persist_tile_embeddings": persist_tile_embeddings,
             "persist_hierarchical_embeddings": persist_hierarchical_embeddings,
             "include_slide_embeddings": include_slide_embeddings,
+            "encoder_name": encoder_name,
+            "output_variant": output_variant,
             "tile_artifacts": tile_artifacts,
             "hierarchical_artifacts": hierarchical_artifacts,
             "slide_artifacts": slide_artifacts,
@@ -220,6 +224,8 @@ def test_collect_distributed_pipeline_artifacts_runs_stage_collects_and_updates(
     assert captured["update"]["persist_tile_embeddings"] is True
     assert captured["update"]["persist_hierarchical_embeddings"] is False
     assert captured["update"]["include_slide_embeddings"] is True
+    assert captured["update"]["encoder_name"] == "prism"
+    assert captured["update"]["output_variant"] == "default"
     assert captured["update"]["tile_artifacts"] == ["tile-artifact"]
     assert captured["update"]["hierarchical_artifacts"] == []
     assert captured["update"]["slide_artifacts"] == ["slide-artifact"]


### PR DESCRIPTION
## Summary
- make process-list output variant resolution tolerate models without `_output_variant`
- update the distributed artifact regression test double for the new provenance kwargs
- keep the new process-list provenance behavior covered without requiring every lightweight test model to define `_output_variant`