### PR TITLE
add dense self-attention map extraction for tile encoders

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -208,7 +208,11 @@ be divisible by the encoder patch size, and unsupported encoders raise
 Implementation note: timm ViTs run a fused SDPA kernel that never materializes
 the attention matrix, so it is recomputed from each block's own projection
 (bit-equivalent to the weights the fused kernel applies). HuggingFace encoders
-use ``output_attentions=True`` directly.
+read the weights via ``output_attentions=True``, but modern ``transformers``
+default to an SDPA implementation that silently ignores that flag (it warns and
+returns no attentions); extraction therefore temporarily switches the model to
+the ``eager`` attention implementation for the forward pass and restores the
+previous setting afterwards.
 
 Pipeline
 ---------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -155,6 +155,61 @@ variable-size model setting:
        allow_non_recommended_settings=True,
    ).to("cuda")
 
+Dense Attention Map Extraction
+------------------------------
+
+Most ViT tile encoders can also return their frozen per-head **prefix-token
+self-attention** as a dense spatial grid. A frozen ViT's CLS-token attention
+doubles as a per-pixel feature (Ramchandani et al.,
+`arXiv:2602.18747 <https://arxiv.org/abs/2602.18747>`_); this is the attention
+analog of ``encode_tiles_dense`` and reuses the same ``get_dense_transform()``
+(normalization only, geometry preserved).
+
+- ``encode_tiles_attention(batch, *, blocks=(-1,), include_registers=False)``
+  accepts a normalized ``(B, C, H, W)`` tensor and returns ``(B, K, h, w)``.
+- ``K = len(blocks) * (1 + M·include_registers) * nh``, where ``nh`` is the head
+  count and ``M`` the model's register-token count (``0`` for models without
+  registers). Each channel is one prefix-token query row's attention over the
+  patch grid for one head — heads are **never** reduced.
+- Channels are stacked in the deterministic order ``[block][cls, reg…][head]``
+  (block outer, in the order requested; then CLS, then any register tokens; head
+  innermost). The CLS block (the first ``nh`` channels of each block) does not
+  depend on ``include_registers`` — registers only *append* channels.
+- ``blocks`` selects transformer blocks (negative indices count from the end);
+  ``include_registers`` adds the register-token query rows (Darcet et al.) as
+  extra channels for models that carry them (e.g. Hibou).
+
+Example:
+
+.. code-block:: python
+
+   import torch
+   from PIL import Image
+
+   from slide2vec.encoders import encoder_registry
+
+   encoder = encoder_registry.require("lunit")().to("cuda")
+   transform = encoder.get_dense_transform()
+
+   tile = Image.open("/data/tile.png").convert("RGB")
+   batch = transform(tile).unsqueeze(0).to(encoder.device)
+
+   with torch.no_grad():
+       attn = encoder.encode_tiles_attention(batch)  # last block, CLS only
+
+   print(attn.shape)  # (1, nh, 28, 28) for a 224 px Lunit tile
+
+Each value is a softmax weight: a slice of one query row over the patch keys, so
+values are non-negative and a channel's spatial sum is ``<= 1`` (the prefix-token
+key columns carry the remaining mass). As with dense extraction, the input must
+be divisible by the encoder patch size, and unsupported encoders raise
+``NotImplementedError``.
+
+Implementation note: timm ViTs run a fused SDPA kernel that never materializes
+the attention matrix, so it is recomputed from each block's own projection
+(bit-equivalent to the weights the fused kernel applies). HuggingFace encoders
+use ``output_attentions=True`` directly.
+
 Pipeline
 ---------
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -140,6 +140,29 @@ Notes:
   ``dynamic_img_size=True`` and ``allow_non_recommended_settings=True`` when
   constructing the encoder.
 
+Dense attention maps
+~~~~~~~~~~~~~~~~~~~~~
+
+Tile encoders that implement ``encode_tiles_attention`` return per-head
+prefix-token self-attention as a spatial grid ``(B, K, h, w)`` — see the
+"Dense Attention Map Extraction" section of :doc:`api` for the channel-order
+contract and knobs.
+
+The following built-in tile presets are covered: ``conch``, ``conchv15``,
+``gigapath``, ``h0-mini``, ``h-optimus-0``, ``h-optimus-1``, ``hibou-b``,
+``hibou-l``, ``lunit``, ``midnight``, ``phikon``, ``phikonv2``, ``prost40m``,
+``uni``, ``uni2``, ``virchow``, and ``virchow2``.
+
+Notes:
+
+- ``musk`` is **not** covered: its BEiT3 backbone uses a non-timm attention
+  module, so attention extraction raises ``NotImplementedError`` (dense
+  patch-token extraction is still available).
+- ``hibou-b`` / ``hibou-l`` carry register tokens; pass ``include_registers=True``
+  to add their query rows as extra channels.
+- ``conch`` / ``conchv15`` recover attention from their inner timm ViT trunk, the
+  same trunk their dense extraction uses.
+
 
 
 Slide-level encoders

--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -1,6 +1,7 @@
 """Encoder abstractions for tile-level and slide-level feature extraction."""
 
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from typing import Callable
 
 import timm
@@ -12,6 +13,36 @@ from torchvision.transforms import v2
 
 def preferred_default_device() -> torch.device:
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+@contextmanager
+def hf_eager_attention(model):
+    """Force an HF model onto eager attention for the duration of the block.
+
+    Recent ``transformers`` default to an SDPA attention implementation that
+    *silently ignores* ``output_attentions=True`` (it warns and returns
+    ``attentions=None``), so attention extraction must temporarily switch the
+    model to ``eager``, which materializes the weights. The previous
+    implementation is restored on exit. A no-op for models that lack
+    ``set_attn_implementation`` or are already eager (e.g. some vendored
+    ``trust_remote_code`` backbones that always compute the weights)."""
+    setter = getattr(model, "set_attn_implementation", None)
+    prev = getattr(getattr(model, "config", None), "_attn_implementation", None)
+    changed = False
+    if callable(setter) and prev not in (None, "eager"):
+        try:
+            setter("eager")
+            changed = True
+        except Exception:
+            changed = False
+    try:
+        yield
+    finally:
+        if changed:
+            try:
+                setter(prev)
+            except Exception:
+                pass
 
 
 def resolve_requested_output_variant(

--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -214,6 +214,126 @@ def resolve_block_indices(blocks, num_blocks: int, *, encoder_name: str) -> list
     return resolved
 
 
+def timm_trunk_attention(
+    trunk,
+    batch: Tensor,
+    *,
+    blocks: tuple[int, ...] = (-1,),
+    include_registers: bool = False,
+    encoder_name: str,
+) -> Tensor:
+    """Extract per-head prefix-token attention maps from a timm ViT trunk.
+
+    The reusable core of :meth:`TimmTileEncoder.encode_tiles_attention`, factored
+    out so wrapper encoders that embed a timm ``VisionTransformer`` (CONCH's
+    ``visual.trunk``, CONCH v1.5's ``trunk``) reuse the exact same path on their
+    inner trunk — the attention analog of how ``_encode_trunk_dense`` is shared.
+
+    Captures each selected block's attention input via a forward-pre-hook on
+    ``trunk.blocks[i].attn`` (the fused SDPA kernel never materializes the matrix),
+    recomputes the softmax weights (:func:`timm_self_attention_weights`), and folds
+    the prefix-token query rows into spatial grids (:func:`prefix_attention_to_grid`).
+    Patch size and prefix-token count are read from the trunk
+    (``patch_embed.patch_size`` / ``num_prefix_tokens``). Output ``(B, K, h, w)`` in
+    ``[block][cls, reg…][head]`` order.
+    """
+    if batch.ndim != 4:
+        raise ValueError(
+            "encode_tiles_attention expects a (B, C, H, W) batch, got shape "
+            f"{tuple(batch.shape)}."
+        )
+    _, _, height, width = batch.shape
+    patch = trunk.patch_embed.patch_size
+    patch_h, patch_w = (patch, patch) if isinstance(patch, int) else (int(patch[0]), int(patch[1]))
+    if height % patch_h != 0 or width % patch_w != 0:
+        raise ValueError(
+            f"Attention extraction for '{encoder_name}' requires input divisible by "
+            f"the patch size: got {height}x{width}, patch {patch_h}x{patch_w}. Pad "
+            "the tile up to a patch multiple first."
+        )
+    if not hasattr(trunk, "blocks"):
+        raise NotImplementedError(
+            f"{encoder_name} has no '.blocks' transformer stack; attention extraction "
+            "supports timm ViT-style backbones only."
+        )
+    block_list = trunk.blocks
+    resolved = resolve_block_indices(blocks, len(block_list), encoder_name=encoder_name)
+
+    captured: dict[int, Tensor] = {}
+
+    def _make_hook(index: int):
+        def _hook(_module, inputs):
+            captured[index] = inputs[0]
+
+        return _hook
+
+    handles = []
+    for index in sorted(set(resolved)):
+        handles.append(block_list[index].attn.register_forward_pre_hook(_make_hook(index)))
+    try:
+        trunk.forward_features(batch)
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    grid_h, grid_w = height // patch_h, width // patch_w
+    num_prefix = int(getattr(trunk, "num_prefix_tokens", 1))
+    grids = []
+    for index in resolved:
+        attn_weights = timm_self_attention_weights(block_list[index].attn, captured[index])
+        grids.append(
+            prefix_attention_to_grid(
+                attn_weights,
+                num_prefix_tokens=num_prefix,
+                include_registers=include_registers,
+                grid_h=grid_h,
+                grid_w=grid_w,
+                encoder_name=encoder_name,
+            )
+        )
+    return torch.cat(grids, dim=1)  # [block] outer (caller order), [cls, reg…][head] inner
+
+
+def attentions_tuple_to_grids(
+    attentions,
+    *,
+    num_prefix_tokens: int,
+    blocks: tuple[int, ...],
+    include_registers: bool,
+    grid_h: int,
+    grid_w: int,
+    encoder_name: str,
+) -> Tensor:
+    """Fold an HF ``output_attentions`` tuple into stacked prefix-token grids.
+
+    HF transformer ViTs expose every block's softmax attention directly (no
+    fused-kernel recompute), as a per-layer tuple of ``(B, nh, N, N)`` tensors.
+    This selects the requested blocks (:func:`resolve_block_indices`), folds each
+    to spatial grids (:func:`prefix_attention_to_grid`), and concatenates them in
+    ``[block][cls, reg…][head]`` order — the shared core of the HF-path encoders
+    (Phikon, Hibou, Midnight), which differ only in ``num_prefix_tokens``.
+    """
+    if not attentions:
+        raise NotImplementedError(
+            f"{encoder_name} returned no attentions; the model must support "
+            "output_attentions=True (an eager/recompute attention implementation, "
+            "not a fused SDPA path that discards the weights)."
+        )
+    resolved = resolve_block_indices(blocks, len(attentions), encoder_name=encoder_name)
+    grids = [
+        prefix_attention_to_grid(
+            attentions[index],
+            num_prefix_tokens=num_prefix_tokens,
+            include_registers=include_registers,
+            grid_h=grid_h,
+            grid_w=grid_w,
+            encoder_name=encoder_name,
+        )
+        for index in resolved
+    ]
+    return torch.cat(grids, dim=1)
+
+
 class Encoder(ABC):
     """Shared lifecycle contract for all encoders."""
 
@@ -480,64 +600,13 @@ class TimmTileEncoder(TileEncoder):
         ``(B, K, h, w)`` in ``[block][cls, reg…][head]`` order — see
         :meth:`TileEncoder.encode_tiles_attention`.
         """
-        if batch.ndim != 4:
-            raise ValueError(
-                "encode_tiles_attention expects a (B, C, H, W) batch, got shape "
-                f"{tuple(batch.shape)}."
-            )
-        _, _, height, width = batch.shape
-        patch_h, patch_w = self._dense_patch_size()
-        if height % patch_h != 0 or width % patch_w != 0:
-            raise ValueError(
-                f"Attention extraction for '{type(self).__name__}' requires input "
-                f"divisible by the patch size: got {height}x{width}, patch "
-                f"{patch_h}x{patch_w}. Pad the tile up to a patch multiple first."
-            )
-        if not hasattr(self._model, "blocks"):
-            raise NotImplementedError(
-                f"{type(self).__name__} has no '.blocks' transformer stack; attention "
-                "extraction supports timm ViT-style backbones only."
-            )
-        block_list = self._model.blocks
-        resolved = resolve_block_indices(
-            blocks, len(block_list), encoder_name=type(self).__name__
+        return timm_trunk_attention(
+            self._model,
+            batch,
+            blocks=blocks,
+            include_registers=include_registers,
+            encoder_name=type(self).__name__,
         )
-
-        captured: dict[int, Tensor] = {}
-
-        def _make_hook(index: int):
-            def _hook(_module, inputs):
-                captured[index] = inputs[0]
-
-            return _hook
-
-        handles = []
-        for index in sorted(set(resolved)):
-            handles.append(block_list[index].attn.register_forward_pre_hook(_make_hook(index)))
-        try:
-            self._model.forward_features(batch)
-        finally:
-            for handle in handles:
-                handle.remove()
-
-        grid_h, grid_w = height // patch_h, width // patch_w
-        num_prefix = self._dense_num_prefix_tokens()
-        grids = []
-        for index in resolved:
-            attn_weights = timm_self_attention_weights(
-                block_list[index].attn, captured[index]
-            )
-            grids.append(
-                prefix_attention_to_grid(
-                    attn_weights,
-                    num_prefix_tokens=num_prefix,
-                    include_registers=include_registers,
-                    grid_h=grid_h,
-                    grid_w=grid_w,
-                    encoder_name=type(self).__name__,
-                )
-            )
-        return torch.cat(grids, dim=1)  # [block] outer (caller order), [cls, reg…][head] inner
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -99,6 +99,121 @@ def reshape_tokens_to_grid(
     return patch_tokens.transpose(1, 2).reshape(batch_size, dim, grid_h, grid_w)
 
 
+def prefix_attention_to_grid(
+    attn_weights: Tensor,
+    *,
+    num_prefix_tokens: int,
+    include_registers: bool,
+    grid_h: int,
+    grid_w: int,
+    encoder_name: str,
+) -> Tensor:
+    """Fold one block's self-attention into per-prefix-token spatial maps.
+
+    Given the full attention weights ``(B, nh, N, N)`` of one transformer block
+    (rows = query tokens, columns = key tokens, each row a softmax over keys),
+    select the **prefix-token query rows** — the CLS token always, the ``M``
+    register tokens too when ``include_registers`` — slice the **patch key columns**,
+    and reshape each selected row back into its ``(grid_h, grid_w)`` spatial layout.
+
+    The output is ``(B, K, grid_h, grid_w)`` with ``K = num_query * nh`` channels in
+    the deterministic order ``[cls, reg…][head]`` (query-token outer, head inner):
+    channel ``q * nh + head`` is prefix-query ``q``'s attention from head ``head``.
+    ``num_query = num_prefix_tokens`` when ``include_registers`` else ``1`` (CLS only).
+
+    This is the attention analog of :func:`reshape_tokens_to_grid` (one folds patch
+    *tokens* into a grid, the other folds prefix-token *attention* into grids); it
+    reuses the same ``num_prefix_tokens`` split. Per-head is preserved on purpose —
+    head specialization is the signal the downstream pixel-classifier exploits, and
+    reducing it would be lossy and irreversible in the cache. Fails loud on a token
+    accounting mismatch rather than silently mis-reshaping.
+    """
+    if attn_weights.ndim != 4:
+        raise ValueError(
+            f"Attention extraction for '{encoder_name}' expected (B, nh, N, N) "
+            f"attention weights, got shape {tuple(attn_weights.shape)}."
+        )
+    batch_size, num_heads, num_query_tokens, num_key_tokens = attn_weights.shape
+    if num_query_tokens != num_key_tokens:
+        raise ValueError(
+            f"Attention extraction for '{encoder_name}' expected square attention "
+            f"(query==key tokens), got {num_query_tokens}x{num_key_tokens}."
+        )
+    if num_prefix_tokens < 1:
+        raise ValueError(
+            f"Attention extraction for '{encoder_name}' needs at least one prefix "
+            f"token (the CLS query row), got num_prefix_tokens={num_prefix_tokens}."
+        )
+    num_patches = grid_h * grid_w
+    expected = num_prefix_tokens + num_patches
+    if num_key_tokens != expected:
+        raise ValueError(
+            f"Attention token accounting mismatch for '{encoder_name}': block "
+            f"returned {num_key_tokens} tokens; with {num_prefix_tokens} prefix "
+            f"token(s) the {grid_h}x{grid_w} grid expects {expected}. Check the "
+            "prefix-token count and the input-size / patch-size / grid geometry."
+        )
+    num_query = num_prefix_tokens if include_registers else 1
+    # rows: prefix query tokens [0:num_query]; columns: patch keys [num_prefix:].
+    patch_rows = attn_weights[:, :, :num_query, num_prefix_tokens:]  # (B, nh, q, P)
+    # (B, nh, q, P) -> (B, q, nh, P) so reshape yields the [query][head] channel order.
+    maps = patch_rows.permute(0, 2, 1, 3).reshape(batch_size, num_query * num_heads, num_patches)
+    return maps.reshape(batch_size, num_query * num_heads, grid_h, grid_w)
+
+
+def timm_self_attention_weights(attn_module, x: Tensor) -> Tensor:
+    """Recompute a timm ``Attention`` block's softmax weights ``(B, nh, N, N)``.
+
+    timm's attention runs a *fused* SDPA kernel by default, which never
+    materializes the attention matrix. To recover it we re-run the projection from
+    the module's own input ``x`` (the post-``norm1`` residual-branch input, captured
+    via a forward-pre-hook) using the module's own ``qkv`` / ``q_norm`` / ``k_norm``
+    / ``num_heads`` / ``head_dim`` / ``scale`` — i.e. exactly the non-fused branch of
+    ``Attention.forward``, so the result is bit-equivalent to the weights the fused
+    kernel applies internally. Dropout is omitted (extraction runs under ``eval``).
+    """
+    if not hasattr(attn_module, "qkv"):
+        raise NotImplementedError(
+            f"{type(attn_module).__name__} has no fused 'qkv' projection; attention "
+            "extraction currently supports timm ViT Attention blocks only."
+        )
+    batch_size, num_tokens, _ = x.shape
+    num_heads = int(attn_module.num_heads)
+    head_dim = int(getattr(attn_module, "head_dim", x.shape[-1] // num_heads))
+    qkv = (
+        attn_module.qkv(x)
+        .reshape(batch_size, num_tokens, 3, num_heads, head_dim)
+        .permute(2, 0, 3, 1, 4)
+    )
+    q, k, _ = qkv.unbind(0)
+    # q_norm / k_norm are Identity unless the model uses QK-norm; apply them either way.
+    q = attn_module.q_norm(q)
+    k = attn_module.k_norm(k)
+    q = q * attn_module.scale
+    attn = q @ k.transpose(-2, -1)
+    return attn.softmax(dim=-1)
+
+
+def resolve_block_indices(blocks, num_blocks: int, *, encoder_name: str) -> list[int]:
+    """Normalize a (possibly negative) block selection against ``num_blocks``.
+
+    Preserves caller order (so the recorded ``[block]`` channel order is the order
+    requested) and validates each index, failing loud on an out-of-range block.
+    """
+    resolved: list[int] = []
+    for raw in blocks:
+        idx = int(raw)
+        if idx < 0:
+            idx += num_blocks
+        if not (0 <= idx < num_blocks):
+            raise ValueError(
+                f"Attention extraction for '{encoder_name}': block index {raw} is out "
+                f"of range for a backbone with {num_blocks} transformer blocks."
+            )
+        resolved.append(idx)
+    return resolved
+
+
 class Encoder(ABC):
     """Shared lifecycle contract for all encoders."""
 
@@ -145,6 +260,33 @@ class TileEncoder(Encoder):
             f"{type(self).__name__} does not support dense (spatial-grid) feature "
             "extraction. Dense extraction requires a ViT tile encoder whose patch "
             "tokens can be reshaped into a spatial grid."
+        )
+
+    def encode_tiles_attention(
+        self,
+        batch: Tensor,
+        *,
+        blocks: tuple[int, ...] = (-1,),
+        include_registers: bool = False,
+    ) -> Tensor:
+        """Encode tiles into per-head CLS/register self-attention maps.
+
+        ``(B, C, H, W) -> (B, K, h, w)`` where each channel is one prefix-token
+        query row's self-attention over the patch grid for one head, stacked in the
+        deterministic order ``[block][cls, reg…][head]``. ``K = len(blocks) *
+        (1 + M·include_registers) * nh`` with ``M`` the model's register-token count
+        (``0`` for models without them) and ``nh`` the head count.
+
+        The per-head CLS attention of a frozen ViT doubles as a dense per-pixel
+        feature (Ramchandani et al., arXiv:2602.18747); ``include_registers`` adds
+        the register-token query rows (Darcet et al.) as extra, optional channels.
+        Default: unsupported — overridden by ViT tile encoders whose attention
+        blocks can be hooked (timm ViTs and HF transformers ViTs).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support attention-map extraction. It "
+            "requires a ViT tile encoder whose self-attention can be recovered "
+            "(timm Attention blocks, or an HF transformer with output_attentions)."
         )
 
     @property
@@ -320,6 +462,82 @@ class TimmTileEncoder(TileEncoder):
             num_prefix_tokens=self._dense_num_prefix_tokens(),
             encoder_name=type(self).__name__,
         )
+
+    def encode_tiles_attention(
+        self,
+        batch: Tensor,
+        *,
+        blocks: tuple[int, ...] = (-1,),
+        include_registers: bool = False,
+    ) -> Tensor:
+        """Encode tiles into per-head prefix-token attention maps (timm ViT family).
+
+        Captures each selected block's attention input via a forward-pre-hook on
+        ``blocks[i].attn`` (the fused SDPA kernel never materializes the attention
+        matrix), then recomputes the softmax weights from the module's own
+        projection (:func:`timm_self_attention_weights`) and folds the prefix-token
+        query rows into spatial grids (:func:`prefix_attention_to_grid`). Output is
+        ``(B, K, h, w)`` in ``[block][cls, reg…][head]`` order — see
+        :meth:`TileEncoder.encode_tiles_attention`.
+        """
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_attention expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch_h, patch_w = self._dense_patch_size()
+        if height % patch_h != 0 or width % patch_w != 0:
+            raise ValueError(
+                f"Attention extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch_h}x{patch_w}. Pad the tile up to a patch multiple first."
+            )
+        if not hasattr(self._model, "blocks"):
+            raise NotImplementedError(
+                f"{type(self).__name__} has no '.blocks' transformer stack; attention "
+                "extraction supports timm ViT-style backbones only."
+            )
+        block_list = self._model.blocks
+        resolved = resolve_block_indices(
+            blocks, len(block_list), encoder_name=type(self).__name__
+        )
+
+        captured: dict[int, Tensor] = {}
+
+        def _make_hook(index: int):
+            def _hook(_module, inputs):
+                captured[index] = inputs[0]
+
+            return _hook
+
+        handles = []
+        for index in sorted(set(resolved)):
+            handles.append(block_list[index].attn.register_forward_pre_hook(_make_hook(index)))
+        try:
+            self._model.forward_features(batch)
+        finally:
+            for handle in handles:
+                handle.remove()
+
+        grid_h, grid_w = height // patch_h, width // patch_w
+        num_prefix = self._dense_num_prefix_tokens()
+        grids = []
+        for index in resolved:
+            attn_weights = timm_self_attention_weights(
+                block_list[index].attn, captured[index]
+            )
+            grids.append(
+                prefix_attention_to_grid(
+                    attn_weights,
+                    num_prefix_tokens=num_prefix,
+                    include_registers=include_registers,
+                    grid_h=grid_h,
+                    grid_w=grid_w,
+                    encoder_name=type(self).__name__,
+                )
+            )
+        return torch.cat(grids, dim=1)  # [block] outer (caller order), [cls, reg…][head] inner
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/models/conch.py
+++ b/slide2vec/encoders/models/conch.py
@@ -18,6 +18,7 @@ from slide2vec.encoders.base import (
     preferred_default_device,
     reshape_tokens_to_grid,
     resolve_requested_output_variant,
+    timm_trunk_attention,
 )
 from slide2vec.encoders.registry import register_encoder
 
@@ -120,6 +121,22 @@ class CONCH(TileEncoder):
             encoder_name=type(self).__name__,
         )
 
+    def encode_tiles_attention(
+        self,
+        batch: Tensor,
+        *,
+        blocks: tuple[int, ...] = (-1,),
+        include_registers: bool = False,
+    ) -> Tensor:
+        # The ViT trunk is a timm VisionTransformer, so reuse the shared timm path.
+        return timm_trunk_attention(
+            self._model.visual.trunk,
+            batch,
+            blocks=blocks,
+            include_registers=include_registers,
+            encoder_name=type(self).__name__,
+        )
+
     @property
     def encode_dim(self) -> int:
         return 512
@@ -164,6 +181,22 @@ class CONCHv15(TileEncoder):
         return _encode_trunk_dense(
             trunk=self._model.trunk,
             batch=batch,
+            encoder_name=type(self).__name__,
+        )
+
+    def encode_tiles_attention(
+        self,
+        batch: Tensor,
+        *,
+        blocks: tuple[int, ...] = (-1,),
+        include_registers: bool = False,
+    ) -> Tensor:
+        # The ViT trunk is a timm VisionTransformer, so reuse the shared timm path.
+        return timm_trunk_attention(
+            self._model.trunk,
+            batch,
+            blocks=blocks,
+            include_registers=include_registers,
             encoder_name=type(self).__name__,
         )
 

--- a/slide2vec/encoders/models/hibou.py
+++ b/slide2vec/encoders/models/hibou.py
@@ -12,6 +12,7 @@ from transformers import AutoModel
 
 from slide2vec.encoders.base import (
     TileEncoder,
+    attentions_tuple_to_grids,
     preferred_default_device,
     reshape_tokens_to_grid,
     resolve_requested_output_variant,
@@ -76,6 +77,43 @@ class _HibouBase(TileEncoder):
             grid_h=height // patch,
             grid_w=width // patch,
             num_prefix_tokens=1 + int(getattr(self._model.config, "num_register_tokens", 0)),
+            encoder_name=type(self).__name__,
+        )
+
+    def encode_tiles_attention(
+        self,
+        batch: Tensor,
+        *,
+        blocks: tuple[int, ...] = (-1,),
+        include_registers: bool = False,
+    ) -> Tensor:
+        """Per-head CLS/register attention maps (HF Dinov2 path).
+
+        Hibou carries register tokens, so ``include_registers`` adds those query
+        rows as extra channels. SDPA-backed HF attention falls back to an eager
+        compute when ``output_attentions=True`` is requested.
+        """
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_attention expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch = int(self._model.config.patch_size)
+        if height % patch != 0 or width % patch != 0:
+            raise ValueError(
+                f"Attention extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch}. Pad the tile up to a patch multiple first."
+            )
+        output = self._model(pixel_values=batch, output_attentions=True)
+        return attentions_tuple_to_grids(
+            output.attentions,
+            num_prefix_tokens=1 + int(getattr(self._model.config, "num_register_tokens", 0)),
+            blocks=blocks,
+            include_registers=include_registers,
+            grid_h=height // patch,
+            grid_w=width // patch,
             encoder_name=type(self).__name__,
         )
 

--- a/slide2vec/encoders/models/hibou.py
+++ b/slide2vec/encoders/models/hibou.py
@@ -13,6 +13,7 @@ from transformers import AutoModel
 from slide2vec.encoders.base import (
     TileEncoder,
     attentions_tuple_to_grids,
+    hf_eager_attention,
     preferred_default_device,
     reshape_tokens_to_grid,
     resolve_requested_output_variant,
@@ -106,7 +107,8 @@ class _HibouBase(TileEncoder):
                 f"divisible by the patch size: got {height}x{width}, patch "
                 f"{patch}. Pad the tile up to a patch multiple first."
             )
-        output = self._model(pixel_values=batch, output_attentions=True)
+        with hf_eager_attention(self._model):
+            output = self._model(pixel_values=batch, output_attentions=True)
         return attentions_tuple_to_grids(
             output.attentions,
             num_prefix_tokens=1 + int(getattr(self._model.config, "num_register_tokens", 0)),

--- a/slide2vec/encoders/models/midnight.py
+++ b/slide2vec/encoders/models/midnight.py
@@ -14,6 +14,7 @@ from transformers import AutoModel
 from slide2vec.encoders.base import (
     TileEncoder,
     attentions_tuple_to_grids,
+    hf_eager_attention,
     preferred_default_device,
     reshape_tokens_to_grid,
     resolve_requested_output_variant,
@@ -107,7 +108,8 @@ class Midnight(TileEncoder):
                 f"divisible by the patch size: got {height}x{width}, patch "
                 f"{patch}. Pad the tile up to a patch multiple first."
             )
-        output = self._model(batch, output_attentions=True)
+        with hf_eager_attention(self._model):
+            output = self._model(batch, output_attentions=True)
         return attentions_tuple_to_grids(
             output.attentions,
             num_prefix_tokens=1,

--- a/slide2vec/encoders/models/midnight.py
+++ b/slide2vec/encoders/models/midnight.py
@@ -13,6 +13,7 @@ from transformers import AutoModel
 
 from slide2vec.encoders.base import (
     TileEncoder,
+    attentions_tuple_to_grids,
     preferred_default_device,
     reshape_tokens_to_grid,
     resolve_requested_output_variant,
@@ -77,6 +78,43 @@ class Midnight(TileEncoder):
             grid_h=height // patch,
             grid_w=width // patch,
             num_prefix_tokens=1,
+            encoder_name=type(self).__name__,
+        )
+
+    def encode_tiles_attention(
+        self,
+        batch: Tensor,
+        *,
+        blocks: tuple[int, ...] = (-1,),
+        include_registers: bool = False,
+    ) -> Tensor:
+        """Per-head CLS attention maps (HF Dinov2 path).
+
+        Midnight has a single prefix token (CLS, no registers), so
+        ``include_registers`` is a no-op here. SDPA-backed HF attention falls back
+        to an eager compute when ``output_attentions=True`` is requested.
+        """
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_attention expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch = int(self._model.config.patch_size)
+        if height % patch != 0 or width % patch != 0:
+            raise ValueError(
+                f"Attention extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch}. Pad the tile up to a patch multiple first."
+            )
+        output = self._model(batch, output_attentions=True)
+        return attentions_tuple_to_grids(
+            output.attentions,
+            num_prefix_tokens=1,
+            blocks=blocks,
+            include_registers=include_registers,
+            grid_h=height // patch,
+            grid_w=width // patch,
             encoder_name=type(self).__name__,
         )
 

--- a/slide2vec/encoders/models/phikon.py
+++ b/slide2vec/encoders/models/phikon.py
@@ -12,7 +12,9 @@ from transformers import AutoImageProcessor, AutoModel
 from slide2vec.encoders.base import (
     TileEncoder,
     preferred_default_device,
+    prefix_attention_to_grid,
     reshape_tokens_to_grid,
+    resolve_block_indices,
     resolve_requested_output_variant,
 )
 from slide2vec.encoders.registry import register_encoder
@@ -88,6 +90,53 @@ class _PhikonBase(TileEncoder):
             num_prefix_tokens=1,
             encoder_name=type(self).__name__,
         )
+
+    def encode_tiles_attention(
+        self,
+        batch: Tensor,
+        *,
+        blocks: tuple[int, ...] = (-1,),
+        include_registers: bool = False,
+    ) -> Tensor:
+        """Encode tiles into per-head CLS attention maps (HF transformers path).
+
+        HF ViTs expose every block's softmax attention directly via
+        ``output_attentions=True`` (no fused-kernel recompute needed). Phikon has a
+        single prefix token (CLS, no registers), so ``include_registers`` is a no-op
+        here (``M = 0``). Output ``(B, K, h, w)`` in ``[block][cls][head]`` order —
+        see :meth:`TileEncoder.encode_tiles_attention`.
+        """
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_attention expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch = int(self._model.config.patch_size)
+        if height % patch != 0 or width % patch != 0:
+            raise ValueError(
+                f"Attention extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch}. Pad the tile up to a patch multiple first."
+            )
+        output = self._model(pixel_values=batch, output_attentions=True)
+        attentions = output.attentions  # tuple: per-layer (B, nh, N, N)
+        resolved = resolve_block_indices(
+            blocks, len(attentions), encoder_name=type(self).__name__
+        )
+        grid_h, grid_w = height // patch, width // patch
+        grids = [
+            prefix_attention_to_grid(
+                attentions[index],
+                num_prefix_tokens=1,
+                include_registers=include_registers,
+                grid_h=grid_h,
+                grid_w=grid_w,
+                encoder_name=type(self).__name__,
+            )
+            for index in resolved
+        ]
+        return torch.cat(grids, dim=1)
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/models/phikon.py
+++ b/slide2vec/encoders/models/phikon.py
@@ -11,10 +11,9 @@ from transformers import AutoImageProcessor, AutoModel
 
 from slide2vec.encoders.base import (
     TileEncoder,
+    attentions_tuple_to_grids,
     preferred_default_device,
-    prefix_attention_to_grid,
     reshape_tokens_to_grid,
-    resolve_block_indices,
     resolve_requested_output_variant,
 )
 from slide2vec.encoders.registry import register_encoder
@@ -120,23 +119,15 @@ class _PhikonBase(TileEncoder):
                 f"{patch}. Pad the tile up to a patch multiple first."
             )
         output = self._model(pixel_values=batch, output_attentions=True)
-        attentions = output.attentions  # tuple: per-layer (B, nh, N, N)
-        resolved = resolve_block_indices(
-            blocks, len(attentions), encoder_name=type(self).__name__
+        return attentions_tuple_to_grids(
+            output.attentions,  # tuple: per-layer (B, nh, N, N)
+            num_prefix_tokens=1,
+            blocks=blocks,
+            include_registers=include_registers,
+            grid_h=height // patch,
+            grid_w=width // patch,
+            encoder_name=type(self).__name__,
         )
-        grid_h, grid_w = height // patch, width // patch
-        grids = [
-            prefix_attention_to_grid(
-                attentions[index],
-                num_prefix_tokens=1,
-                include_registers=include_registers,
-                grid_h=grid_h,
-                grid_w=grid_w,
-                encoder_name=type(self).__name__,
-            )
-            for index in resolved
-        ]
-        return torch.cat(grids, dim=1)
 
     @property
     def encode_dim(self) -> int:

--- a/slide2vec/encoders/models/phikon.py
+++ b/slide2vec/encoders/models/phikon.py
@@ -12,6 +12,7 @@ from transformers import AutoImageProcessor, AutoModel
 from slide2vec.encoders.base import (
     TileEncoder,
     attentions_tuple_to_grids,
+    hf_eager_attention,
     preferred_default_device,
     reshape_tokens_to_grid,
     resolve_requested_output_variant,
@@ -118,7 +119,8 @@ class _PhikonBase(TileEncoder):
                 f"divisible by the patch size: got {height}x{width}, patch "
                 f"{patch}. Pad the tile up to a patch multiple first."
             )
-        output = self._model(pixel_values=batch, output_attentions=True)
+        with hf_eager_attention(self._model):
+            output = self._model(pixel_values=batch, output_attentions=True)
         return attentions_tuple_to_grids(
             output.attentions,  # tuple: per-layer (B, nh, N, N)
             num_prefix_tokens=1,

--- a/tests/test_attention_extraction.py
+++ b/tests/test_attention_extraction.py
@@ -20,9 +20,11 @@ import torch.nn.functional as F  # noqa: E402
 from slide2vec.encoders.base import (  # noqa: E402
     TileEncoder,
     TimmTileEncoder,
+    attentions_tuple_to_grids,
     prefix_attention_to_grid,
     resolve_block_indices,
     timm_self_attention_weights,
+    timm_trunk_attention,
 )
 
 
@@ -139,6 +141,41 @@ def test_attention_rows_form_a_distribution_over_grid_is_not_assumed():
         out = enc.encode_tiles_attention(x)
     assert (out >= 0).all()
     assert (out.flatten(2).sum(-1) <= 1.0 + 1e-5).all()
+
+
+# --------------------------------------------------------------------------- #
+# timm_trunk_attention: shared core reused by the timm encoders and the CONCH
+# wrappers (whose .visual.trunk / .trunk is itself a timm VisionTransformer).
+# --------------------------------------------------------------------------- #
+
+
+def test_timm_trunk_attention_matches_encoder_method():
+    """The free function on the trunk == the TimmTileEncoder method (same path)."""
+    enc = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)
+    x = torch.randn(1, 3, 224, 224)
+    with torch.no_grad():
+        via_method = enc.encode_tiles_attention(x, blocks=(-1, -2))
+        via_func = timm_trunk_attention(
+            enc._model, x, blocks=(-1, -2), encoder_name="trunk"
+        )
+    torch.testing.assert_close(via_method, via_func, rtol=0, atol=0)
+
+
+def test_conch_reuses_timm_trunk_attention():
+    """CONCH reads its inner timm trunk via .visual.trunk; the override must match
+    the trunk run directly through the shared function."""
+    from slide2vec.encoders.models.conch import CONCH
+
+    trunk = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)._model
+    enc = CONCH.__new__(CONCH)
+    enc._model = SimpleNamespace(visual=SimpleNamespace(trunk=trunk))
+    x = torch.randn(1, 3, 224, 224)
+    with torch.no_grad():
+        out = enc.encode_tiles_attention(x, blocks=(-1,))
+        direct = timm_trunk_attention(trunk, x, blocks=(-1,), encoder_name="CONCH")
+    nh = trunk.blocks[-1].attn.num_heads
+    assert out.shape == (1, nh, 14, 14)
+    torch.testing.assert_close(out, direct, rtol=0, atol=0)
 
 
 # --------------------------------------------------------------------------- #
@@ -259,6 +296,60 @@ def test_phikon_attention_rejects_indivisible_input():
     enc._model = _FakeHFViTWithAttn(patch_size=16, num_heads=12, num_layers=12)
     with pytest.raises(ValueError, match="divisible by the patch size"):
         enc.encode_tiles_attention(torch.randn(1, 3, 220, 220))
+
+
+def test_attentions_tuple_helper_fails_loud_when_model_returns_none():
+    """A fused-SDPA HF model that ignores output_attentions yields attentions=None;
+    the helper must fail loud rather than crash deep inside the reshape."""
+    with pytest.raises(NotImplementedError, match="output_attentions=True"):
+        attentions_tuple_to_grids(
+            None, num_prefix_tokens=1, blocks=(-1,), include_registers=False,
+            grid_h=14, grid_w=14, encoder_name="e",
+        )
+
+
+class _FakeHFDinoV2:
+    """HF Dinov2 double: callable positionally or via pixel_values, with registers."""
+
+    def __init__(self, *, patch_size, num_heads, num_layers, num_register_tokens=0):
+        self.config = SimpleNamespace(
+            patch_size=patch_size, num_register_tokens=num_register_tokens
+        )
+        self._num_heads = num_heads
+        self._num_layers = num_layers
+        self._num_prefix = 1 + num_register_tokens
+
+    def __call__(self, pixel_values=None, *, output_attentions=False):
+        assert output_attentions is True
+        b, _, h, w = pixel_values.shape
+        n = self._num_prefix + (h // self.config.patch_size) * (w // self.config.patch_size)
+        attentions = tuple(
+            torch.rand(b, self._num_heads, n, n).softmax(dim=-1)
+            for _ in range(self._num_layers)
+        )
+        return _FakeHFAttnOutput(attentions)
+
+
+def test_hibou_attention_includes_registers():
+    from slide2vec.encoders.models.hibou import HibouB
+
+    enc = HibouB.__new__(HibouB)
+    enc._model = _FakeHFDinoV2(patch_size=14, num_heads=12, num_layers=12, num_register_tokens=4)
+    x = torch.randn(1, 3, 224, 224)  # grid 16x16
+    cls_only = enc.encode_tiles_attention(x, include_registers=False)
+    with_reg = enc.encode_tiles_attention(x, include_registers=True)
+    assert cls_only.shape == (1, 12, 16, 16)            # CLS only
+    assert with_reg.shape == (1, (1 + 4) * 12, 16, 16)  # CLS + 4 registers
+
+
+def test_midnight_attention_cls_only():
+    from slide2vec.encoders.models.midnight import Midnight
+
+    enc = Midnight.__new__(Midnight)
+    enc._model = _FakeHFDinoV2(patch_size=14, num_heads=6, num_layers=12)
+    x = torch.randn(2, 3, 224, 224)  # grid 16x16
+    out = enc.encode_tiles_attention(x, blocks=(-1, -2))
+    assert out.shape == (2, 2 * 6, 16, 16)  # 2 blocks * (1 CLS * 6 heads)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_attention_extraction.py
+++ b/tests/test_attention_extraction.py
@@ -1,0 +1,289 @@
+"""Tests for attention-map tile extraction: ``encode_tiles_attention``.
+
+Run fully offline (``pretrained=False``) — no weight downloads, no HF token. The
+keystone correctness check proves the recomputed timm attention weights are *the*
+weights the fused SDPA kernel applies (``attn_w @ v`` == ``SDPA(q, k, v)``), pinning
+the recompute, not just the output shape. Shape / channel-order / multi-block
+tests pin the locked ``[block][cls, reg…][head]`` contract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+import torch.nn.functional as F  # noqa: E402
+
+from slide2vec.encoders.base import (  # noqa: E402
+    TileEncoder,
+    TimmTileEncoder,
+    prefix_attention_to_grid,
+    resolve_block_indices,
+    timm_self_attention_weights,
+)
+
+
+def _make_timm_encoder(model_name: str, **timm_kwargs) -> TimmTileEncoder:
+    return TimmTileEncoder(model_name, pretrained=False, num_classes=0, **timm_kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Keystone: recomputed weights == the weights SDPA applies internally.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("reg_tokens", [0, 4])
+def test_recomputed_weights_match_sdpa(reg_tokens: int):
+    kwargs = {"dynamic_img_size": True}
+    if reg_tokens:
+        kwargs.update(reg_tokens=reg_tokens, no_embed_class=True, class_token=True)
+    enc = _make_timm_encoder("vit_tiny_patch16_224", **kwargs)
+    attn = enc._model.blocks[-1].attn
+    x = torch.randn(2, 3, 224, 224)
+
+    captured = {}
+    handle = attn.register_forward_pre_hook(lambda _m, inp: captured.__setitem__("x", inp[0]))
+    with torch.no_grad():
+        enc._model.forward_features(x)
+    handle.remove()
+
+    xa = captured["x"]
+    B, N, _ = xa.shape
+    head_dim = int(attn.head_dim)
+    qkv = attn.qkv(xa).reshape(B, N, 3, attn.num_heads, head_dim).permute(2, 0, 3, 1, 4)
+    q, k, v = qkv.unbind(0)
+    q, k = attn.q_norm(q), attn.k_norm(k)
+    reference = F.scaled_dot_product_attention(q, k, v)  # fused kernel ground truth
+
+    weights = timm_self_attention_weights(attn, xa)
+    mine = weights @ v
+    # weights are the exact softmax SDPA applies: applying them to v reproduces SDPA.
+    torch.testing.assert_close(mine, reference, rtol=0, atol=1e-5)
+    # and every query row is a proper distribution over keys.
+    torch.testing.assert_close(weights.sum(-1), torch.ones(B, attn.num_heads, N), atol=1e-5, rtol=0)
+
+
+# --------------------------------------------------------------------------- #
+# encode_tiles_attention: shape + locked channel-order contract.
+# --------------------------------------------------------------------------- #
+
+
+def test_attention_shape_cls_only_patch16():
+    enc = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)
+    nh = enc._model.blocks[-1].attn.num_heads
+    x = torch.randn(2, 3, 224, 224)
+    with torch.no_grad():
+        out = enc.encode_tiles_attention(x)  # blocks=(-1,), no registers
+    assert out.shape == (2, 1 * nh, 14, 14)  # K = 1 (CLS) * nh
+
+
+def test_attention_shape_with_registers_and_multiblock():
+    enc = _make_timm_encoder(
+        "vit_tiny_patch16_224",
+        dynamic_img_size=True,
+        reg_tokens=4,
+        no_embed_class=True,
+        class_token=True,
+    )
+    nh = enc._model.blocks[-1].attn.num_heads
+    x = torch.randn(1, 3, 256, 256)  # grid 16x16
+    with torch.no_grad():
+        out = enc.encode_tiles_attention(x, blocks=(-1, -2), include_registers=True)
+    # K = len(blocks) * (1 CLS + 4 reg) * nh
+    assert out.shape == (1, 2 * (1 + 4) * nh, 16, 16)
+
+
+def test_cls_channels_are_register_invariant():
+    """The first nh channels (block's CLS-from-each-head) must not depend on the
+    include_registers flag — registers only *append* channels after the CLS block."""
+    enc = _make_timm_encoder(
+        "vit_tiny_patch16_224",
+        dynamic_img_size=True,
+        reg_tokens=4,
+        no_embed_class=True,
+        class_token=True,
+    )
+    nh = enc._model.blocks[-1].attn.num_heads
+    x = torch.randn(1, 3, 224, 224)
+    with torch.no_grad():
+        cls_only = enc.encode_tiles_attention(x, include_registers=False)
+        with_reg = enc.encode_tiles_attention(x, include_registers=True)
+    assert cls_only.shape[1] == nh
+    assert with_reg.shape[1] == (1 + 4) * nh
+    torch.testing.assert_close(cls_only, with_reg[:, :nh], rtol=0, atol=1e-6)
+
+
+def test_multiblock_order_is_block_outer():
+    """blocks=(-1, -2) must concat block -1's channels then block -2's, in order."""
+    enc = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)
+    nh = enc._model.blocks[-1].attn.num_heads
+    x = torch.randn(1, 3, 224, 224)
+    with torch.no_grad():
+        last = enc.encode_tiles_attention(x, blocks=(-1,))
+        second_last = enc.encode_tiles_attention(x, blocks=(-2,))
+        both = enc.encode_tiles_attention(x, blocks=(-1, -2))
+    torch.testing.assert_close(both[:, :nh], last, rtol=0, atol=1e-6)
+    torch.testing.assert_close(both[:, nh:], second_last, rtol=0, atol=1e-6)
+
+
+def test_attention_rows_form_a_distribution_over_grid_is_not_assumed():
+    """CLS->patch rows are a *slice* of the full softmax row, so they need NOT sum to
+    1 over the patch grid alone (prefix columns carry mass). Sanity: non-negative,
+    bounded by the full-row sum (<= 1)."""
+    enc = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)
+    x = torch.randn(1, 3, 224, 224)
+    with torch.no_grad():
+        out = enc.encode_tiles_attention(x)
+    assert (out >= 0).all()
+    assert (out.flatten(2).sum(-1) <= 1.0 + 1e-5).all()
+
+
+# --------------------------------------------------------------------------- #
+# prefix_attention_to_grid: row-major layout + channel order, in isolation.
+# --------------------------------------------------------------------------- #
+
+
+def test_prefix_attention_to_grid_row_major_and_channel_order():
+    nh, grid_h, grid_w, num_prefix = 2, 2, 3, 3  # CLS + 2 registers
+    num_patches = grid_h * grid_w
+    N = num_prefix + num_patches
+    attn = torch.zeros(1, nh, N, N)
+    # For each (query prefix q, head) put a unique pattern in the patch columns:
+    # patch column p gets value (q*10 + head*100 + p), so we can read order back.
+    for q in range(num_prefix):
+        for head in range(nh):
+            for p in range(num_patches):
+                attn[0, head, q, num_prefix + p] = q * 10 + head * 100 + p
+    grid = prefix_attention_to_grid(
+        attn,
+        num_prefix_tokens=num_prefix,
+        include_registers=True,
+        grid_h=grid_h,
+        grid_w=grid_w,
+        encoder_name="t",
+    )
+    assert grid.shape == (1, num_prefix * nh, grid_h, grid_w)
+    # channel = q * nh + head  -> [cls, reg…][head]
+    for q in range(num_prefix):
+        for head in range(nh):
+            ch = q * nh + head
+            expected = torch.tensor(
+                [q * 10 + head * 100 + p for p in range(num_patches)], dtype=torch.float
+            ).reshape(grid_h, grid_w)
+            torch.testing.assert_close(grid[0, ch], expected, rtol=0, atol=0)
+
+
+def test_prefix_attention_to_grid_cls_only_drops_registers():
+    nh, grid_h, grid_w, num_prefix = 2, 2, 2, 3
+    N = num_prefix + grid_h * grid_w
+    attn = torch.rand(1, nh, N, N)
+    grid = prefix_attention_to_grid(
+        attn, num_prefix_tokens=num_prefix, include_registers=False,
+        grid_h=grid_h, grid_w=grid_w, encoder_name="t",
+    )
+    assert grid.shape == (1, nh, grid_h, grid_w)  # CLS only
+
+
+def test_prefix_attention_to_grid_token_mismatch_fails_loud():
+    attn = torch.rand(1, 2, 1 + 9, 1 + 9)  # 9 patches
+    with pytest.raises(ValueError, match="token accounting mismatch"):
+        prefix_attention_to_grid(
+            attn, num_prefix_tokens=1, include_registers=False,
+            grid_h=4, grid_w=4, encoder_name="t",  # 16 != 9
+        )
+
+
+def test_prefix_attention_to_grid_rejects_non_4d():
+    with pytest.raises(ValueError, match=r"\(B, nh, N, N\)"):
+        prefix_attention_to_grid(
+            torch.rand(2, 5, 5), num_prefix_tokens=1, include_registers=False,
+            grid_h=2, grid_w=2, encoder_name="t",
+        )
+
+
+def test_resolve_block_indices_normalizes_and_validates():
+    assert resolve_block_indices((-1, 0, -2), 12, encoder_name="e") == [11, 0, 10]
+    with pytest.raises(ValueError, match="out of range"):
+        resolve_block_indices((12,), 12, encoder_name="e")
+
+
+# --------------------------------------------------------------------------- #
+# Family B (HF transformers): output_attentions path, faked offline.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeHFAttnOutput:
+    def __init__(self, attentions):
+        self.attentions = attentions
+
+
+class _FakeHFViTWithAttn:
+    """Minimal HF ViT double exposing per-layer output_attentions."""
+
+    def __init__(self, *, patch_size: int, num_heads: int, num_layers: int):
+        self.config = SimpleNamespace(patch_size=patch_size)
+        self._num_heads = num_heads
+        self._num_layers = num_layers
+
+    def __call__(self, *, pixel_values, output_attentions=False):
+        assert output_attentions is True
+        b, _, h, w = pixel_values.shape
+        n = 1 + (h // self.config.patch_size) * (w // self.config.patch_size)
+        # Per-layer softmax-normalized attention so the slice invariants hold.
+        attentions = tuple(
+            torch.rand(b, self._num_heads, n, n).softmax(dim=-1)
+            for _ in range(self._num_layers)
+        )
+        return _FakeHFAttnOutput(attentions)
+
+
+def test_phikon_attention_uses_output_attentions():
+    from slide2vec.encoders.models.phikon import Phikon
+
+    enc = Phikon.__new__(Phikon)
+    enc._model = _FakeHFViTWithAttn(patch_size=16, num_heads=12, num_layers=12)
+    x = torch.randn(2, 3, 224, 224)
+    out = enc.encode_tiles_attention(x, blocks=(-1,))
+    assert out.shape == (2, 12, 14, 14)  # 1 CLS * 12 heads, grid 224/16=14
+    multi = enc.encode_tiles_attention(x, blocks=(-1, -2))
+    assert multi.shape == (2, 24, 14, 14)
+
+
+def test_phikon_attention_rejects_indivisible_input():
+    from slide2vec.encoders.models.phikon import Phikon
+
+    enc = Phikon.__new__(Phikon)
+    enc._model = _FakeHFViTWithAttn(patch_size=16, num_heads=12, num_layers=12)
+    with pytest.raises(ValueError, match="divisible by the patch size"):
+        enc.encode_tiles_attention(torch.randn(1, 3, 220, 220))
+
+
+# --------------------------------------------------------------------------- #
+# Gating: non-attention-capable encoders raise.
+# --------------------------------------------------------------------------- #
+
+
+def test_attention_unsupported_encoder_raises():
+    class _NonAttn(TileEncoder):
+        def get_transform(self):  # pragma: no cover - stub
+            return lambda x: x
+
+        def encode_tiles(self, batch):  # pragma: no cover - stub
+            return batch
+
+        @property
+        def encode_dim(self) -> int:  # pragma: no cover - stub
+            return 0
+
+        @property
+        def device(self):  # pragma: no cover - stub
+            return torch.device("cpu")
+
+        def to(self, device):  # pragma: no cover - stub
+            return self
+
+    with pytest.raises(NotImplementedError, match="does not support attention-map"):
+        _NonAttn().encode_tiles_attention(torch.randn(1, 3, 224, 224))

--- a/tests/test_attention_extraction.py
+++ b/tests/test_attention_extraction.py
@@ -330,6 +330,53 @@ class _FakeHFDinoV2:
         return _FakeHFAttnOutput(attentions)
 
 
+class _FakeSdpaHFViT:
+    """HF double mimicking the modern SDPA default: it *drops* attentions
+    (returns None) unless the model is switched to eager via
+    ``set_attn_implementation`` — exactly the trap the real Phikon/Midnight hit."""
+
+    def __init__(self, *, patch_size, num_heads, num_layers):
+        self.config = SimpleNamespace(patch_size=patch_size, _attn_implementation="sdpa")
+        self._num_heads = num_heads
+        self._num_layers = num_layers
+
+    def set_attn_implementation(self, impl):
+        self.config._attn_implementation = impl
+
+    def __call__(self, pixel_values=None, *, output_attentions=False):
+        b, _, h, w = pixel_values.shape
+        n = 1 + (h // self.config.patch_size) * (w // self.config.patch_size)
+        if self.config._attn_implementation != "eager" or not output_attentions:
+            return _FakeHFAttnOutput(None)  # SDPA silently discards the weights
+        attentions = tuple(
+            torch.rand(b, self._num_heads, n, n).softmax(dim=-1)
+            for _ in range(self._num_layers)
+        )
+        return _FakeHFAttnOutput(attentions)
+
+
+def test_phikon_forces_eager_when_sdpa_default():
+    """encode_tiles_attention must switch an SDPA-default model to eager (else it
+    would get attentions=None) and restore the prior implementation afterwards."""
+    from slide2vec.encoders.models.phikon import Phikon
+
+    enc = Phikon.__new__(Phikon)
+    enc._model = _FakeSdpaHFViT(patch_size=16, num_heads=12, num_layers=12)
+    out = enc.encode_tiles_attention(torch.randn(1, 3, 224, 224), blocks=(-1,))
+    assert out.shape == (1, 12, 14, 14)
+    assert enc._model.config._attn_implementation == "sdpa"  # restored
+
+
+def test_midnight_forces_eager_when_sdpa_default():
+    from slide2vec.encoders.models.midnight import Midnight
+
+    enc = Midnight.__new__(Midnight)
+    enc._model = _FakeSdpaHFViT(patch_size=14, num_heads=6, num_layers=12)
+    out = enc.encode_tiles_attention(torch.randn(1, 3, 224, 224))
+    assert out.shape == (1, 6, 16, 16)
+    assert enc._model.config._attn_implementation == "sdpa"  # restored
+
+
 def test_hibou_attention_includes_registers():
     from slide2vec.encoders.models.hibou import HibouB
 


### PR DESCRIPTION
## What

Adds an opt-in `TileEncoder.encode_tiles_attention(batch, *, blocks=(-1,), include_registers=False)` that turns a frozen ViT's per-head **CLS / register self-attention** into dense `(B, K, h, w)` maps — the attention analog of the existing `encode_tiles_dense` token-grid path.

Frozen-ViT CLS-attention doubles as a dense per-pixel feature (Ramchandani et al., [arXiv:2602.18747](https://arxiv.org/abs/2602.18747)); soma consumes these grids as the feature source for its decoder-free pixel-classifier segmentation path.

## How

Two reusable cores in `base.py`, one per backbone family:

- **timm path** — `timm_trunk_attention(trunk, ...)` (a free function paralleling `_encode_trunk_dense`): forward-pre-hook each selected `blocks[i].attn` to capture its input (the fused SDPA kernel never materializes the matrix), recompute the softmax weights from the module's own `qkv`/`q_norm`/`k_norm`/`scale` (`timm_self_attention_weights`), and fold the prefix-token query rows into spatial grids (`prefix_attention_to_grid`).
- **HF path** — `attentions_tuple_to_grids(attentions, ...)`: HF ViTs expose every block's softmax attention via `output_attentions=True`; select blocks and fold them. Wrapped in `hf_eager_attention(model)` because modern `transformers` default to an SDPA implementation that *silently ignores* `output_attentions` (warns, returns `None`); the context manager forces eager for the call and restores the prior implementation. The helper still fails loud if attentions come back empty rather than mis-reshaping.

`prefix_attention_to_grid` selects the prefix-token query rows (CLS always; the `M` register rows when `include_registers`) over the patch key columns; output `K = num_query * nh` channels in deterministic `[block][cls, reg…][head]` order. `resolve_block_indices` normalizes/validates a (possibly negative) block selection, preserving caller order.

## Encoder coverage

Every standard ViT tile encoder now supports attention extraction:

| Family | Encoders | Path |
|---|---|---|
| timm | UNI/UNI2, Virchow/Virchow2, GigaPath, H-Optimus-0/1, H0Mini, Lunit, Prost40M | inherited `TimmTileEncoder` method |
| timm trunk (wrapped) | CONCH, CONCH v1.5 | reuse `timm_trunk_attention` on `.visual.trunk` / `.trunk` |
| HF transformers | Phikon/Phikon2, Hibou-B/L (+ registers), Midnight | `output_attentions=True` under forced eager |
| **out of scope** | **MUSK** | BEiT3 (torchscale) attention is non-timm; stays on the inherited `NotImplementedError` |