### PR TITLE
use hs2p spacing read plan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.0.7",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.0.8",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -88,7 +88,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.0.7",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.0.8",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/slide2vec/runtime/hierarchical.py
+++ b/slide2vec/runtime/hierarchical.py
@@ -1,4 +1,5 @@
 import numpy as np
+from hs2p.wsi.geometry import plan_spacing_read
 
 from slide2vec.api import PreprocessingConfig
 from slide2vec.utils.coordinates import coordinate_arrays
@@ -17,6 +18,21 @@ def is_hierarchical_preprocessing(preprocessing: PreprocessingConfig | None) -> 
     return preprocessing.region_tile_multiple is not None or preprocessing.requested_region_size_px is not None
 
 
+def _level_downsample_pairs(level_downsamples) -> list[tuple[float, float]]:
+    pairs: list[tuple[float, float]] = []
+    for downsample in level_downsamples:
+        if isinstance(downsample, (tuple, list, np.ndarray)):
+            if len(downsample) == 0:
+                raise ValueError("level_downsamples entries must not be empty")
+            x_value = float(downsample[0])
+            y_value = float(downsample[1]) if len(downsample) > 1 else x_value
+            pairs.append((x_value, y_value))
+        else:
+            value = float(downsample)
+            pairs.append((value, value))
+    return pairs
+
+
 def resolve_hierarchical_geometry(preprocessing: PreprocessingConfig, tiling_result) -> dict[str, int]:
     if preprocessing.region_tile_multiple is None:
         raise ValueError("Hierarchical preprocessing requires region_tile_multiple")
@@ -28,14 +44,16 @@ def resolve_hierarchical_geometry(preprocessing: PreprocessingConfig, tiling_res
     multiple = int(preprocessing.region_tile_multiple)
     if requested_region_size_px % multiple != 0:
         raise ValueError("requested_region_size_px must be divisible by region_tile_multiple")
-    read_spacing_um = float(getattr(tiling_result, "read_spacing_um"))
     base_spacing_um = float(getattr(tiling_result, "base_spacing_um"))
-    if abs(read_spacing_um - requested_spacing_um) / requested_spacing_um <= float(preprocessing.tolerance):
-        read_tile_size_px = requested_tile_size_px
-    else:
-        read_tile_size_px = int(
-            round(requested_tile_size_px * requested_spacing_um / read_spacing_um)
-        )
+    read_plan = plan_spacing_read(
+        requested_spacing_um=requested_spacing_um,
+        level0_spacing_um=base_spacing_um,
+        level_downsamples=_level_downsample_pairs(getattr(tiling_result, "level_downsamples")),
+        target_size_px=(requested_tile_size_px, requested_tile_size_px),
+        tolerance=float(preprocessing.tolerance),
+    )
+    read_spacing_um = float(read_plan.read_spacing_um)
+    read_tile_size_px = int(read_plan.read_size_px[0])
     read_region_size_px = read_tile_size_px * multiple
     # Use the actual read geometry that produced the tile crop. When the
     # resolved spacing is considered equivalent to the requested spacing,

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -3892,6 +3892,7 @@ def test_resolve_hierarchical_geometry_scales_tile_first_under_spacing_mismatch(
         read_spacing_um=0.27,
         tile_size_lv0=3319,
         base_spacing_um=0.27,
+        level_downsamples=[1.0],
     )
 
     geometry = hierarchical.resolve_hierarchical_geometry(preprocessing, tiling_result)
@@ -3900,6 +3901,44 @@ def test_resolve_hierarchical_geometry_scales_tile_first_under_spacing_mismatch(
     assert geometry["read_region_size_px"] == 3320
     assert geometry["tile_size_lv0"] == 415
     assert geometry["tiles_per_region"] == 64
+
+
+def test_resolve_hierarchical_geometry_uses_hs2p_spacing_plan_for_tile_size(monkeypatch):
+    calls = []
+
+    def fake_plan_spacing_read(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(read_size_px=(415, 415), read_spacing_um=0.27)
+
+    monkeypatch.setattr(hierarchical, "plan_spacing_read", fake_plan_spacing_read)
+    preprocessing = PreprocessingConfig(
+        requested_spacing_um=0.5,
+        requested_tile_size_px=224,
+        requested_region_size_px=1792,
+        region_tile_multiple=8,
+    )
+    tiling_result = SimpleNamespace(
+        read_tile_size_px=3319,
+        read_spacing_um=0.27,
+        tile_size_lv0=3319,
+        base_spacing_um=0.27,
+        level_downsamples=[1.0, 2.0, 4.0],
+    )
+
+    geometry = hierarchical.resolve_hierarchical_geometry(preprocessing, tiling_result)
+
+    assert calls == [
+        {
+            "requested_spacing_um": 0.5,
+            "level0_spacing_um": 0.27,
+            "level_downsamples": [(1.0, 1.0), (2.0, 2.0), (4.0, 4.0)],
+            "target_size_px": (224, 224),
+            "tolerance": 0.05,
+        }
+    ]
+    assert geometry["read_tile_size_px"] == 415
+    assert geometry["read_region_size_px"] == 3320
+    assert geometry["tile_size_lv0"] == 415
 
 
 def test_resolve_hierarchical_geometry_keeps_level0_footprint_when_spacing_matches_base():
@@ -3916,6 +3955,7 @@ def test_resolve_hierarchical_geometry_keeps_level0_footprint_when_spacing_match
         read_spacing_um=0.486187607049942,
         tile_size_lv0=224,
         base_spacing_um=0.486187607049942,
+        level_downsamples=[1.0],
     )
 
     geometry = hierarchical.resolve_hierarchical_geometry(preprocessing, tiling_result)
@@ -4067,6 +4107,7 @@ def test_compute_hierarchical_embeddings_for_slide_encodes_flat_tile_batches_and
         requested_spacing_um=0.5,
         read_spacing_um=0.5,
         base_spacing_um=0.5,
+        level_downsamples=[1.0],
         read_level=0,
     )
 


### PR DESCRIPTION
## Summary

- Bump the hs2p dependency floor to 4.0.8 so slide2vec can rely on the spacing-aware read planning primitive from hs2p PR #138.
- Replace duplicated hierarchical read-size math with `hs2p.wsi.geometry.plan_spacing_read`.
- Preserve the existing tile-first hierarchical behavior by planning one tile and multiplying by `region_tile_multiple`.

## Notes

The batched on-the-fly readers still use their existing CuCIM/supertile path; this PR only reuses the shared hs2p planner where slide2vec was duplicating spacing geometry.