### PR TITLE
Batch tile-level process_list rewrites

### DIFF
--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -148,6 +148,52 @@ def load_model(
     )
 
 
+def _reconcile_embedding_process_list(
+    *,
+    model,
+    preprocessing: PreprocessingConfig,
+    execution: ExecutionOptions,
+    process_list_path,
+    embeddable_slides,
+    output_dir,
+):
+    """Reconcile the process_list with the embeddings on disk once, at end of run.
+
+    The incremental persist callback batches its process_list writes for the tile
+    path, so the trailing partial batch is only persisted by this final full-CSV
+    reconciliation. Every single-GPU embedding entry point must call it after its
+    embed loop. Collecting artifacts from disk (rather than the callback's
+    in-memory list) also covers resume-skipped slides. Returns the collected
+    (tile, hierarchical, slide) artifact lists.
+    """
+    persist_tile_embeddings = embedding.should_persist_tile_embeddings(model, execution)
+    persist_hierarchical_embeddings = hierarchical.is_hierarchical_preprocessing(preprocessing)
+    include_slide_embeddings = model.level == "slide"
+    include_tile_embeddings = persist_tile_embeddings and not persist_hierarchical_embeddings
+    tile_artifacts, hierarchical_artifacts, slide_artifacts = artifacts_collect.collect_pipeline_artifacts(
+        embeddable_slides,
+        output_dir=output_dir,
+        output_format=execution.output_format,
+        include_tile_embeddings=include_tile_embeddings,
+        include_hierarchical_embeddings=persist_hierarchical_embeddings,
+        include_slide_embeddings=include_slide_embeddings,
+    )
+    if process_list_path is not None and Path(process_list_path).is_file():
+        persistence.update_process_list_after_embedding(
+            process_list_path,
+            successful_slides=embeddable_slides,
+            persist_tile_embeddings=persist_tile_embeddings,
+            persist_hierarchical_embeddings=persist_hierarchical_embeddings,
+            include_slide_embeddings=include_slide_embeddings,
+            encoder_name=model.name,
+            output_variant=process_list.resolved_process_list_output_variant(model),
+            tile_artifacts=tile_artifacts,
+            hierarchical_artifacts=hierarchical_artifacts,
+            slide_artifacts=slide_artifacts,
+        )
+    return tile_artifacts, hierarchical_artifacts, slide_artifacts
+
+
 def embed_slides(
     model,
     slides,
@@ -266,6 +312,18 @@ def embed_slides(
                         hierarchical_artifacts=hierarchical_artifacts,
                         slide_artifacts=slide_artifacts,
                     )
+            elif execution.output_dir is not None:
+                # Single-GPU: the incremental callback persisted the embeddings but
+                # batches its process_list writes, so reconcile the full CSV once at
+                # the end (covers the trailing partial batch on a clean run).
+                _reconcile_embedding_process_list(
+                    model=model,
+                    preprocessing=preprocessing,
+                    execution=execution,
+                    process_list_path=process_list_path,
+                    embeddable_slides=embeddable_slides,
+                    output_dir=Path(execution.output_dir),
+                )
             emit_progress(
                 "embedding.finished",
                 slide_count=len(embeddable_slides),
@@ -752,7 +810,6 @@ def run_pipeline(
         persist_tile_embeddings = embedding.should_persist_tile_embeddings(model, execution)
         persist_hierarchical_embeddings = hierarchical.is_hierarchical_preprocessing(resolved_preprocessing)
         include_slide_embeddings = model.level == "slide"
-        include_tile_embeddings = persist_tile_embeddings and not persist_hierarchical_embeddings
         pending_slides, pending_tiling_results = persist_callbacks.pending_local_embedding_records(
             embeddable_slides,
             embeddable_tiling_results,
@@ -790,25 +847,13 @@ def run_pipeline(
                 on_embedded_slide=local_persist_callback,
                 collect_results=False,
             )
-        tile_artifacts, hierarchical_artifacts, slide_artifacts = artifacts_collect.collect_pipeline_artifacts(
-            embeddable_slides,
+        tile_artifacts, hierarchical_artifacts, slide_artifacts = _reconcile_embedding_process_list(
+            model=model,
+            preprocessing=resolved_preprocessing,
+            execution=execution,
+            process_list_path=process_list_path,
+            embeddable_slides=embeddable_slides,
             output_dir=output_dir,
-            output_format=execution.output_format,
-            include_tile_embeddings=include_tile_embeddings,
-            include_hierarchical_embeddings=persist_hierarchical_embeddings,
-            include_slide_embeddings=include_slide_embeddings,
-        )
-        persistence.update_process_list_after_embedding(
-            process_list_path,
-            successful_slides=embeddable_slides,
-            persist_tile_embeddings=persist_tile_embeddings,
-            persist_hierarchical_embeddings=persist_hierarchical_embeddings,
-            include_slide_embeddings=include_slide_embeddings,
-            encoder_name=model.name,
-            output_variant=process_list.resolved_process_list_output_variant(model),
-            tile_artifacts=tile_artifacts,
-            hierarchical_artifacts=hierarchical_artifacts,
-            slide_artifacts=slide_artifacts,
         )
         emit_progress(
             "embedding.finished",
@@ -907,7 +952,7 @@ def run_pipeline_with_coordinates(
                 slide_artifacts=slide_artifacts,
                 process_list_path=process_list_path,
             )
-        local_persist_callback, tile_or_hier_artifacts, slide_artifacts = persist_callbacks.build_incremental_persist_callback(
+        local_persist_callback, _, _ = persist_callbacks.build_incremental_persist_callback(
             model=model,
             preprocessing=resolved_preprocessing,
             execution=execution,
@@ -922,33 +967,18 @@ def run_pipeline_with_coordinates(
             on_embedded_slide=local_persist_callback,
             collect_results=False,
         )
-        tile_artifacts: list[TileEmbeddingArtifact] = []
-        hierarchical_artifacts: list[HierarchicalEmbeddingArtifact] = []
-        for artifact in tile_or_hier_artifacts:
-            if isinstance(artifact, HierarchicalEmbeddingArtifact):
-                hierarchical_artifacts.append(artifact)
-            elif artifact is not None:
-                tile_artifacts.append(artifact)
-        # The incremental callback batches its process_list writes, so reconcile
-        # the full CSV once at the end (covers the final partial batch and writes
-        # O(1) times rather than once per sample).
-        if process_list_path.is_file():
-            persistence.update_process_list_after_embedding(
-                process_list_path,
-                successful_slides=embeddable_slides,
-                persist_tile_embeddings=embedding.should_persist_tile_embeddings(model, execution),
-                persist_hierarchical_embeddings=hierarchical.is_hierarchical_preprocessing(resolved_preprocessing),
-                include_slide_embeddings=model.level == "slide",
-                encoder_name=model.name,
-                output_variant=process_list.resolved_process_list_output_variant(model),
-                tile_artifacts=tile_artifacts,
-                hierarchical_artifacts=hierarchical_artifacts,
-                slide_artifacts=list(slide_artifacts),
-            )
+        tile_artifacts, hierarchical_artifacts, slide_artifacts = _reconcile_embedding_process_list(
+            model=model,
+            preprocessing=resolved_preprocessing,
+            execution=execution,
+            process_list_path=process_list_path,
+            embeddable_slides=embeddable_slides,
+            output_dir=output_dir,
+        )
         return RunResult(
             tile_artifacts=tile_artifacts,
             hierarchical_artifacts=hierarchical_artifacts,
-            slide_artifacts=list(slide_artifacts),
+            slide_artifacts=slide_artifacts,
             process_list_path=process_list_path,
         )
     except Exception as exc:

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -929,6 +929,22 @@ def run_pipeline_with_coordinates(
                 hierarchical_artifacts.append(artifact)
             elif artifact is not None:
                 tile_artifacts.append(artifact)
+        # The incremental callback batches its process_list writes, so reconcile
+        # the full CSV once at the end (covers the final partial batch and writes
+        # O(1) times rather than once per sample).
+        if process_list_path.is_file():
+            persistence.update_process_list_after_embedding(
+                process_list_path,
+                successful_slides=embeddable_slides,
+                persist_tile_embeddings=embedding.should_persist_tile_embeddings(model, execution),
+                persist_hierarchical_embeddings=hierarchical.is_hierarchical_preprocessing(resolved_preprocessing),
+                include_slide_embeddings=model.level == "slide",
+                encoder_name=model.name,
+                output_variant=process_list.resolved_process_list_output_variant(model),
+                tile_artifacts=tile_artifacts,
+                hierarchical_artifacts=hierarchical_artifacts,
+                slide_artifacts=list(slide_artifacts),
+            )
         return RunResult(
             tile_artifacts=tile_artifacts,
             hierarchical_artifacts=hierarchical_artifacts,

--- a/slide2vec/runtime/persist_callbacks.py
+++ b/slide2vec/runtime/persist_callbacks.py
@@ -18,6 +18,16 @@ from slide2vec.runtime.persistence import update_process_list_after_embedding
 from slide2vec.runtime.process_list import resolved_process_list_output_variant
 from slide2vec.utils.tiling_io import load_embedding_process_df
 
+# Number of completed tile-level samples to buffer before rewriting the
+# process_list CSV. Each rewrite re-reads and re-writes the *entire* CSV, so
+# doing it once per sample is O(N^2) in I/O when every tile is its own sample
+# (e.g. patch-level benchmarks with hundreds of thousands of tiles). Batching
+# makes it O(N) while only risking the re-embedding of at most this many cheap
+# tile samples after a crash (a clean run reconciles the full CSV at the end).
+# Slide- and hierarchical-level runs (sample == slide: few, expensive samples)
+# keep a flush interval of 1 so every completed slide is checkpointed.
+TILE_EMBEDDING_FLUSH_INTERVAL = 1000
+
 
 def has_complete_local_embedding_outputs(
     sample_id: str,
@@ -141,6 +151,45 @@ def build_incremental_persist_callback(
     persist_hierarchical_embeddings = is_hierarchical_preprocessing(preprocessing)
     include_slide_embeddings = model.level == "slide"
 
+    # Only the pure tile-level path produces the many-cheap-samples workload that
+    # makes per-sample CSV rewrites O(N^2). When the model aggregates to slide
+    # level (or runs hierarchically) the sample is a slide/region — few and
+    # expensive — so checkpoint every one (interval 1). save_tile_embeddings on a
+    # slide-level model still iterates per slide, hence the include_slide check.
+    is_tile_level = (
+        persist_tile_embeddings
+        and not persist_hierarchical_embeddings
+        and not include_slide_embeddings
+    )
+    flush_interval = TILE_EMBEDDING_FLUSH_INTERVAL if is_tile_level else 1
+
+    # Buffered completions awaiting the next batched process_list rewrite.
+    pending_slides: list[SlideSpec] = []
+    pending_tile_artifacts: list[TileEmbeddingArtifact] = []
+    pending_hierarchical_artifacts: list[HierarchicalEmbeddingArtifact] = []
+    pending_slide_artifacts: list[SlideEmbeddingArtifact] = []
+
+    def _flush_process_list() -> None:
+        if not pending_slides:
+            return
+        if process_list_path is not None and process_list_path.is_file():
+            update_process_list_after_embedding(
+                process_list_path,
+                successful_slides=list(pending_slides),
+                persist_tile_embeddings=persist_tile_embeddings,
+                persist_hierarchical_embeddings=persist_hierarchical_embeddings,
+                include_slide_embeddings=include_slide_embeddings,
+                encoder_name=model.name,
+                output_variant=resolved_process_list_output_variant(model),
+                tile_artifacts=list(pending_tile_artifacts),
+                hierarchical_artifacts=list(pending_hierarchical_artifacts),
+                slide_artifacts=list(pending_slide_artifacts),
+            )
+        pending_slides.clear()
+        pending_tile_artifacts.clear()
+        pending_hierarchical_artifacts.clear()
+        pending_slide_artifacts.clear()
+
     def _persist_completed_slide(slide: SlideSpec, tiling_result, embedded_slide: EmbeddedSlide) -> None:
         tile_artifact, slide_artifact = persist_embedded_slide(
             model,
@@ -153,18 +202,16 @@ def build_incremental_persist_callback(
             tile_artifacts.append(tile_artifact)
         if slide_artifact is not None:
             slide_artifacts.append(slide_artifact)
-        if process_list_path is not None and process_list_path.is_file():
-            update_process_list_after_embedding(
-                process_list_path,
-                successful_slides=[slide],
-                persist_tile_embeddings=persist_tile_embeddings,
-                persist_hierarchical_embeddings=persist_hierarchical_embeddings,
-                include_slide_embeddings=include_slide_embeddings,
-                encoder_name=model.name,
-                output_variant=resolved_process_list_output_variant(model),
-                tile_artifacts=[tile_artifact] if isinstance(tile_artifact, TileEmbeddingArtifact) else [],
-                hierarchical_artifacts=[tile_artifact] if isinstance(tile_artifact, HierarchicalEmbeddingArtifact) else [],
-                slide_artifacts=[slide_artifact] if slide_artifact is not None else [],
-            )
+        # Buffer this completion; a slide with no successful artifact is still
+        # recorded so the batched rewrite can mark its feature_status="error".
+        pending_slides.append(slide)
+        if isinstance(tile_artifact, TileEmbeddingArtifact):
+            pending_tile_artifacts.append(tile_artifact)
+        elif isinstance(tile_artifact, HierarchicalEmbeddingArtifact):
+            pending_hierarchical_artifacts.append(tile_artifact)
+        if slide_artifact is not None:
+            pending_slide_artifacts.append(slide_artifact)
+        if len(pending_slides) >= flush_interval:
+            _flush_process_list()
 
     return _persist_completed_slide, tile_artifacts, slide_artifacts

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1578,6 +1578,68 @@ def test_run_pipeline_local_persists_completed_embeddings_before_later_slide_fai
     assert recorded.loc["slide-b", "aggregation_status"] == "tbp"
 
 
+def _drive_persist_callback(monkeypatch, tmp_path, *, model_level, num_samples):
+    """Build an incremental persist callback and feed it `num_samples` completions.
+
+    Returns the list of per-write batch sizes recorded by a stubbed
+    ``update_process_list_after_embedding`` (i.e. how the process_list rewrites
+    were grouped).
+    """
+    process_list_path = tmp_path / "process_list.csv"
+    process_list_path.write_text("sample_id\n", encoding="utf-8")
+
+    monkeypatch.setattr(persist_callbacks, "should_persist_tile_embeddings", lambda *a, **k: True)
+    monkeypatch.setattr(persist_callbacks, "is_hierarchical_preprocessing", lambda *a, **k: False)
+    monkeypatch.setattr(persist_callbacks, "resolved_process_list_output_variant", lambda *a, **k: None)
+    monkeypatch.setattr(persist_callbacks, "TILE_EMBEDDING_FLUSH_INTERVAL", 3)
+
+    def fake_persist_embedded_slide(model, embedded_slide, tiling_result, *, preprocessing, execution):
+        artifact = persist_callbacks.TileEmbeddingArtifact(
+            sample_id=embedded_slide.sample_id,
+            path=tmp_path / f"{embedded_slide.sample_id}.pt",
+            metadata_path=tmp_path / f"{embedded_slide.sample_id}.meta.json",
+            format="pt",
+            feature_dim=4,
+            num_tiles=2,
+        )
+        return artifact, None
+
+    monkeypatch.setattr(persist_callbacks, "persist_embedded_slide", fake_persist_embedded_slide)
+
+    batch_sizes: list[int] = []
+    monkeypatch.setattr(
+        persist_callbacks,
+        "update_process_list_after_embedding",
+        lambda *a, **k: batch_sizes.append(len(k["successful_slides"])),
+    )
+
+    model = SimpleNamespace(name="enc", level=model_level)
+    callback, _, _ = persist_callbacks.build_incremental_persist_callback(
+        model=model,
+        preprocessing=SimpleNamespace(),
+        execution=SimpleNamespace(output_dir=tmp_path),
+        process_list_path=process_list_path,
+    )
+    for i in range(num_samples):
+        callback(make_slide(f"s-{i}"), SimpleNamespace(), SimpleNamespace(sample_id=f"s-{i}"))
+    return batch_sizes
+
+
+def test_incremental_persist_callback_batches_tile_level_process_list_writes(monkeypatch, tmp_path: Path):
+    # Tile-level (many cheap samples): writes are batched at the flush interval,
+    # and the trailing partial batch is left for the caller's final reconciliation
+    # (so 7 completions at interval 3 -> two writes of 3, one sample still buffered).
+    batch_sizes = _drive_persist_callback(monkeypatch, tmp_path, model_level="tile", num_samples=7)
+    assert batch_sizes == [3, 3]
+
+
+def test_incremental_persist_callback_checkpoints_slide_level_every_sample(monkeypatch, tmp_path: Path):
+    # Slide-level (few expensive samples): every completion is checkpointed
+    # immediately so a crash never loses an expensive slide embedding.
+    batch_sizes = _drive_persist_callback(monkeypatch, tmp_path, model_level="slide", num_samples=4)
+    assert batch_sizes == [1, 1, 1, 1]
+
+
 def test_tile_slides_forwards_spacing_at_level_0_to_hs2p(monkeypatch, tmp_path: Path):
     import slide2vec.inference as inference
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -2594,6 +2594,71 @@ def test_direct_embed_slides_persists_completed_embeddings_before_later_slide_fa
     assert recorded.loc["slide-b", "feature_status"] == "tbp"
     assert recorded.loc["slide-b", "aggregation_status"] == "tbp"
 
+
+def test_direct_embed_slides_single_gpu_reconciles_batched_tile_status_on_clean_run(monkeypatch, tmp_path: Path):
+    # Tile-level single-GPU run with fewer slides than TILE_EMBEDDING_FLUSH_INTERVAL:
+    # the incremental callback buffers every completion and never flushes mid-run,
+    # so feature_status is written only by the end-of-run reconciliation. Without
+    # it, a clean run would leave these rows as "tbp" despite the .pt files existing.
+    pytest.importorskip("torch")
+    import slide2vec.inference as inference
+
+    slides = [make_slide("slide-a"), make_slide("slide-b")]
+    tiling_results = [
+        SimpleNamespace(
+            x=np.array([0, 1]),
+            y=np.array([2, 3]),
+            tile_size_lv0=224,
+            coordinates_npz_path=Path("/tmp/slide-a.coordinates.npz"),
+            coordinates_meta_path=Path("/tmp/slide-a.coordinates.meta.json"),
+        ),
+        SimpleNamespace(
+            x=np.array([4, 5]),
+            y=np.array([6, 7]),
+            tile_size_lv0=224,
+            coordinates_npz_path=Path("/tmp/slide-b.coordinates.npz"),
+            coordinates_meta_path=Path("/tmp/slide-b.coordinates.meta.json"),
+        ),
+    ]
+    process_list_path = tmp_path / "process_list.csv"
+    process_list_path.write_text(
+        "sample_id,annotation,image_path,mask_path,spacing_at_level_0,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
+        "slide-a,tissue,/tmp/slide-a.svs,,,"
+        "success,2,/tmp/slide-a.coordinates.npz,/tmp/slide-a.coordinates.meta.json,,\n"
+        "slide-b,tissue,/tmp/slide-b.svs,,,"
+        "success,2,/tmp/slide-b.coordinates.npz,/tmp/slide-b.coordinates.meta.json,,\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(tiling_pipeline, "prepare_tiled_slides",
+        lambda slide_records, preprocessing, output_dir, num_workers: (slides, tiling_results, process_list_path),
+    )
+    # Clean run: every slide embeds successfully.
+    monkeypatch.setattr(embedding_pipeline, "compute_tile_embeddings_for_slide",
+        lambda *args, **kwargs: np.zeros((2, 4), dtype=np.float32),
+    )
+
+    model = SimpleNamespace(
+        name="uni2",
+        level="tile",
+        _requested_device="cpu",
+        _load_backend=lambda: SimpleNamespace(),
+    )
+
+    inference.embed_slides(
+        model,
+        slides,
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=ExecutionOptions(output_dir=tmp_path, save_tile_embeddings=True, num_gpus=1),
+    )
+
+    assert (tmp_path / "tile_embeddings" / "slide-a.pt").is_file()
+    assert (tmp_path / "tile_embeddings" / "slide-b.pt").is_file()
+    recorded = pd.read_csv(process_list_path).set_index("sample_id")
+    assert recorded.loc["slide-a", "feature_status"] == "success"
+    assert recorded.loc["slide-b", "feature_status"] == "success"
+
+
 def test_slide_level_pipeline_skips_tile_artifacts_when_save_tile_embeddings_is_false(monkeypatch, tmp_path: Path):
     import slide2vec.inference as inference
 


### PR DESCRIPTION
## Problem

The incremental embedding persist callback (`runtime/persist_callbacks.py`) rewrote the **entire** `process_list` CSV once per completed sample. At slide counts (dozens–hundreds of WSIs) this is invisible, but in the **tile path every tile is its own sample**, so embedding N=100k+ tiles re-read and re-wrote the whole CSV N times — **O(N²) I/O with a full-table DataFrame allocated and freed per tile**. That dominated runtime and memory and compounded the OOM-kills seen extracting large patch datasets (e.g. PatchCamelyon, 327k tiles).

## Fix

- Buffer completed **tile-level** samples and rewrite the `process_list` once per `TILE_EMBEDDING_FLUSH_INTERVAL` (1000), relying on the existing end-of-run full-CSV reconciliation for the authoritative final state. Net: **O(N)**; on a crash at most one buffered batch of cheap tile samples is re-embedded.
- **Slide-/hierarchical-level** runs (few, expensive samples) keep a flush interval of **1**, so every sample is still checkpointed individually — no loss of crash granularity where it matters.
- Add the missing end-of-run reconciliation to the `run_with_coordinates` path, which previously relied entirely on the per-sample writes (and so would have dropped the trailing batch under batching).