### PR TITLE
Expose patch_size on non-timm dense encoders (CONCH, CONCHv15, Hibou, Midnight, MUSK)

### DIFF
--- a/slide2vec/encoders/models/conch.py
+++ b/slide2vec/encoders/models/conch.py
@@ -142,6 +142,13 @@ class CONCH(TileEncoder):
         return 512
 
     @property
+    def patch_size(self) -> tuple[int, int]:
+        # The CONCH vision trunk is a timm ViT-B/16; expose its patch size so the
+        # dense path can resolve the token grid. open_clip builds the trunk without
+        # dynamic_img_size, so dense extraction must use the native 448 window.
+        return _patch_size_from_trunk(self._model.visual.trunk)
+
+    @property
     def device(self) -> torch.device:
         return self._device
 
@@ -203,6 +210,11 @@ class CONCHv15(TileEncoder):
     @property
     def encode_dim(self) -> int:
         return 768
+
+    @property
+    def patch_size(self) -> tuple[int, int]:
+        # CONCHv15's TITAN trunk is a timm ViT; expose its patch size for the dense path.
+        return _patch_size_from_trunk(self._model.trunk)
 
     @property
     def device(self) -> torch.device:

--- a/slide2vec/encoders/models/hibou.py
+++ b/slide2vec/encoders/models/hibou.py
@@ -124,6 +124,12 @@ class _HibouBase(TileEncoder):
         return self._encode_dim
 
     @property
+    def patch_size(self) -> tuple[int, int]:
+        # HF Dinov2-style config carries the patch size; expose it for the dense path.
+        patch = int(self._model.config.patch_size)
+        return patch, patch
+
+    @property
     def device(self) -> torch.device:
         return self._device
 

--- a/slide2vec/encoders/models/midnight.py
+++ b/slide2vec/encoders/models/midnight.py
@@ -125,6 +125,12 @@ class Midnight(TileEncoder):
         return 3072
 
     @property
+    def patch_size(self) -> tuple[int, int]:
+        # HF Dinov2-style config carries the patch size; expose it for the dense path.
+        patch = int(self._model.config.patch_size)
+        return patch, patch
+
+    @property
     def device(self) -> torch.device:
         return self._device
 

--- a/slide2vec/encoders/models/musk.py
+++ b/slide2vec/encoders/models/musk.py
@@ -115,6 +115,11 @@ class MUSK(TileEncoder):
         return 2048 if self._output_variant == "ms_aug" else 1024  # cls
 
     @property
+    def patch_size(self) -> tuple[int, int]:
+        # BEiT3 vision embedding carries the patch size; expose it for the dense path.
+        return _as_hw(self._model.beit3.vision_embed.patch_size)
+
+    @property
     def device(self) -> torch.device:
         return self._device
 


### PR DESCRIPTION
## What

Dense extraction (used by soma's segmentation / detection paths) resolves the token grid from `encoder.patch_size`. Only `TimmTileEncoder` subclasses exposed it; the encoders defined directly on `TileEncoder` — **CONCH, CONCHv15, Hibou, Midnight, MUSK** — fell through to the base `NotImplementedError`, so they couldn't be used for dense extraction even though each implements `encode_tiles_dense`.

## How

Each already computes its patch size inside `encode_tiles_dense`; this lifts that exact expression into a `patch_size` property:

| encoder | source |
|---|---|
| CONCH / CONCHv15 | `_patch_size_from_trunk(self._model.trunk)` (timm ViT trunk) |
| Hibou / Midnight | `self._model.config.patch_size` (HF Dinov2-style config) |
| MUSK | `self._model.beit3.vision_embed.patch_size` |

Purely additive; no behavior change for existing (pooled / attention) paths.