### PR TITLE
add dense feature extraction to docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -104,6 +104,57 @@ Enable hierarchical mode by setting ``region_tile_multiple`` in
 The tile embeddings tensor will have shape ``(R, T, D)`` instead of ``(N, D)``.
 See :doc:`hierarchical` for the full explanation.
 
+Dense Tile Feature Extraction
+-----------------------------
+
+Some tile encoders can return the spatial grid of ViT patch-token features
+instead of a single pooled vector per tile. This is useful for dense downstream
+tasks where patch-token features must stay registered to the input tile.
+
+Dense extraction is a low-level encoder API:
+
+- ``get_dense_transform()`` applies the encoder's photometric normalization
+  without resize or center-crop, so tile geometry is preserved.
+- ``encode_tiles_dense(batch)`` accepts a normalized ``(B, C, H, W)`` tensor and
+  returns ``(B, d, h, w)``.
+- ``h`` and ``w`` are resolved from the input size and encoder patch size
+  (for example, a 224 px tile with an 8 px patch size returns a 28 x 28 grid).
+
+Example:
+
+.. code-block:: python
+
+   import torch
+   from PIL import Image
+
+   from slide2vec.encoders import encoder_registry
+
+   encoder = encoder_registry.require("lunit")().to("cuda")
+   transform = encoder.get_dense_transform()
+
+   tile = Image.open("/data/tile.png").convert("RGB")
+   batch = transform(tile).unsqueeze(0).to(encoder.device)
+
+   with torch.no_grad():
+       dense = encoder.encode_tiles_dense(batch)
+
+   print(dense.shape)  # torch.Size([1, 384, 28, 28]) for a 224 px Lunit tile
+
+The dense transform deliberately does not resize, crop, or pad. The input
+height and width passed to ``encode_tiles_dense`` must be divisible by the
+encoder patch size, unless the specific encoder is pinned to a native input
+size. Unsupported encoders raise ``NotImplementedError``.
+
+For H-Optimus encoders, non-native dense extraction requires opting into the
+variable-size model setting:
+
+.. code-block:: python
+
+   encoder = encoder_registry.require("h-optimus-0")(
+       dynamic_img_size=True,
+       allow_non_recommended_settings=True,
+   ).to("cuda")
+
 Pipeline
 ---------
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -114,6 +114,32 @@ Tile-level encoders
      - ``0.25``, ``0.5``, ``1.0``, ``2.0``
      - Karasikov et al. (2025)
 
+Dense tile grids
+~~~~~~~~~~~~~~~~
+
+Dense tile feature extraction is available on tile encoders that implement
+``encode_tiles_dense``. It returns a spatial patch-token tensor ``(B, d, h, w)``
+instead of the pooled ``(B, D)`` tensor returned by ``encode_tiles``.
+
+The following built-in tile presets are covered by the dense encoder interface:
+``conch``, ``conchv15``, ``gigapath``, ``h0-mini``, ``h-optimus-0``,
+``h-optimus-1``, ``hibou-b``, ``hibou-l``, ``lunit``, ``midnight``, ``musk``,
+``phikon``, ``phikonv2``, ``prost40m``, ``uni``, ``uni2``, ``virchow``, and
+``virchow2``.
+
+Notes:
+
+- Dense grids use patch-token dimensions. For encoders whose pooled output
+  concatenates CLS and mean patch tokens, ``d`` can be smaller than the pooled
+  output dimension ``D``.
+- ``get_dense_transform`` preserves geometry by applying normalization only.
+  Resize, crop, padding, and sliding-window policy are the caller's
+  responsibility.
+- ``musk`` dense extraction currently requires its native 384 x 384 input size.
+- H-Optimus dense extraction at non-native input sizes requires
+  ``dynamic_img_size=True`` and ``allow_non_recommended_settings=True`` when
+  constructing the encoder.
+
 
 
 Slide-level encoders

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -68,6 +68,10 @@ Shapes by artifact type:
    * - ``patient_embeddings``
      - ``(D,)``
 
+Dense tile grids are not currently written by :class:`~slide2vec.Pipeline` or
+the CLI. They are exposed through the low-level tile encoder API as
+``encode_tiles_dense(...)``; see :doc:`api` for usage.
+
 
 Embedding Meta Files
 --------------------


### PR DESCRIPTION
## Summary

- document the low-level dense tile extraction encoder API
- list dense-capable tile presets and model-specific caveats
- clarify that dense grids are not currently written by the CLI or Pipeline output layout