### PR TITLE
add dense tile feature extraction

### DIFF
--- a/slide2vec/encoders/__init__.py
+++ b/slide2vec/encoders/__init__.py
@@ -10,6 +10,8 @@ from slide2vec.encoders.base import (
     SlideEncoder,
     TileEncoder,
     TimmTileEncoder,
+    reshape_tokens_to_grid,
+    resolve_recommended_dynamic_img_size,
     resolve_requested_output_variant,
 )
 from slide2vec.encoders.registry import (
@@ -29,6 +31,8 @@ __all__ = [
     "TileEncoder",
     "SlideEncoder",
     "TimmTileEncoder",
+    "reshape_tokens_to_grid",
+    "resolve_recommended_dynamic_img_size",
     "resolve_requested_output_variant",
     "encoder_registry",
     "register_encoder",

--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -7,6 +7,7 @@ import timm
 import torch
 from timm.data import create_transform, resolve_data_config
 from torch import Tensor
+from torchvision.transforms import v2
 
 
 def preferred_default_device() -> torch.device:
@@ -27,6 +28,75 @@ def resolve_requested_output_variant(
             f"Unsupported output_variant '{resolved}'. Available: {available}"
         )
     return resolved
+
+
+def resolve_recommended_dynamic_img_size(
+    *,
+    requested: bool | None,
+    recommended: bool,
+    allow_non_recommended: bool,
+    encoder_name: str,
+) -> bool:
+    """Resolve ``dynamic_img_size`` against an encoder's card-recommended value.
+
+    ``None`` uses the recommended value. A value that differs from the
+    recommendation requires ``allow_non_recommended_settings=True`` (e.g. dense
+    feature extraction deliberately enabling variable input size, justified by
+    the registration / native-size-no-op tests); otherwise it raises, so a
+    pipeline never silently runs an encoder outside its documented config.
+    """
+    if requested is None:
+        return recommended
+    if requested != recommended and not allow_non_recommended:
+        raise ValueError(
+            f"Encoder '{encoder_name}' recommends dynamic_img_size={recommended} "
+            f"(per its model card); got dynamic_img_size={requested}, which deviates "
+            "from the recommended setting. Pass allow_non_recommended_settings=True "
+            "to override it deliberately (e.g. dense extraction needs variable input "
+            "size; this is a native-size no-op, verified in the encoder tests)."
+        )
+    return requested
+
+
+def reshape_tokens_to_grid(
+    tokens: Tensor,
+    *,
+    grid_h: int,
+    grid_w: int,
+    num_prefix_tokens: int,
+    encoder_name: str,
+) -> Tensor:
+    """Fold a ViT ``(B, T, d)`` token sequence into a dense ``(B, d, h, w)`` grid.
+
+    Strips the leading ``num_prefix_tokens`` (CLS + register tokens) and reshapes
+    the remaining patch tokens back into their row-major spatial grid. ViT patch
+    tokens are emitted in row-major order ``[(0,0), (0,1), ..., (h-1, w-1)]`` after
+    the prefix tokens, so ``transpose(1, 2).reshape(B, d, h, w)`` recovers the
+    spatial layout. Verified bit-for-bit against timm's
+    ``get_intermediate_layers(..., reshape=True)`` in the encoder tests.
+
+    Fails loudly if the post-strip token count does not match ``grid_h * grid_w``:
+    a silent reshape would train a decoder on spatially corrupted features, which
+    is worse than a hard failure.
+    """
+    if tokens.ndim != 3:
+        raise ValueError(
+            f"Dense extraction for '{encoder_name}' expected a (B, T, d) token "
+            f"sequence from the backbone, got shape {tuple(tokens.shape)}. This "
+            "encoder may not expose a recoverable patch-token grid."
+        )
+    patch_tokens = tokens[:, num_prefix_tokens:, :]
+    batch_size, num_tokens, dim = patch_tokens.shape
+    expected = grid_h * grid_w
+    if num_tokens != expected:
+        raise ValueError(
+            f"Dense token accounting mismatch for '{encoder_name}': backbone "
+            f"returned {tokens.shape[1]} tokens; after stripping "
+            f"{num_prefix_tokens} prefix token(s), {num_tokens} remain, but the "
+            f"{grid_h}x{grid_w} grid expects {expected}. Check the prefix-token "
+            "count and the input-size / patch-size / grid geometry."
+        )
+    return patch_tokens.transpose(1, 2).reshape(batch_size, dim, grid_h, grid_w)
 
 
 class Encoder(ABC):
@@ -62,6 +132,39 @@ class TileEncoder(Encoder):
     def encode_tiles(self, batch: Tensor) -> Tensor:
         """Encode a batch of tiles. (B, C, H, W) -> (B, D)."""
         ...
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        """Encode tiles into a dense spatial feature grid. (B, C, H, W) -> (B, d, h, w).
+
+        Default: unsupported. ViT tile encoders with a recoverable patch grid
+        override this; vision-language / slide-native encoders (no usable patch
+        grid) do not. ``d`` is the per-token feature dim and ``h, w`` the token
+        grid (``H / patch``, ``W / patch``).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support dense (spatial-grid) feature "
+            "extraction. Dense extraction requires a ViT tile encoder whose patch "
+            "tokens can be reshaped into a spatial grid."
+        )
+
+    def get_dense_transform(self) -> Callable:
+        """Photometric (normalization-only) transform for dense extraction.
+
+        Returns a transform that applies ONLY this encoder's normalization
+        (per-channel mean/std) — **no Resize, no CenterCrop** — so the dense
+        feature grid covers the *full* source tile and stays spatially registered
+        to it. This deliberately differs from ``get_transform`` (the pooled recipe):
+        some encoders resize-then-center-crop there (GigaPath ``Resize(256) ->
+        CenterCrop(224)``; Lunit ``crop_pct=0.9 -> Resize(248) -> CenterCrop(224)``),
+        which drops the tile margins and would misregister the grid against a dense
+        target mask. Geometry (padding to a patch multiple, optional resize,
+        cropping logits back) is the dense pipeline's responsibility, not the
+        encoder's. Default: unsupported, mirroring ``encode_tiles_dense``.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not provide a dense transform. Only "
+            "encoders that support dense (spatial-grid) extraction define one."
+        )
 
 
 class SlideEncoder(Encoder):
@@ -144,8 +247,63 @@ class TimmTileEncoder(TileEncoder):
         data_config = resolve_data_config(self._model.pretrained_cfg, model=self._model)
         return create_transform(**data_config)
 
+    def get_dense_transform(self) -> Callable:
+        # Normalization only — no Resize/CenterCrop (see TileEncoder.get_dense_transform).
+        # mean/std come from the same resolved data config get_transform uses, so the
+        # photometric pipeline matches pooled extraction even for encoders with custom
+        # normalization (e.g. H-optimus 0.7072.../0.2119...); verified per-encoder.
+        cfg = resolve_data_config(self._model.pretrained_cfg, model=self._model)
+        return v2.Compose([
+            v2.ToImage(),
+            v2.ToDtype(torch.float32, scale=True),
+            v2.Normalize(mean=cfg["mean"], std=cfg["std"]),
+        ])
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         return self._model(batch)
+
+    def _dense_patch_size(self) -> tuple[int, int]:
+        """Backbone patch size as ``(patch_h, patch_w)``."""
+        patch = self._model.patch_embed.patch_size
+        if isinstance(patch, int):
+            return patch, patch
+        patch_h, patch_w = patch
+        return int(patch_h), int(patch_w)
+
+    def _dense_num_prefix_tokens(self) -> int:
+        """Number of leading non-patch tokens (CLS + register tokens)."""
+        return int(self._model.num_prefix_tokens)
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        """Encode tiles into a dense spatial grid. (B, C, H, W) -> (B, d, h, w).
+
+        Runs the frozen backbone's ``forward_features`` and folds the patch-token
+        sequence back into its spatial grid (CLS/register tokens discarded). The
+        backbone must accept ``batch`` at its current spatial size (timm ViTs need
+        ``dynamic_img_size=True`` for sizes other than their native input), and
+        ``H, W`` must be divisible by the patch size.
+        """
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_dense expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch_h, patch_w = self._dense_patch_size()
+        if height % patch_h != 0 or width % patch_w != 0:
+            raise ValueError(
+                f"Dense extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch_h}x{patch_w}. Pad the tile up to a patch multiple first."
+            )
+        tokens = self._model.forward_features(batch)
+        return reshape_tokens_to_grid(
+            tokens,
+            grid_h=height // patch_h,
+            grid_w=width // patch_w,
+            num_prefix_tokens=self._dense_num_prefix_tokens(),
+            encoder_name=type(self).__name__,
+        )
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -147,6 +147,18 @@ class TileEncoder(Encoder):
             "tokens can be reshaped into a spatial grid."
         )
 
+    @property
+    def patch_size(self) -> tuple[int, int]:
+        """Backbone patch size ``(patch_h, patch_w)`` — only for dense encoders.
+
+        Encoder-authoritative (a property of the frozen model), used to resolve the
+        dense token grid. Default: unsupported, mirroring ``encode_tiles_dense``.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not expose a patch size (only dense-capable "
+            "ViT tile encoders do)."
+        )
+
     def get_dense_transform(self) -> Callable:
         """Photometric (normalization-only) transform for dense extraction.
 
@@ -269,6 +281,10 @@ class TimmTileEncoder(TileEncoder):
             return patch, patch
         patch_h, patch_w = patch
         return int(patch_h), int(patch_w)
+
+    @property
+    def patch_size(self) -> tuple[int, int]:
+        return self._dense_patch_size()
 
     def _dense_num_prefix_tokens(self) -> int:
         """Number of leading non-patch tokens (CLS + register tokens)."""

--- a/slide2vec/encoders/models/conch.py
+++ b/slide2vec/encoders/models/conch.py
@@ -10,10 +10,66 @@ from typing import Callable
 
 import torch
 from torch import Tensor
+from torchvision.transforms import v2
 from transformers import AutoModel
 
-from slide2vec.encoders.base import TileEncoder, preferred_default_device, resolve_requested_output_variant
+from slide2vec.encoders.base import (
+    TileEncoder,
+    preferred_default_device,
+    reshape_tokens_to_grid,
+    resolve_requested_output_variant,
+)
 from slide2vec.encoders.registry import register_encoder
+
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+def _normalize_only_transform(
+    *,
+    mean: tuple[float, float, float],
+    std: tuple[float, float, float],
+) -> Callable:
+    return v2.Compose([
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
+        v2.Normalize(mean=mean, std=std),
+    ])
+
+
+def _patch_size_from_trunk(trunk) -> tuple[int, int]:
+    patch = trunk.patch_embed.patch_size
+    if isinstance(patch, int):
+        return patch, patch
+    patch_h, patch_w = patch
+    return int(patch_h), int(patch_w)
+
+
+def _encode_trunk_dense(*, trunk, batch: Tensor, encoder_name: str) -> Tensor:
+    if batch.ndim != 4:
+        raise ValueError(
+            "encode_tiles_dense expects a (B, C, H, W) batch, got shape "
+            f"{tuple(batch.shape)}."
+        )
+    _, _, height, width = batch.shape
+    patch_h, patch_w = _patch_size_from_trunk(trunk)
+    if height % patch_h != 0 or width % patch_w != 0:
+        raise ValueError(
+            f"Dense extraction for '{encoder_name}' requires input divisible by "
+            f"the patch size: got {height}x{width}, patch {patch_h}x{patch_w}. "
+            "Pad the tile up to a patch multiple first."
+        )
+    if hasattr(trunk, "forward_features"):
+        tokens = trunk.forward_features(batch)
+    else:
+        tokens = trunk(batch)
+    return reshape_tokens_to_grid(
+        tokens,
+        grid_h=height // patch_h,
+        grid_w=width // patch_w,
+        num_prefix_tokens=int(getattr(trunk, "num_prefix_tokens", 1)),
+        encoder_name=encoder_name,
+    )
 
 
 @register_encoder(
@@ -39,8 +95,30 @@ class CONCH(TileEncoder):
     def get_transform(self) -> Callable:
         return self._transform
 
+    def get_dense_transform(self) -> Callable:
+        try:
+            from conch.open_clip_custom.constants import (
+                OPENAI_DATASET_MEAN,
+                OPENAI_DATASET_STD,
+            )
+
+            mean = tuple(float(v) for v in OPENAI_DATASET_MEAN)
+            std = tuple(float(v) for v in OPENAI_DATASET_STD)
+        except Exception:
+            mean, std = _IMAGENET_MEAN, _IMAGENET_STD
+        return _normalize_only_transform(mean=mean, std=std)
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         return self._model.encode_image(batch, proj_contrast=False, normalize=False)
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        # Use the ViT trunk tokens directly. self._model.visual(...) returns
+        # attentional-pool tokens for captioning/contrast, not a spatial patch grid.
+        return _encode_trunk_dense(
+            trunk=self._model.visual.trunk,
+            batch=batch,
+            encoder_name=type(self).__name__,
+        )
 
     @property
     def encode_dim(self) -> int:
@@ -76,8 +154,18 @@ class CONCHv15(TileEncoder):
     def get_transform(self) -> Callable:
         return self._transform
 
+    def get_dense_transform(self) -> Callable:
+        return _normalize_only_transform(mean=_IMAGENET_MEAN, std=_IMAGENET_STD)
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         return self._model(batch)
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        return _encode_trunk_dense(
+            trunk=self._model.trunk,
+            batch=batch,
+            encoder_name=type(self).__name__,
+        )
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/models/gigapath.py
+++ b/slide2vec/encoders/models/gigapath.py
@@ -1,6 +1,9 @@
 """Prov-GigaPath encoder implementation."""
 
+from typing import Callable
+
 import torch
+from torchvision.transforms import v2
 
 from slide2vec.encoders.base import (
     SlideEncoder,
@@ -9,6 +12,14 @@ from slide2vec.encoders.base import (
     resolve_requested_output_variant,
 )
 from slide2vec.encoders.registry import register_encoder
+
+# Prov-GigaPath model card transform: resize the 256px tile to 256 (no-op),
+# center-crop to the model's native 224, ImageNet normalization. timm's packaged
+# pretrained_cfg reports crop_pct=1.0 -> get_transform would instead Resize(224),
+# downscaling the whole tile to ~0.57 mpp; the paper feeds the center 224 at the
+# native 0.5 mpp. https://www.nature.com/articles/s41586-024-07441-w
+_GIGAPATH_MEAN = (0.485, 0.456, 0.406)
+_GIGAPATH_STD = (0.229, 0.224, 0.225)
 
 
 @register_encoder(
@@ -25,7 +36,24 @@ class GigaPath(TimmTileEncoder):
         super().__init__(
             "hf_hub:prov-gigapath/prov-gigapath",
             output_variant=output_variant,
+            dynamic_img_size=True,
         )
+
+    def get_transform(self) -> Callable:
+        # POOLED transform only: center-crops the 256px tile to the model's 224px
+        # native input (paper recipe, center 224 @ native 0.5 mpp). Dense extraction
+        # must NOT route through this — it needs the full uncropped tile so the grid
+        # covers the whole source tile. The dense path supplies its own no-crop
+        # transform (Resize(256), no CenterCrop) → a 16x16 grid over the full tile;
+        # encode_tiles_dense itself is transform-agnostic (inherited from
+        # TimmTileEncoder) and operates on whatever batch the dense pipeline feeds.
+        return v2.Compose([
+            v2.ToImage(),
+            v2.Resize(256, interpolation=v2.InterpolationMode.BICUBIC, antialias=True),
+            v2.CenterCrop(224),
+            v2.ToDtype(torch.float32, scale=True),
+            v2.Normalize(mean=_GIGAPATH_MEAN, std=_GIGAPATH_STD),
+        ])
 
 
 @register_encoder(

--- a/slide2vec/encoders/models/hibou.py
+++ b/slide2vec/encoders/models/hibou.py
@@ -10,7 +10,12 @@ from torch import Tensor
 from torchvision.transforms import v2
 from transformers import AutoModel
 
-from slide2vec.encoders.base import TileEncoder, preferred_default_device, resolve_requested_output_variant
+from slide2vec.encoders.base import (
+    TileEncoder,
+    preferred_default_device,
+    reshape_tokens_to_grid,
+    resolve_requested_output_variant,
+)
 from slide2vec.encoders.registry import register_encoder
 
 _HIBOU_MEAN = (0.7068, 0.5755, 0.722)
@@ -40,9 +45,39 @@ class _HibouBase(TileEncoder):
     def get_transform(self) -> Callable:
         return _hibou_transform()
 
+    def get_dense_transform(self) -> Callable:
+        return v2.Compose([
+            v2.ToImage(),
+            v2.ToDtype(torch.float32, scale=True),
+            v2.Normalize(mean=_HIBOU_MEAN, std=_HIBOU_STD),
+        ])
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         output = self._model(pixel_values=batch)
         return output.pooler_output
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_dense expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch = int(self._model.config.patch_size)
+        if height % patch != 0 or width % patch != 0:
+            raise ValueError(
+                f"Dense extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch}. Pad the tile up to a patch multiple first."
+            )
+        output = self._model(pixel_values=batch)
+        return reshape_tokens_to_grid(
+            output.last_hidden_state,
+            grid_h=height // patch,
+            grid_w=width // patch,
+            num_prefix_tokens=1 + int(getattr(self._model.config, "num_register_tokens", 0)),
+            encoder_name=type(self).__name__,
+        )
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/models/hoptimus.py
+++ b/slide2vec/encoders/models/hoptimus.py
@@ -7,7 +7,11 @@ import torch
 from torch import Tensor
 from torchvision.transforms import v2
 
-from slide2vec.encoders.base import TimmTileEncoder, resolve_requested_output_variant
+from slide2vec.encoders.base import (
+    TimmTileEncoder,
+    resolve_recommended_dynamic_img_size,
+    resolve_requested_output_variant,
+)
 from slide2vec.encoders.registry import register_encoder
 
 # Shared normalization for H-Optimus models
@@ -73,12 +77,26 @@ class _HOptimusBase(TimmTileEncoder):
     source="bioptimus/H-optimus-0",
 )
 class HOptimus0(TimmTileEncoder):
-    def __init__(self, *, output_variant: str | None = None):
+    # bioptimus' model card explicitly loads with dynamic_img_size=False, so that
+    # is the recommended default. Dense extraction needs variable input size and
+    # opts in via dynamic_img_size=True + allow_non_recommended_settings=True.
+    def __init__(
+        self,
+        *,
+        output_variant: str | None = None,
+        dynamic_img_size: bool | None = None,
+        allow_non_recommended_settings: bool = False,
+    ):
         super().__init__(
             "hf-hub:bioptimus/H-optimus-0",
             output_variant=output_variant,
             init_values=1e-5,
-            dynamic_img_size=False,
+            dynamic_img_size=resolve_recommended_dynamic_img_size(
+                requested=dynamic_img_size,
+                recommended=False,
+                allow_non_recommended=allow_non_recommended_settings,
+                encoder_name="h-optimus-0",
+            ),
         )
 
     def get_transform(self) -> Callable:
@@ -95,12 +113,24 @@ class HOptimus0(TimmTileEncoder):
     source="bioptimus/H-optimus-1",
 )
 class HOptimus1(TimmTileEncoder):
-    def __init__(self, *, output_variant: str | None = None):
+    # See HOptimus0: card recommends dynamic_img_size=False; dense extraction opts in.
+    def __init__(
+        self,
+        *,
+        output_variant: str | None = None,
+        dynamic_img_size: bool | None = None,
+        allow_non_recommended_settings: bool = False,
+    ):
         super().__init__(
             "hf-hub:bioptimus/H-optimus-1",
             output_variant=output_variant,
             init_values=1e-5,
-            dynamic_img_size=False,
+            dynamic_img_size=resolve_recommended_dynamic_img_size(
+                requested=dynamic_img_size,
+                recommended=False,
+                allow_non_recommended=allow_non_recommended_settings,
+                encoder_name="h-optimus-1",
+            ),
         )
 
     def get_transform(self) -> Callable:

--- a/slide2vec/encoders/models/lunit.py
+++ b/slide2vec/encoders/models/lunit.py
@@ -18,4 +18,5 @@ class LunitTileEncoder(TimmTileEncoder):
         super().__init__(
             "hf_hub:1aurent/vit_small_patch8_224.lunit_dino",
             output_variant=output_variant,
+            dynamic_img_size=True,  # enable dense extraction; no-op at native size
         )

--- a/slide2vec/encoders/models/midnight.py
+++ b/slide2vec/encoders/models/midnight.py
@@ -11,7 +11,12 @@ from torch import Tensor
 from torchvision.transforms import v2
 from transformers import AutoModel
 
-from slide2vec.encoders.base import TileEncoder, preferred_default_device, resolve_requested_output_variant
+from slide2vec.encoders.base import (
+    TileEncoder,
+    preferred_default_device,
+    reshape_tokens_to_grid,
+    resolve_requested_output_variant,
+)
 from slide2vec.encoders.registry import register_encoder
 
 
@@ -39,11 +44,41 @@ class Midnight(TileEncoder):
             v2.Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)),
         ])
 
+    def get_dense_transform(self) -> Callable:
+        return v2.Compose([
+            v2.ToImage(),
+            v2.ToDtype(torch.float32, scale=True),
+            v2.Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)),
+        ])
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         output = self._model(batch).last_hidden_state
         cls_token = output[:, 0, :]
         patch_tokens = output[:, 1:, :].mean(dim=1)
         return torch.cat([cls_token, patch_tokens], dim=-1)
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_dense expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch = int(self._model.config.patch_size)
+        if height % patch != 0 or width % patch != 0:
+            raise ValueError(
+                f"Dense extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch}. Pad the tile up to a patch multiple first."
+            )
+        output = self._model(batch)
+        return reshape_tokens_to_grid(
+            output.last_hidden_state,
+            grid_h=height // patch,
+            grid_w=width // patch,
+            num_prefix_tokens=1,
+            encoder_name=type(self).__name__,
+        )
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/models/musk.py
+++ b/slide2vec/encoders/models/musk.py
@@ -11,8 +11,20 @@ from torch import Tensor
 from torchvision.transforms import v2
 from timm.models import create_model
 
-from slide2vec.encoders.base import TileEncoder, preferred_default_device, resolve_requested_output_variant
+from slide2vec.encoders.base import (
+    TileEncoder,
+    preferred_default_device,
+    reshape_tokens_to_grid,
+    resolve_requested_output_variant,
+)
 from slide2vec.encoders.registry import register_encoder
+
+
+def _as_hw(value: int | tuple[int, int] | list[int]) -> tuple[int, int]:
+    if isinstance(value, int):
+        return value, value
+    height, width = value
+    return int(height), int(width)
 
 
 @register_encoder(
@@ -47,6 +59,13 @@ class MUSK(TileEncoder):
             v2.Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)),
         ])
 
+    def get_dense_transform(self) -> Callable:
+        return v2.Compose([
+            v2.ToImage(),
+            v2.ToDtype(torch.float32, scale=True),
+            v2.Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)),
+        ])
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         # MUSK's linear-probe / MIL feature-extraction recipe uses out_norm=False
         # (raw embeddings); out_norm=True L2-normalizes and is for zero-shot/retrieval.
@@ -58,6 +77,38 @@ class MUSK(TileEncoder):
             out_norm=False,
             ms_aug=self._output_variant == "ms_aug",
         )[0]
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_dense expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+        )
+        _, _, height, width = batch.shape
+        vision_embed = self._model.beit3.vision_embed
+        native_h, native_w = _as_hw(vision_embed.img_size)
+        if (height, width) != (native_h, native_w):
+            raise ValueError(
+                f"Dense extraction for '{type(self).__name__}' currently requires "
+                f"the native {native_h}x{native_w} input size; got {height}x{width}. "
+                "Use native-size tiles or wait for explicit resize/sliding-window "
+                "dense input modes."
+            )
+        patch_h, patch_w = _as_hw(vision_embed.patch_size)
+        tokens = self._model(
+            image=batch,
+            with_head=False,
+            out_norm=False,
+            ms_aug=False,
+            return_global=False,
+        )[0]
+        return reshape_tokens_to_grid(
+            tokens,
+            grid_h=height // patch_h,
+            grid_w=width // patch_w,
+            num_prefix_tokens=1,
+            encoder_name=type(self).__name__,
+        )
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/models/musk.py
+++ b/slide2vec/encoders/models/musk.py
@@ -48,10 +48,14 @@ class MUSK(TileEncoder):
         ])
 
     def encode_tiles(self, batch: Tensor) -> Tensor:
+        # MUSK's linear-probe / MIL feature-extraction recipe uses out_norm=False
+        # (raw embeddings); out_norm=True L2-normalizes and is for zero-shot/retrieval.
+        # return_global defaults to True (CLS), so [0] is the (B, D) image embedding.
+        # https://github.com/lilab-stanford/MUSK
         return self._model(
             image=batch,
             with_head=False,
-            out_norm=True,
+            out_norm=False,
             ms_aug=self._output_variant == "ms_aug",
         )[0]
 

--- a/slide2vec/encoders/models/phikon.py
+++ b/slide2vec/encoders/models/phikon.py
@@ -50,6 +50,11 @@ class _PhikonBase(TileEncoder):
             v2.Normalize(mean=self._processor.image_mean, std=self._processor.image_std),
         ])
 
+    @property
+    def patch_size(self) -> tuple[int, int]:
+        patch = int(self._model.config.patch_size)
+        return patch, patch
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         output = self._model(pixel_values=batch)
         return output.last_hidden_state[:, 0, :]  # CLS token

--- a/slide2vec/encoders/models/phikon.py
+++ b/slide2vec/encoders/models/phikon.py
@@ -9,7 +9,12 @@ import torch
 from torch import Tensor
 from transformers import AutoImageProcessor, AutoModel
 
-from slide2vec.encoders.base import TileEncoder, preferred_default_device, resolve_requested_output_variant
+from slide2vec.encoders.base import (
+    TileEncoder,
+    preferred_default_device,
+    reshape_tokens_to_grid,
+    resolve_requested_output_variant,
+)
 from slide2vec.encoders.registry import register_encoder
 
 
@@ -33,9 +38,51 @@ class _PhikonBase(TileEncoder):
 
         return _transform
 
+    def get_dense_transform(self) -> Callable:
+        # Normalization only — no resize/crop (see TileEncoder.get_dense_transform).
+        # Reuses the HF processor's normalization so it matches pooled extraction;
+        # Phikon is pinned to its native 224, so the dense pipeline must feed 224.
+        from torchvision.transforms import v2
+
+        return v2.Compose([
+            v2.ToImage(),
+            v2.ToDtype(torch.float32, scale=True),
+            v2.Normalize(mean=self._processor.image_mean, std=self._processor.image_std),
+        ])
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         output = self._model(pixel_values=batch)
         return output.last_hidden_state[:, 0, :]  # CLS token
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        """Encode tiles into a dense spatial grid. (B, C, H, W) -> (B, d, h, w).
+
+        Phikon's ViT emits ``[CLS, patch tokens...]`` (one prefix token, no
+        register tokens). The model is pinned to its native input size, so the
+        grid is ``input_size / patch_size`` (e.g. 224/16 -> 14x14); feeding a
+        larger tile raises inside the HF backbone (positional-embedding mismatch).
+        """
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_dense expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch = int(self._model.config.patch_size)
+        if height % patch != 0 or width % patch != 0:
+            raise ValueError(
+                f"Dense extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch}. Pad the tile up to a patch multiple first."
+            )
+        output = self._model(pixel_values=batch)
+        return reshape_tokens_to_grid(
+            output.last_hidden_state,
+            grid_h=height // patch,
+            grid_w=width // patch,
+            num_prefix_tokens=1,
+            encoder_name=type(self).__name__,
+        )
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/models/prost40m.py
+++ b/slide2vec/encoders/models/prost40m.py
@@ -18,4 +18,5 @@ class Prost40M(TimmTileEncoder):
         super().__init__(
             "hf-hub:waticlems/Prost40M",
             output_variant=output_variant,
+            dynamic_img_size=True,  # enable dense extraction; no-op at native size
         )

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -90,6 +90,7 @@ def load_model(
     device: str = "auto",
     output_variant: str | None = None,
     allow_non_recommended_settings: bool = False,
+    dynamic_img_size: bool | None = None,
     token: str | None = None,
 ) -> LoadedModel:
     name = canonicalize_model_name(name)
@@ -105,7 +106,20 @@ def load_model(
         hf_login(token=token, add_to_git_credential=False)
 
     encoder_cls = encoder_registry.require(name)
-    encoder = encoder_cls(output_variant=output_variant)
+    # Pass dynamic_img_size / allow_non_recommended_settings ONLY to encoders whose
+    # constructor accepts them (e.g. H-optimus needs both to opt into variable input
+    # size for dense extraction; most others hardcode dynamic_img_size=True and take
+    # neither). Limited to these two named params on purpose — not a generic kwargs
+    # passthrough — so load_model stays a narrow construction contract.
+    import inspect
+
+    ctor_params = inspect.signature(encoder_cls.__init__).parameters
+    extra_kwargs: dict = {}
+    if dynamic_img_size is not None and "dynamic_img_size" in ctor_params:
+        extra_kwargs["dynamic_img_size"] = dynamic_img_size
+    if "allow_non_recommended_settings" in ctor_params:
+        extra_kwargs["allow_non_recommended_settings"] = allow_non_recommended_settings
+    encoder = encoder_cls(output_variant=output_variant, **extra_kwargs)
 
     tile_encoder = None
     if resolved_level == "tile":

--- a/tests/test_dense_extraction.py
+++ b/tests/test_dense_extraction.py
@@ -1,0 +1,324 @@
+"""Tests for dense (spatial-grid) tile extraction: ``encode_tiles_dense``.
+
+These run fully offline (``pretrained=False``) — no weight downloads, no HF
+token. The key correctness check compares our manual prefix-strip + row-major
+reshape against timm's own reshape-aware ``get_intermediate_layers`` as a
+ground-truth oracle, pinning spatial registration (not just tensor shape).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+
+from slide2vec.encoders.base import (  # noqa: E402
+    TileEncoder,
+    TimmTileEncoder,
+    reshape_tokens_to_grid,
+    resolve_recommended_dynamic_img_size,
+)
+
+
+def _make_timm_encoder(model_name: str, **timm_kwargs) -> TimmTileEncoder:
+    """Build an offline timm tile encoder (random weights) for shape/order tests."""
+    return TimmTileEncoder(
+        model_name,
+        pretrained=False,
+        num_classes=0,
+        **timm_kwargs,
+    )
+
+
+def _timm_grid_oracle(model, x: torch.Tensor) -> torch.Tensor:
+    """timm's own reshape-aware patch grid: the (B, d, h, w) ground truth."""
+    return model.get_intermediate_layers(
+        x, n=1, reshape=True, return_prefix_tokens=False, norm=True
+    )[0]
+
+
+# --------------------------------------------------------------------------- #
+# Oracle: spatial registration against timm's reshape-aware extraction.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("input_size,grid", [(224, 14), (256, 16)])
+def test_dense_matches_timm_oracle_patch16(input_size: int, grid: int):
+    enc = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)
+    x = torch.randn(2, 3, input_size, input_size)
+    with torch.no_grad():
+        mine = enc.encode_tiles_dense(x)
+        oracle = _timm_grid_oracle(enc._model, x)
+    assert mine.shape == (2, enc.encode_dim, grid, grid)
+    torch.testing.assert_close(mine, oracle, rtol=0, atol=1e-6)
+
+
+def test_dense_matches_timm_oracle_with_register_tokens():
+    # CLS + 8 register tokens, no_embed_class=True (UNI2-style prefix layout).
+    enc = _make_timm_encoder(
+        "vit_tiny_patch16_224",
+        dynamic_img_size=True,
+        reg_tokens=8,
+        no_embed_class=True,
+        class_token=True,
+    )
+    assert enc._dense_num_prefix_tokens() == 9
+    x = torch.randn(2, 3, 256, 256)
+    with torch.no_grad():
+        mine = enc.encode_tiles_dense(x)
+        oracle = _timm_grid_oracle(enc._model, x)
+    assert mine.shape == (2, enc.encode_dim, 16, 16)
+    torch.testing.assert_close(mine, oracle, rtol=0, atol=1e-6)
+
+
+def test_dense_matches_timm_oracle_patch14():
+    # patch-14 backbone: 518 / 14 = 37, exercises a non-power-of-two grid ratio.
+    enc = _make_timm_encoder("vit_small_patch14_reg4_dinov2", dynamic_img_size=True)
+    assert enc._dense_patch_size() == (14, 14)
+    x = torch.randn(1, 3, 518, 518)
+    with torch.no_grad():
+        mine = enc.encode_tiles_dense(x)
+        oracle = _timm_grid_oracle(enc._model, x)
+    assert mine.shape == (1, enc.encode_dim, 37, 37)
+    torch.testing.assert_close(mine, oracle, rtol=0, atol=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# reshape_tokens_to_grid: prefix stripping + row-major layout, in isolation.
+# --------------------------------------------------------------------------- #
+
+
+def test_reshape_strips_prefix_and_is_row_major():
+    grid_h, grid_w, num_prefix, dim = 3, 4, 2, 1
+    tokens = torch.full((1, num_prefix + grid_h * grid_w, dim), -1.0)
+    # Patch token k carries value k; prefix tokens keep the -1 sentinel.
+    for k in range(grid_h * grid_w):
+        tokens[0, num_prefix + k, 0] = float(k)
+    grid = reshape_tokens_to_grid(
+        tokens,
+        grid_h=grid_h,
+        grid_w=grid_w,
+        num_prefix_tokens=num_prefix,
+        encoder_name="test",
+    )
+    # grid[0, 0, i, j] must equal flat row-major index i*w + j (no prefix leakage).
+    expected = torch.arange(grid_h * grid_w, dtype=torch.float).reshape(
+        1, 1, grid_h, grid_w
+    )
+    assert torch.equal(grid, expected)
+
+
+def test_reshape_rejects_non_token_sequence():
+    with pytest.raises(ValueError, match="token sequence"):
+        reshape_tokens_to_grid(
+            torch.randn(2, 196),  # missing feature axis
+            grid_h=14,
+            grid_w=14,
+            num_prefix_tokens=1,
+            encoder_name="test",
+        )
+
+
+def test_reshape_token_count_mismatch_fails_loud():
+    tokens = torch.randn(1, 1 + 14 * 14, 8)
+    with pytest.raises(ValueError, match="token accounting mismatch"):
+        reshape_tokens_to_grid(
+            tokens,
+            grid_h=16,  # 16*16=256 != 196
+            grid_w=16,
+            num_prefix_tokens=1,
+            encoder_name="test",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# encode_tiles_dense: input validation + fail-loud guards.
+# --------------------------------------------------------------------------- #
+
+
+def test_encode_tiles_dense_rejects_indivisible_input():
+    enc = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)
+    with pytest.raises(ValueError, match="divisible by the patch size"):
+        enc.encode_tiles_dense(torch.randn(1, 3, 220, 220))  # 220 % 16 != 0
+
+
+def test_encode_tiles_dense_rejects_non_4d_input():
+    enc = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)
+    with pytest.raises(ValueError, match=r"\(B, C, H, W\)"):
+        enc.encode_tiles_dense(torch.randn(3, 224, 224))
+
+
+def test_encode_tiles_dense_wrong_prefix_count_fails_loud():
+    class _WrongPrefix(TimmTileEncoder):
+        def _dense_num_prefix_tokens(self) -> int:
+            return super()._dense_num_prefix_tokens() + 3
+
+    enc = _WrongPrefix("vit_tiny_patch16_224", pretrained=False, dynamic_img_size=True)
+    with pytest.raises(ValueError, match="token accounting mismatch"):
+        enc.encode_tiles_dense(torch.randn(1, 3, 224, 224))
+
+
+@pytest.mark.parametrize(
+    "arch,native",
+    [
+        ("vit_small_patch16_224", 224),  # patch-16 (UNI / Prost40M family)
+        ("vit_small_patch8_224", 224),  # patch-8 (Lunit)
+        ("vit_small_patch14_reg4_dinov2", 518),  # patch-14 + reg tokens (H-optimus)
+    ],
+)
+def test_dynamic_img_size_is_native_size_noop(arch: str, native: int):
+    """Flipping ``dynamic_img_size`` on must not change native-size output.
+
+    This is why enabling the flag on the previously-static encoders is safe for
+    their existing pooled use: at the native input size timm's positional-embed
+    resample is an identity, so the dense-vs-static models are bit-identical.
+    Weight-independent, so it runs offline with copied random weights.
+    """
+    static = timm.create_model(
+        arch, pretrained=False, num_classes=0, dynamic_img_size=False
+    ).eval()
+    dynamic = timm.create_model(
+        arch, pretrained=False, num_classes=0, dynamic_img_size=True
+    ).eval()
+    dynamic.load_state_dict(static.state_dict())  # identical weights, only flag differs
+    x = torch.randn(2, 3, native, native)
+    with torch.no_grad():
+        torch.testing.assert_close(
+            static.forward_features(x), dynamic.forward_features(x), rtol=0, atol=1e-6
+        )
+
+
+def test_phikon_dense_end_to_end():
+    """Exercise the HF (non-timm) dense glue end-to-end on a public encoder.
+
+    Validates ``config.patch_size`` lookup, the ``last_hidden_state`` ``[CLS,
+    patches...]`` layout, and num_prefix=1 — the path the reshape unit tests do
+    not wire up. Skips when transformers is absent or weights can't be fetched.
+    """
+    pytest.importorskip("transformers")
+    try:
+        from slide2vec.encoders.models.phikon import Phikon
+
+        enc = Phikon().to("cpu")
+    except Exception as exc:  # network / weights unavailable
+        pytest.skip(f"Phikon weights unavailable: {type(exc).__name__}: {exc}")
+    x = torch.randn(2, 3, 224, 224)
+    with torch.no_grad():
+        grid = enc.encode_tiles_dense(x)
+    assert grid.shape == (2, enc.encode_dim, 14, 14)  # 224 / 16 = 14
+
+
+def test_gigapath_dense_transform_is_pooled_only_and_crops():
+    """GigaPath's get_transform is the POOLED recipe — it center-crops 256->224.
+
+    The dense pipeline must NOT route through it (the crop would drop the tile
+    margins and misregister the grid); it supplies its own no-crop transform.
+    encode_tiles_dense is transform-agnostic and inherited from TimmTileEncoder,
+    so it is NOT overridden/disabled on GigaPath. We assert the pooled transform
+    still crops (so the dense pipeline knows to bypass it) without downloading
+    weights.
+    """
+    from slide2vec.encoders.models.gigapath import GigaPath
+
+    enc = GigaPath.__new__(GigaPath)  # no weights needed; get_transform is static
+    out = enc.get_transform()(torch.zeros(3, 256, 256, dtype=torch.uint8))
+    assert out.shape == (3, 224, 224)  # pooled transform crops to native 224
+    # The dense method is the inherited, transform-agnostic one (not disabled).
+    assert GigaPath.encode_tiles_dense is TimmTileEncoder.encode_tiles_dense
+
+
+def test_dense_transform_is_normalization_only_no_resize_or_crop():
+    """get_dense_transform must normalize WITHOUT resizing/cropping.
+
+    A resize or center-crop here would shrink/clip the source tile and misregister
+    the dense grid against the target mask (the GigaPath/Lunit pooled-transform
+    trap). It must use the same resolved mean/std as the pooled transform so dense
+    and pooled extraction are photometrically identical.
+    """
+    from timm.data import resolve_data_config
+
+    enc = _make_timm_encoder("vit_tiny_patch16_224")
+    tf = enc.get_dense_transform()
+    names = {type(t).__name__ for t in tf.transforms}
+    assert "Resize" not in names and "CenterCrop" not in names
+
+    img = torch.randint(0, 256, (3, 320, 288), dtype=torch.uint8)  # non-native, non-square
+    out = tf(img)
+    assert tuple(out.shape) == (3, 320, 288)  # geometry preserved
+    assert out.dtype == torch.float32
+
+    cfg = resolve_data_config(enc._model.pretrained_cfg, model=enc._model)
+    mean = torch.tensor(cfg["mean"]).view(3, 1, 1)
+    std = torch.tensor(cfg["std"]).view(3, 1, 1)
+    expected = (img.float() / 255.0 - mean) / std
+    torch.testing.assert_close(out.as_subclass(torch.Tensor), expected, rtol=0, atol=1e-6)
+
+
+def test_get_dense_transform_unsupported_encoder_raises():
+    class _NonDense(TileEncoder):
+        def get_transform(self):  # pragma: no cover - trivial stub
+            return lambda x: x
+
+        def encode_tiles(self, batch):  # pragma: no cover - trivial stub
+            return batch
+
+        @property
+        def encode_dim(self) -> int:  # pragma: no cover - trivial stub
+            return 0
+
+        @property
+        def device(self):  # pragma: no cover - trivial stub
+            return torch.device("cpu")
+
+        def to(self, device):  # pragma: no cover - trivial stub
+            return self
+
+    with pytest.raises(NotImplementedError, match="does not provide a dense transform"):
+        _NonDense().get_dense_transform()
+
+
+def test_resolve_recommended_dynamic_img_size():
+    r = resolve_recommended_dynamic_img_size
+    # None -> recommended
+    assert r(requested=None, recommended=False, allow_non_recommended=False, encoder_name="e") is False
+    assert r(requested=None, recommended=True, allow_non_recommended=False, encoder_name="e") is True
+    # matching the recommendation needs no flag
+    assert r(requested=False, recommended=False, allow_non_recommended=False, encoder_name="e") is False
+    # deviating with the flag is allowed
+    assert r(requested=True, recommended=False, allow_non_recommended=True, encoder_name="e") is True
+    # deviating without the flag raises
+    with pytest.raises(ValueError, match="recommends dynamic_img_size=False"):
+        r(requested=True, recommended=False, allow_non_recommended=False, encoder_name="e")
+
+
+def test_hoptimus_dynamic_img_size_gated_without_download():
+    # The guard fires while evaluating __init__ args, before timm downloads weights,
+    # so this runs offline: H-optimus recommends dynamic_img_size=False.
+    from slide2vec.encoders.models.hoptimus import HOptimus0
+
+    with pytest.raises(ValueError, match="recommends dynamic_img_size=False"):
+        HOptimus0(dynamic_img_size=True)
+
+
+def test_dense_unsupported_encoder_raises_not_implemented():
+    class _NonDense(TileEncoder):
+        def get_transform(self):  # pragma: no cover - trivial stub
+            return lambda x: x
+
+        def encode_tiles(self, batch):  # pragma: no cover - trivial stub
+            return batch
+
+        @property
+        def encode_dim(self) -> int:  # pragma: no cover - trivial stub
+            return 0
+
+        @property
+        def device(self):  # pragma: no cover - trivial stub
+            return torch.device("cpu")
+
+        def to(self, device):  # pragma: no cover - trivial stub
+            return self
+
+    with pytest.raises(NotImplementedError, match="does not support dense"):
+        _NonDense().encode_tiles_dense(torch.randn(1, 3, 224, 224))

--- a/tests/test_dense_extraction.py
+++ b/tests/test_dense_extraction.py
@@ -8,6 +8,8 @@ ground-truth oracle, pinning spatial registration (not just tensor shape).
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 torch = pytest.importorskip("torch")
@@ -207,6 +209,167 @@ def test_phikon_dense_end_to_end():
     with torch.no_grad():
         grid = enc.encode_tiles_dense(x)
     assert grid.shape == (2, enc.encode_dim, 14, 14)  # 224 / 16 = 14
+
+
+class _FakeOutput:
+    def __init__(self, last_hidden_state: torch.Tensor):
+        self.last_hidden_state = last_hidden_state
+        self.pooler_output = last_hidden_state[:, 0]
+
+
+def _token_sequence(
+    *,
+    batch_size: int,
+    prefix_tokens: int,
+    grid_h: int,
+    grid_w: int,
+    dim: int,
+) -> torch.Tensor:
+    tokens = torch.full((batch_size, prefix_tokens + grid_h * grid_w, dim), -1.0)
+    patch_values = torch.arange(grid_h * grid_w, dtype=torch.float32).view(1, -1, 1)
+    tokens[:, prefix_tokens:, :] = patch_values
+    return tokens
+
+
+class _FakeHFViT:
+    def __init__(self, *, patch_size: int, hidden_size: int, prefix_tokens: int):
+        self.config = SimpleNamespace(
+            patch_size=patch_size,
+            num_register_tokens=prefix_tokens - 1,
+        )
+        self.hidden_size = hidden_size
+        self.prefix_tokens = prefix_tokens
+
+    def __call__(self, *args, **kwargs):
+        batch = kwargs.get("pixel_values") if "pixel_values" in kwargs else args[0]
+        _, _, height, width = batch.shape
+        tokens = _token_sequence(
+            batch_size=batch.shape[0],
+            prefix_tokens=self.prefix_tokens,
+            grid_h=height // int(self.config.patch_size),
+            grid_w=width // int(self.config.patch_size),
+            dim=self.hidden_size,
+        )
+        return _FakeOutput(tokens)
+
+
+def test_midnight_dense_uses_last_hidden_state_patch_tokens():
+    from slide2vec.encoders.models.midnight import Midnight
+
+    enc = Midnight.__new__(Midnight)
+    enc._model = _FakeHFViT(patch_size=14, hidden_size=1536, prefix_tokens=1)
+    grid = enc.encode_tiles_dense(torch.randn(2, 3, 224, 224))
+    assert grid.shape == (2, 1536, 16, 16)
+    expected = torch.arange(16 * 16, dtype=torch.float32).reshape(16, 16)
+    assert torch.equal(grid[0, 0], expected)
+
+
+def test_hibou_dense_strips_cls_and_register_tokens():
+    from slide2vec.encoders.models.hibou import HibouB
+
+    enc = HibouB.__new__(HibouB)
+    enc._model = _FakeHFViT(patch_size=14, hidden_size=768, prefix_tokens=5)
+    grid = enc.encode_tiles_dense(torch.randn(1, 3, 224, 224))
+    assert grid.shape == (1, 768, 16, 16)
+    expected = torch.arange(16 * 16, dtype=torch.float32).reshape(16, 16)
+    assert torch.equal(grid[0, 0], expected)
+
+
+class _FakePatchEmbed:
+    patch_size = (16, 16)
+
+
+class _FakeTrunk:
+    patch_embed = _FakePatchEmbed()
+    num_prefix_tokens = 1
+
+    def __init__(self, *, hidden_size: int = 768):
+        self.hidden_size = hidden_size
+
+    def forward_features(self, batch: torch.Tensor) -> torch.Tensor:
+        _, _, height, width = batch.shape
+        return _token_sequence(
+            batch_size=batch.shape[0],
+            prefix_tokens=self.num_prefix_tokens,
+            grid_h=height // 16,
+            grid_w=width // 16,
+            dim=self.hidden_size,
+        )
+
+
+def test_conch_dense_uses_visual_trunk_not_attentional_tokens():
+    from slide2vec.encoders.models.conch import CONCH
+
+    class _Visual:
+        trunk = _FakeTrunk(hidden_size=768)
+
+        def __call__(self, batch):  # pragma: no cover - must not be used
+            return torch.zeros(batch.shape[0], 512), torch.zeros(batch.shape[0], 256, 768)
+
+    enc = CONCH.__new__(CONCH)
+    enc._model = SimpleNamespace(visual=_Visual())
+    grid = enc.encode_tiles_dense(torch.randn(1, 3, 448, 448))
+    assert grid.shape == (1, 768, 28, 28)
+    expected = torch.arange(28 * 28, dtype=torch.float32).reshape(28, 28)
+    assert torch.equal(grid[0, 0], expected)
+
+
+def test_conchv15_dense_uses_returned_conch_trunk():
+    from slide2vec.encoders.models.conch import CONCHv15
+
+    enc = CONCHv15.__new__(CONCHv15)
+    enc._model = SimpleNamespace(trunk=_FakeTrunk(hidden_size=1024))
+    grid = enc.encode_tiles_dense(torch.randn(1, 3, 448, 448))
+    assert grid.shape == (1, 1024, 28, 28)
+
+
+class _FakeMUSKModel:
+    def __init__(self):
+        self.beit3 = SimpleNamespace(
+            vision_embed=SimpleNamespace(img_size=384, patch_size=16)
+        )
+
+    def __call__(
+        self,
+        *,
+        image: torch.Tensor,
+        with_head: bool,
+        out_norm: bool,
+        ms_aug: bool,
+        return_global: bool,
+    ):
+        assert with_head is False
+        assert out_norm is False
+        assert ms_aug is False
+        assert return_global is False
+        tokens = _token_sequence(
+            batch_size=image.shape[0],
+            prefix_tokens=1,
+            grid_h=24,
+            grid_w=24,
+            dim=1024,
+        )
+        return tokens, None
+
+
+def test_musk_dense_supports_native_384_only():
+    from slide2vec.encoders.models.musk import MUSK
+
+    enc = MUSK.__new__(MUSK)
+    enc._model = _FakeMUSKModel()
+    grid = enc.encode_tiles_dense(torch.randn(1, 3, 384, 384))
+    assert grid.shape == (1, 1024, 24, 24)
+    expected = torch.arange(24 * 24, dtype=torch.float32).reshape(24, 24)
+    assert torch.equal(grid[0, 0], expected)
+
+
+def test_musk_dense_rejects_non_native_size_until_resize_or_sliding_window():
+    from slide2vec.encoders.models.musk import MUSK
+
+    enc = MUSK.__new__(MUSK)
+    enc._model = _FakeMUSKModel()
+    with pytest.raises(ValueError, match="native 384x384 input size"):
+        enc.encode_tiles_dense(torch.randn(1, 3, 512, 512))
 
 
 def test_gigapath_dense_transform_is_pooled_only_and_crops():

--- a/tests/test_dense_locality_gated.py
+++ b/tests/test_dense_locality_gated.py
@@ -1,0 +1,162 @@
+"""Spatial-registration check for dense extraction at the larger (512px) grid.
+
+This is the "spatially correct, not just non-crashing" oracle. It places a
+high-contrast block at a known, asymmetric grid cell and verifies the *change*
+in the dense feature map (vs a background-only encoding) peaks at that cell.
+
+Why a *difference* probe: register-free ViTs (UNI, Virchow, Lunit, Prost40M)
+carry high-norm artifact/outlier tokens (Darcet et al., "Vision Transformers
+Need Registers") that dominate any raw distance-from-background score and produce
+false misregistration. Encoding background-only and localizing the delta cancels
+those artifacts, isolating the stimulus.
+
+Gated on HF_TOKEN (downloads real encoder weights) and skips per-encoder when a
+download is unavailable. Heavy on CPU for ViT-giant encoders — intended to be run
+deliberately (ideally on GPU), not in the fast offline suite.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("timm")
+from timm.data import resolve_data_config  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("HF_TOKEN"),
+    reason="HF_TOKEN required to download encoder weights",
+)
+
+
+def _encoder_classes() -> dict:
+    from slide2vec.encoders.models.hoptimus import H0Mini, HOptimus0, HOptimus1
+    from slide2vec.encoders.models.lunit import LunitTileEncoder
+    from slide2vec.encoders.models.prost40m import Prost40M
+    from slide2vec.encoders.models.uni import UNI, UNI2
+    from slide2vec.encoders.models.virchow import Virchow, Virchow2
+
+    return {
+        "uni": UNI,
+        "uni2": UNI2,
+        "virchow": Virchow,
+        "virchow2": Virchow2,
+        "h0-mini": H0Mini,
+        "h-optimus-0": HOptimus0,
+        "h-optimus-1": HOptimus1,
+        "lunit": LunitTileEncoder,
+        "prost40m": Prost40M,
+    }
+
+
+def _registration_failures(enc, *, target_size: int = 512, block_cells: int = 2):
+    """Run the difference-probe; return (encoded_size, grid, list_of_failures)."""
+    model = enc._model
+    cfg = resolve_data_config(getattr(model, "pretrained_cfg", {}) or {}, model=model)
+    mean = torch.tensor(cfg["mean"]).view(1, 3, 1, 1)
+    std = torch.tensor(cfg["std"]).view(1, 3, 1, 1)
+
+    patch = enc._dense_patch_size()[0]
+    encoded = (target_size // patch) * patch  # largest patch multiple <= target
+    grid = encoded // patch
+
+    @torch.no_grad()
+    def encode(image: torch.Tensor) -> torch.Tensor:
+        return enc.encode_tiles_dense((image - mean) / std)[0]  # (d, G, G)
+
+    background = encode(torch.full((1, 3, encoded, encoded), 0.5))
+
+    def stimulus(cell_r: int, cell_c: int) -> torch.Tensor:
+        image = torch.full((1, 3, encoded, encoded), 0.5)
+        r0, c0 = cell_r * patch, cell_c * patch
+        r1, c1 = r0 + block_cells * patch, c0 + block_cells * patch
+        image[:, 0, r0:r1, c0:c1] = 1.0  # red block on gray
+        image[:, 1, r0:r1, c0:c1] = 0.0
+        image[:, 2, r0:r1, c0:c1] = 0.0
+        return image
+
+    # Asymmetric targets so a transpose / flip is detectable; one centre sanity check.
+    targets = [
+        (int(0.15 * grid), int(0.72 * grid)),
+        (int(0.07 * grid), int(0.22 * grid)),
+        (int(0.85 * grid), int(0.10 * grid)),
+        (grid // 2, grid // 2),
+    ]
+    failures = []
+    for cell_r, cell_c in targets:
+        delta = (encode(stimulus(cell_r, cell_c)) - background).pow(2).sum(0).sqrt()
+        peak_r, peak_c = divmod(int(delta.argmax().item()), grid)
+        # Correct if the peak lands inside the stimulus block (+1-cell halo).
+        in_block = (
+            cell_r - 1 <= peak_r <= cell_r + block_cells
+            and cell_c - 1 <= peak_c <= cell_c + block_cells
+        )
+        if not in_block:
+            failures.append(((cell_r, cell_c), (peak_r, peak_c)))
+    return encoded, grid, failures
+
+
+# The encoders whose dynamic_img_size we FLIPPED this session: real hf-hub source
+# + the extra timm kwargs slide2vec passes. The offline proxy test verifies the
+# no-op property architecturally; this verifies it on the ACTUAL merged configs
+# (no_embed_class, patch-arg quirks) before relying on "native-size no-op" as the
+# safety guarantee for the global flag change. Native size is read from the model's
+# own pretrained_cfg (NOT the registry input_size, which is the larger preprocessing
+# tile size the encoder transform downsizes to the model native, e.g. GigaPath
+# 256->224).
+_FLIPPED_CONFIGS = {
+    "h-optimus-0": ("hf-hub:bioptimus/H-optimus-0", {"init_values": 1e-5}),
+    "h-optimus-1": ("hf-hub:bioptimus/H-optimus-1", {"init_values": 1e-5}),
+    "gigapath": ("hf_hub:prov-gigapath/prov-gigapath", {}),
+    "lunit": ("hf_hub:1aurent/vit_small_patch8_224.lunit_dino", {}),
+    "prost40m": ("hf-hub:waticlems/Prost40M", {}),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_FLIPPED_CONFIGS))
+def test_flipped_encoder_native_size_is_noop_on_real_config(name: str):
+    """Flipping dynamic_img_size on the REAL merged config is bit-identical at
+    native size — the guarantee that the global flag change does not alter
+    existing pooled extraction for these encoders."""
+    import timm
+
+    source, extra = _FLIPPED_CONFIGS[name]
+    try:
+        static = timm.create_model(
+            source, pretrained=True, num_classes=0, dynamic_img_size=False, **extra
+        ).eval()
+        dynamic = timm.create_model(
+            source, pretrained=True, num_classes=0, dynamic_img_size=True, **extra
+        ).eval()
+    except Exception as exc:  # gated weights / network unavailable
+        pytest.skip(f"{name} weights unavailable: {type(exc).__name__}: {exc}")
+    dynamic.load_state_dict(static.state_dict())  # identical weights, only flag differs
+    native = static.pretrained_cfg["input_size"][-1]  # model native size, not tile size
+    x = torch.randn(2, 3, native, native)
+    with torch.no_grad():
+        torch.testing.assert_close(
+            static.forward_features(x), dynamic.forward_features(x), rtol=0, atol=1e-6
+        )
+
+
+# H-optimus recommends dynamic_img_size=False; dense extraction opts in explicitly.
+_DENSE_CTOR_KWARGS = {
+    "h-optimus-0": dict(dynamic_img_size=True, allow_non_recommended_settings=True),
+    "h-optimus-1": dict(dynamic_img_size=True, allow_non_recommended_settings=True),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_encoder_classes()))
+def test_dense_grid_is_spatially_registered(name: str):
+    encoder_cls = _encoder_classes()[name]
+    try:
+        enc = encoder_cls(**_DENSE_CTOR_KWARGS.get(name, {})).to("cpu")
+    except Exception as exc:  # gated weights / network unavailable
+        pytest.skip(f"{name} weights unavailable: {type(exc).__name__}: {exc}")
+    encoded, grid, failures = _registration_failures(enc)
+    assert not failures, (
+        f"{name} @ {encoded}px ({grid}x{grid}) dense grid is misregistered: "
+        f"(target -> peak) {failures}"
+    )

--- a/tests/test_tiling_pipeline.py
+++ b/tests/test_tiling_pipeline.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from slide2vec.api import PreprocessingConfig
+from slide2vec.runtime import tiling_pipeline
+
+
+def test_resolve_model_preprocessing_fills_missing_defaults(monkeypatch):
+    model = SimpleNamespace(name="virchow2")
+    preprocessing = PreprocessingConfig(backend="auto", requested_spacing_um=None, requested_tile_size_px=256)
+
+    monkeypatch.setattr(
+        tiling_pipeline,
+        "resolve_preprocessing_defaults",
+        lambda model_name: {"tile_size_px": 224, "spacing_um": 0.5},
+    )
+    monkeypatch.setattr(
+        tiling_pipeline,
+        "_resolve_hierarchical_preprocessing",
+        lambda preprocessing: preprocessing,
+    )
+
+    resolved = tiling_pipeline.resolve_model_preprocessing(model, preprocessing)
+
+    assert resolved.requested_spacing_um == 0.5
+    assert resolved.requested_tile_size_px == 256


### PR DESCRIPTION
## Summary

- add dense tile feature extraction helpers for ViT-style tile encoders
- add dense transforms that preserve tile geometry while applying encoder normalization
- wire dense extraction support through model-specific encoders, with guards for non-recommended dynamic image size settings
- add offline dense-grid tests plus gated spatial-registration checks for real encoder weights