### PR TITLE
improve hierarchical extraction

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -137,6 +137,8 @@ Config fields:
 - `region_tile_multiple` — region grid width/height in tiles (e.g., `6` means 6x6 = 36 tiles per region; must be >= 2)
 - `target_region_size_px` — explicit parent region size in pixels; auto-derived from `target_tile_size_px * region_tile_multiple` if omitted
 
+When the selected read spacing differs from `target_spacing_um`, hierarchical extraction resolves effective geometry tile-first: it scales `target_tile_size_px` to the effective read spacing, then derives the effective parent region as `effective_tile_size_px * region_tile_multiple`. This keeps unrolled subtile geometry aligned with the model-facing tile size contract under spacing-driven rounding.
+
 When persisted via `Pipeline`, hierarchical artifacts are written to `hierarchical_embeddings/` and `RunResult` includes a `hierarchical_artifacts` list.
 
 Hierarchical extraction is supported for all tile-level models.

--- a/slide2vec/distributed/direct_embed_worker.py
+++ b/slide2vec/distributed/direct_embed_worker.py
@@ -25,6 +25,7 @@ def main(argv=None) -> int:
         _compute_hierarchical_embedding_shard_for_slide,
         _compute_tile_embeddings_for_slide,
         _is_hierarchical_preprocessing,
+        _resolve_hierarchical_geometry,
         deserialize_execution,
         deserialize_preprocessing,
         load_successful_tiled_slides,
@@ -74,9 +75,11 @@ def main(argv=None) -> int:
                 slide, tiling_result = paired_by_sample[sample_id]
                 loaded = model._load_backend()
                 if _is_hierarchical_preprocessing(preprocessing):
+                    geometry = _resolve_hierarchical_geometry(preprocessing, tiling_result)
                     index = _build_hierarchical_index(
                         tiling_result,
                         region_tile_multiple=int(preprocessing.region_tile_multiple),
+                        tile_size_lv0=int(geometry["tile_size_lv0"]),
                     )
                     flat_indices = np.array_split(index.flat_index, world_size)[global_rank]
                     shard_indices, tile_embeddings = _compute_hierarchical_embedding_shard_for_slide(

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -112,23 +112,14 @@ def _resolve_hierarchical_geometry(preprocessing: PreprocessingConfig, tiling_re
     target_tile_size_px = int(preprocessing.target_tile_size_px)
     target_region_size_px = int(preprocessing.target_region_size_px)
     target_spacing_um = float(preprocessing.target_spacing_um)
-    effective_spacing_value = getattr(tiling_result, "effective_spacing_um", None)
-    base_spacing_value = getattr(tiling_result, "base_spacing_um", None)
     multiple = int(preprocessing.region_tile_multiple)
     if target_region_size_px % multiple != 0:
         raise ValueError("target_region_size_px must be divisible by region_tile_multiple")
-    if effective_spacing_value is None:
-        effective_region_size_px = int(getattr(tiling_result, "effective_tile_size_px"))
-        effective_tile_size_px = effective_region_size_px // multiple
-    else:
-        effective_spacing_um = float(effective_spacing_value)
-        effective_tile_size_px = int(round(target_tile_size_px * target_spacing_um / effective_spacing_um))
-        effective_region_size_px = effective_tile_size_px * multiple
-    if base_spacing_value is None:
-        tile_size_lv0 = int(getattr(tiling_result, "tile_size_lv0")) // multiple
-    else:
-        base_spacing_um = float(base_spacing_value)
-        tile_size_lv0 = int(round(target_tile_size_px * target_spacing_um / base_spacing_um))
+    effective_spacing_um = float(getattr(tiling_result, "effective_spacing_um"))
+    base_spacing_um = float(getattr(tiling_result, "base_spacing_um"))
+    effective_tile_size_px = int(round(target_tile_size_px * target_spacing_um / effective_spacing_um))
+    effective_region_size_px = effective_tile_size_px * multiple
+    tile_size_lv0 = int(round(target_tile_size_px * target_spacing_um / base_spacing_um))
     return {
         "region_tile_multiple": multiple,
         "tiles_per_region": multiple * multiple,

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -111,19 +111,32 @@ def _resolve_hierarchical_geometry(preprocessing: PreprocessingConfig, tiling_re
         raise ValueError("Hierarchical preprocessing requires target_region_size_px")
     target_tile_size_px = int(preprocessing.target_tile_size_px)
     target_region_size_px = int(preprocessing.target_region_size_px)
-    effective_region_size_px = int(getattr(tiling_result, "effective_tile_size_px"))
-    tile_size_lv0 = int(getattr(tiling_result, "tile_size_lv0"))
+    target_spacing_um = float(preprocessing.target_spacing_um)
+    effective_spacing_value = getattr(tiling_result, "effective_spacing_um", None)
+    base_spacing_value = getattr(tiling_result, "base_spacing_um", None)
     multiple = int(preprocessing.region_tile_multiple)
     if target_region_size_px % multiple != 0:
         raise ValueError("target_region_size_px must be divisible by region_tile_multiple")
+    if effective_spacing_value is None:
+        effective_region_size_px = int(getattr(tiling_result, "effective_tile_size_px"))
+        effective_tile_size_px = effective_region_size_px // multiple
+    else:
+        effective_spacing_um = float(effective_spacing_value)
+        effective_tile_size_px = int(round(target_tile_size_px * target_spacing_um / effective_spacing_um))
+        effective_region_size_px = effective_tile_size_px * multiple
+    if base_spacing_value is None:
+        tile_size_lv0 = int(getattr(tiling_result, "tile_size_lv0")) // multiple
+    else:
+        base_spacing_um = float(base_spacing_value)
+        tile_size_lv0 = int(round(target_tile_size_px * target_spacing_um / base_spacing_um))
     return {
         "region_tile_multiple": multiple,
         "tiles_per_region": multiple * multiple,
         "target_tile_size_px": target_tile_size_px,
-        "effective_tile_size_px": effective_region_size_px // multiple,
+        "effective_tile_size_px": effective_tile_size_px,
         "target_region_size_px": target_region_size_px,
         "effective_region_size_px": effective_region_size_px,
-        "tile_size_lv0": tile_size_lv0 // multiple,
+        "tile_size_lv0": tile_size_lv0,
     }
 
 
@@ -131,14 +144,18 @@ def _build_hierarchical_index(
     tiling_result,
     *,
     region_tile_multiple: int,
+    tile_size_lv0: int | None = None,
 ) -> HierarchicalIndex:
     x_values, y_values = coordinate_arrays(tiling_result)
     num_regions = int(len(x_values))
     multiple = int(region_tile_multiple)
     if multiple < 2:
         raise ValueError("region_tile_multiple must be at least 2")
-    tile_size_lv0 = int(getattr(tiling_result, "tile_size_lv0"))
-    subtile_size_lv0 = tile_size_lv0 // multiple
+    subtile_size_lv0 = (
+        int(tile_size_lv0)
+        if tile_size_lv0 is not None
+        else int(getattr(tiling_result, "tile_size_lv0")) // multiple
+    )
     tiles_per_region = multiple * multiple
     if num_regions == 0:
         empty = np.empty(0, dtype=np.int64)
@@ -1275,6 +1292,7 @@ def _compute_hierarchical_embeddings_for_slide(
     index = _build_hierarchical_index(
         tiling_result,
         region_tile_multiple=int(geometry["region_tile_multiple"]),
+        tile_size_lv0=int(geometry["tile_size_lv0"]),
     )
     resolved_indices = index.flat_index
     if flat_indices is not None:
@@ -1370,6 +1388,7 @@ def _compute_hierarchical_embedding_shard_for_slide(
     index = _build_hierarchical_index(
         tiling_result,
         region_tile_multiple=int(geometry["region_tile_multiple"]),
+        tile_size_lv0=int(geometry["tile_size_lv0"]),
     )
     resolved_indices = np.asarray(flat_indices, dtype=np.int64)
     collate_fn = OnTheFlyHierarchicalBatchCollator(

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,9 @@
 # Lessons Learned
 
+## 2026-04-10
+
+- In this environment, never route `apply_patch` through `exec_command`; use the dedicated `apply_patch` tool directly for file edits.
+
 ## 2026-04-01
 
 - When the user says backward compatibility is not needed, do not add compatibility-preserving behavior or messaging; implement the simpler direct behavior instead.

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -2975,6 +2975,7 @@ def test_compute_hierarchical_embeddings_for_slide_encodes_flat_tile_batches_and
         tile_size_lv0=448,
         target_spacing_um=0.5,
         effective_spacing_um=0.5,
+        base_spacing_um=0.5,
         read_level=0,
     )
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -2808,6 +2808,49 @@ def test_build_hierarchical_index_is_region_major_and_row_major_within_region():
     )
 
 
+def test_resolve_hierarchical_geometry_scales_tile_first_under_spacing_mismatch():
+    import slide2vec.inference as inference
+
+    preprocessing = PreprocessingConfig(
+        target_spacing_um=0.5,
+        target_tile_size_px=224,
+        target_region_size_px=1792,
+        region_tile_multiple=8,
+    )
+    tiling_result = SimpleNamespace(
+        effective_tile_size_px=3319,
+        effective_spacing_um=0.27,
+        tile_size_lv0=3319,
+        base_spacing_um=0.27,
+    )
+
+    geometry = inference._resolve_hierarchical_geometry(preprocessing, tiling_result)
+
+    assert geometry["effective_tile_size_px"] == 415
+    assert geometry["effective_region_size_px"] == 3320
+    assert geometry["tile_size_lv0"] == 415
+    assert geometry["tiles_per_region"] == 64
+
+
+def test_build_hierarchical_index_uses_tile_first_level0_offsets_under_spacing_mismatch():
+    import slide2vec.inference as inference
+
+    tiling_result = SimpleNamespace(
+        x=np.array([100], dtype=np.int64),
+        y=np.array([200], dtype=np.int64),
+    )
+
+    index = inference._build_hierarchical_index(
+        tiling_result,
+        region_tile_multiple=8,
+        tile_size_lv0=415,
+    )
+
+    assert index.tiles_per_region == 64
+    np.testing.assert_array_equal(index.subtile_x[:8], np.array([100, 515, 930, 1345, 1760, 2175, 2590, 3005], dtype=np.int64))
+    np.testing.assert_array_equal(index.subtile_y[::8], np.array([200, 615, 1030, 1445, 1860, 2275, 2690, 3105], dtype=np.int64))
+
+
 def test_merge_hierarchical_embedding_shards_restores_original_region_shape():
     import slide2vec.inference as inference
 


### PR DESCRIPTION
## Summary

This PR makes hierarchical extraction in slide2vec resolve effective geometry tile-first when the selected read spacing differs from the requested spacing.

Previously, hierarchical runs derived the requested parent region as usual (target_tile_size_px * region_tile_multiple), but after tiling they effectively treated the rounded region artifact size as canonical and recovered the effective subtile size by dividing that rounded region by region_tile_multiple.

That creates avoidable drift under spacing-driven rounding. For example, a requested 224px tile at 0.5 µm/px may correspond to an effective read tile of 415px at 0.27 µm/px, while a requested 1792px parent region may round to 3319px. Dividing 3319 // 8 yields 414, which is no longer aligned with the model-facing tile size implied by the spacing ratio.

  This PR changes hierarchical embedding to use a tile-first policy instead:

  - scale target_tile_size_px to the effective read spacing to get effective_tile_size_px
  - derive effective_region_size_px = effective_tile_size_px * region_tile_multiple
  - derive level-0 subtile offsets from the tile-first subtile size as well

  ## Changes

  - Updated slide2vec.inference._resolve_hierarchical_geometry(...) to:
      - compute effective_tile_size_px from target_tile_size_px, target_spacing_um, and tiling_result.effective_spacing_um
      - compute effective_region_size_px from effective_tile_size_px * region_tile_multiple
      - compute level-0 subtile size from target_tile_size_px, target_spacing_um, and tiling_result.base_spacing_um
  - Updated _build_hierarchical_index(...) to accept the resolved level-0 subtile size explicitly instead of always deriving it by dividing the rounded region artifact
  - Wired the new geometry through:
      - single-process hierarchical embedding
      - distributed hierarchical shard embedding
  - Added focused regression tests covering:
      - tile-first effective geometry under spacing mismatch
      - tile-first level-0 subtile offsets under spacing mismatch
  - Documented the new hierarchical rounding behavior in the Python API docs