### PR TITLE
fix null CLI spacing defaults

### DIFF
--- a/slide2vec/utils/config.py
+++ b/slide2vec/utils/config.py
@@ -41,6 +41,21 @@ def _encoder_derived_cfg(model_name: str) -> dict:
     }
 
 
+def _fill_null_encoder_defaults(cfg, encoder_defaults: dict) -> None:
+    """Fill null leaves with encoder defaults after user/CLI config merging."""
+    defaults_cfg = OmegaConf.create(encoder_defaults)
+    for path in (
+        "tiling.params.requested_tile_size_px",
+        "tiling.params.requested_spacing_um",
+        "speed.precision",
+    ):
+        if OmegaConf.select(cfg, path) is not None:
+            continue
+        default_value = OmegaConf.select(defaults_cfg, path)
+        if default_value is not None:
+            OmegaConf.update(cfg, path, default_value, merge=False)
+
+
 def validate_model_recommended_settings(cfg, *, run_on_cpu: bool = False) -> None:
     from slide2vec.encoders.registry import encoder_registry
     from slide2vec.encoders.validation import validate_encoder_config
@@ -88,14 +103,17 @@ def get_cfg_from_args(args):
 
     default_cfg = OmegaConf.create(default_config)
     model_name = OmegaConf.select(requested_cfg, "model.name")
-    spacing = OmegaConf.select(requested_cfg, "tiling.params.requested_spacing_um")
-    tile_size = OmegaConf.select(requested_cfg, "tiling.params.requested_tile_size_px")
-    if model_name and (spacing is None or tile_size is None):
-        encoder_defaults = _encoder_derived_cfg(model_name)
-        if encoder_defaults:
-            default_cfg = OmegaConf.merge(default_cfg, OmegaConf.create(encoder_defaults))
-
     cfg = OmegaConf.merge(default_cfg, user_cfg, cli_cfg)
+    if model_name and any(
+        OmegaConf.select(cfg, path) is None
+        for path in (
+            "tiling.params.requested_tile_size_px",
+            "tiling.params.requested_spacing_um",
+            "speed.precision",
+        )
+    ):
+        encoder_defaults = _encoder_derived_cfg(model_name)
+        _fill_null_encoder_defaults(cfg, encoder_defaults)
     OmegaConf.resolve(cfg)
     validate_model_recommended_settings(cfg, run_on_cpu=bool(getattr(args, "run_on_cpu", False)))
     return cfg

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -79,6 +79,34 @@ def test_get_cfg_from_args_fills_missing_preprocessing_from_single_spacing_model
     assert cfg.tiling.params.requested_tile_size_px == 448
 
 
+def test_get_cfg_from_args_fills_null_spacing_from_model_default(tmp_path: Path):
+    pytest.importorskip("omegaconf")
+
+    from slide2vec.utils.config import get_cfg_from_args
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "\n".join(
+            [
+                "csv: /tmp/slides.csv",
+                "output_dir: /tmp/output",
+                "model:",
+                "  name: conchv15",
+                "tiling:",
+                "  params:",
+                "    requested_spacing_um:",
+                "    requested_tile_size_px: 448",
+            ]
+        )
+    )
+    args = SimpleNamespace(config_file=str(cfg_path), output_dir=None, opts=[], run_on_cpu=False)
+
+    cfg = get_cfg_from_args(args)
+
+    assert cfg.tiling.params.requested_spacing_um == pytest.approx(0.5)
+    assert cfg.tiling.params.requested_tile_size_px == 448
+
+
 def test_get_cfg_from_args_rejects_models_with_ambiguous_spacing_defaults(tmp_path: Path):
     pytest.importorskip("omegaconf")
 


### PR DESCRIPTION
## Summary

Fixes CLI config loading when a user leaves `tiling.params.requested_spacing_um` explicitly blank/null in YAML while using a model preset with an unambiguous spacing default.

## Root Cause

The loader previously merged encoder-derived defaults before the user config. An explicit YAML null in the user config then overwrote the inferred spacing, leaving `requested_spacing_um` as `None` and causing downstream CLI construction to fail.

## Changes

- Fill null model-derived config leaves after the final default/user/CLI merge.
- Preserve explicit user and CLI values; only still-null leaves are filled.
- Add a regression test for explicit null spacing with model defaults.