### PR TITLE
skip multi-GPU validation for tiling-only runs

### DIFF
--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -608,7 +608,14 @@ def run_pipeline(
         raise ValueError("At least one slide is required")
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required for Pipeline.run(...)")
-    if execution.num_gpus > 1:
+    # `validate_multi_gpu_execution` validates the multi-GPU *embedding* setup
+    # and touches `torch.cuda` in the parent process. A tiling-only run has no
+    # embedding stage, so skip it: any GPU work during tiling (e.g. SAM2 mask
+    # generation on cuda) runs inside the spawned tiling workers, which
+    # initialize their own CUDA and do not depend on this parent-side check.
+    # Initializing a CUDA context in the parent here only buys needless fork
+    # risk for the downstream tiling pool with no benefit.
+    if not tiling_only and execution.num_gpus > 1:
         distributed_stage.validate_multi_gpu_execution(model, execution)
 
     output_dir = Path(execution.output_dir)

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -125,6 +125,91 @@ def test_pipeline_run_uses_distributed_embedding_path_when_num_gpus_is_greater_t
     assert result.tile_artifacts == ["tile-artifact"]
     assert result.slide_artifacts == ["slide-artifact"]
 
+
+def test_run_pipeline_tiling_only_skips_multi_gpu_validation(monkeypatch, tmp_path: Path):
+    """Tiling is CPU-only; it must not initialize CUDA in the parent.
+
+    ``validate_multi_gpu_execution`` calls ``torch.cuda`` in the parent process,
+    which (combined with forking the tiling pool) caused deadlocks. For a
+    tiling-only run there is no GPU stage, so the validation must be skipped even
+    when ``num_gpus > 1``.
+    """
+    import slide2vec.inference as inference
+
+    slide = make_slide("slide-a")
+    tiling_result = SimpleNamespace(x=np.array([0, 1]), y=np.array([2, 3]), tile_size_lv0=224)
+
+    monkeypatch.setattr(
+        tiling_pipeline,
+        "prepare_tiled_slides",
+        lambda *args, **kwargs: ([slide], [tiling_result], tmp_path / "process_list.csv"),
+    )
+
+    validate_calls = []
+    monkeypatch.setattr(
+        distributed_stage,
+        "validate_multi_gpu_execution",
+        lambda *args, **kwargs: validate_calls.append(True),
+    )
+
+    result = inference.run_pipeline(
+        Model.from_preset("virchow2"),
+        slides=[slide],
+        preprocessing=DEFAULT_PREPROCESSING,
+        tiling_only=True,
+        execution=ExecutionOptions(output_dir=tmp_path, num_gpus=2),
+    )
+
+    assert validate_calls == []
+    assert result.tile_artifacts == []
+    assert result.slide_artifacts == []
+    assert result.process_list_path == tmp_path / "process_list.csv"
+
+
+def test_run_pipeline_validates_multi_gpu_when_not_tiling_only(monkeypatch, tmp_path: Path):
+    """The multi-GPU fast-fail check must still run for full embedding runs."""
+    import slide2vec.inference as inference
+
+    slide = make_slide("slide-a")
+    tiling_result = SimpleNamespace(x=np.array([0, 1]), y=np.array([2, 3]), tile_size_lv0=224)
+
+    monkeypatch.setattr(
+        tiling_pipeline,
+        "prepare_tiled_slides",
+        lambda *args, **kwargs: ([slide], [tiling_result], tmp_path / "process_list.csv"),
+    )
+    monkeypatch.setattr(
+        artifacts_collect,
+        "run_distributed_embedding_stage",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        artifacts_collect,
+        "collect_pipeline_artifacts",
+        lambda *args, **kwargs: (["tile-artifact"], [], ["slide-artifact"]),
+    )
+    monkeypatch.setattr(
+        artifacts_collect, "update_process_list_after_embedding", lambda *args, **kwargs: None
+    )
+
+    validate_calls = []
+    monkeypatch.setattr(
+        distributed_stage,
+        "validate_multi_gpu_execution",
+        lambda *args, **kwargs: validate_calls.append(True),
+    )
+
+    inference.run_pipeline(
+        Model.from_preset("virchow2"),
+        slides=[slide],
+        preprocessing=DEFAULT_PREPROCESSING,
+        tiling_only=False,
+        execution=ExecutionOptions(output_dir=tmp_path, num_gpus=2),
+    )
+
+    assert validate_calls == [True]
+
+
 def test_run_pipeline_distributed_branch_delegates_to_distributed_collection_helper(monkeypatch, tmp_path: Path):
     import slide2vec.inference as inference
 


### PR DESCRIPTION
## Problem

`run_pipeline` called `validate_multi_gpu_execution` before the tiling stage whenever `num_gpus > 1`. That helper validates the multi-GPU **embedding** setup and calls `torch.cuda.is_available()` / `torch.cuda.device_count()` in the **parent** process, initializing a CUDA context before the tiling worker pool is created. An initialized CUDA context in the parent is one of the triggers for the tiling deadlocks fixed in hs2p (clemsgrs/hs2p#135).

A tiling-only run has no embedding stage, so there is no reason to run the embedding-stage multi-GPU check — or to initialize CUDA in the parent — for it.

> Note: tiling *coordinate generation* is CPU, but mask generation may use the GPU (SAM2 with `sam2_device="cuda"`). That GPU work happens **inside the spawned tiling workers**, which initialize their own CUDA; it does not depend on `validate_multi_gpu_execution` (which is about the embedding stage). So skipping the check does not affect SAM2-on-GPU tiling.

## Fix

Skip `validate_multi_gpu_execution` when `tiling_only=True`. The check still runs as a fast-fail for full embedding runs (`tiling_only=False`).

## Tests

- `test_run_pipeline_tiling_only_skips_multi_gpu_validation` — validation is not called for `tiling_only=True` even with `num_gpus=2`.
- `test_run_pipeline_validates_multi_gpu_when_not_tiling_only` — validation still runs for full embedding runs.
- Inference regression suite: 93 passed.

Best paired with clemsgrs/hs2p#135 (which makes the tiling pools fork-safe via spawn).