### PR TITLE
Dense grid extraction over slide regions at coordinates

### DIFF
--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -1,0 +1,229 @@
+"""Dense ``(d, h, w)`` grid extraction over **slide regions at coordinates**.
+
+The dense counterpart of the pooled coordinate path (``compute_tile_embeddings_for_slide``
+→ ``run_forward_pass`` → ``encode_tiles``): instead of pooling each region to one vector,
+each sampled ROI is read **spacing-aware** from the slide, run through the encoder's
+normalization-only dense transform (``get_dense_transform`` — NOT the pooled transform,
+which crops), padded up to the encoder's patch multiple, and encoded via
+``encode_tiles_dense`` into a ``(d, grid_h, grid_w)`` token grid.
+
+This is the extraction half of soma's slide-manifest segmentation path: slide2vec reads
+regions + encodes (it already owns the region reader and the dense encode); soma sources
+the ROI coordinates (hs2p annotation sampling) and persists/caches the grids. It mirrors
+the pooled split exactly — extraction here, caching in soma.
+
+Region reads are spacing-aware via hs2p (:meth:`hs2p.wsi.wsi.WSI.read_region_at_spacing`):
+the finest pyramid level ``<=`` the requested µm/px is read and downscaled to the exact
+``target_size`` (``area`` for images), so the token grid registers against a mask read at
+the same spacing. The ``wsi`` is injected (any object exposing ``read_region_at_spacing``),
+so the loop is unit-testable offline with a fake reader + a random-weight encoder.
+
+Whole-tile only (one padded forward per region). Sliding-window dense extraction over
+coordinates (``window_size`` < input) is a deferred follow-up — large ROIs that exceed the
+encoder's comfortable field are out of scope for the first increment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
+from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
+
+_PAD_MODES = {"reflect", "constant", "zero", "replicate"}
+
+
+def _normalize_hw(value: int | tuple[int, int], *, name: str) -> tuple[int, int]:
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError(f"{name} must be positive, got {value}")
+        return value, value
+    try:
+        h, w = value
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an int or an (h, w) pair, got {value!r}") from exc
+    h, w = int(h), int(w)
+    if h <= 0 or w <= 0:
+        raise ValueError(f"{name} must be positive, got {(h, w)}")
+    return h, w
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+@dataclass(frozen=True)
+class DenseGridGeometry:
+    """Resolved spatial layout for one dense extraction (slide2vec-owned).
+
+    ``target_size`` is the supervision tile size (h, w); ``encoded_size`` is that rounded
+    up to the patch multiple (pad on bottom/right); ``grid_shape`` is the resulting token
+    grid (grid_h, grid_w). Mirrors soma's ``DenseGridGeometry`` — the dense-grid geometry
+    is extraction geometry and belongs in the extraction engine; soma reads it back from
+    the persisted sidecar.
+    """
+
+    target_size: tuple[int, int]
+    patch_size: tuple[int, int]
+    encoded_size: tuple[int, int]
+    grid_shape: tuple[int, int]
+    pad: tuple[int, int]  # (pad_bottom, pad_right)
+
+
+def compute_dense_geometry(
+    *, target_size: int | tuple[int, int], patch_size: int | tuple[int, int]
+) -> DenseGridGeometry:
+    """Encoded size, token grid, and bottom/right padding for a ``target_size`` tile."""
+    target_h, target_w = _normalize_hw(target_size, name="target_size")
+    patch_h, patch_w = _normalize_hw(patch_size, name="patch_size")
+    encoded_h = _round_up(target_h, patch_h)
+    encoded_w = _round_up(target_w, patch_w)
+    return DenseGridGeometry(
+        target_size=(target_h, target_w),
+        patch_size=(patch_h, patch_w),
+        encoded_size=(encoded_h, encoded_w),
+        grid_shape=(encoded_h // patch_h, encoded_w // patch_w),
+        pad=(encoded_h - target_h, encoded_w - target_w),
+    )
+
+
+def pad_image_to_encoded(
+    tensor: torch.Tensor,
+    geometry: DenseGridGeometry,
+    *,
+    pad_mode: str,
+    image_pad_value: float | None,
+) -> torch.Tensor:
+    """Pad a ``(C, H, W)`` tile (bottom/right) up to ``geometry.encoded_size``."""
+    pad_bottom, pad_right = geometry.pad
+    if pad_bottom == 0 and pad_right == 0:
+        return tensor
+    x = tensor.unsqueeze(0)  # F.pad's 2-D modes need a batch dim
+    pad = (0, pad_right, 0, pad_bottom)  # (left, right, top, bottom)
+    if pad_mode in ("constant", "zero"):
+        x = F.pad(x, pad, mode="constant", value=float(image_pad_value or 0.0))
+    else:
+        x = F.pad(x, pad, mode=pad_mode)
+    return x.squeeze(0)
+
+
+def _resolve_encode_fn(
+    model,
+    *,
+    feature_kind: str,
+    attention_blocks: tuple[int, ...],
+    attention_include_registers: bool,
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    if feature_kind == "patch_features":
+        return model.encode_tiles_dense
+    if feature_kind == "cls_attention":
+        blocks = tuple(int(b) for b in attention_blocks)
+        include_registers = bool(attention_include_registers)
+
+        def encode_fn(window: torch.Tensor) -> torch.Tensor:
+            return model.encode_tiles_attention(
+                window, blocks=blocks, include_registers=include_registers
+            )
+
+        return encode_fn
+    raise ValueError(
+        f"unsupported feature_kind {feature_kind!r}; expected 'patch_features' or 'cls_attention'"
+    )
+
+
+def encode_regions_dense(
+    *,
+    model,
+    device: torch.device | str,
+    wsi,
+    coordinates: Sequence[tuple[int, int]],
+    requested_spacing_um: float,
+    target_size: int | tuple[int, int],
+    tolerance: float = 0.05,
+    pad_mode: str = "reflect",
+    image_pad_value: float | None = None,
+    feature_kind: str = "patch_features",
+    attention_blocks: tuple[int, ...] = (-1,),
+    attention_include_registers: bool = False,
+    batch_size: int = 1,
+    precision: str = "fp32",
+    dense_transform: Callable | None = None,
+) -> np.ndarray:
+    """Encode slide regions at ``coordinates`` into dense grids; return ``(N, d, gh, gw)``.
+
+    Injectable core: takes a constructed dense-capable ``model`` (with
+    ``encode_tiles_dense`` / ``encode_tiles_attention`` / ``patch_size`` /
+    ``get_dense_transform``) and a ``wsi`` exposing
+    ``read_region_at_spacing(location, requested_spacing_um, size, *, tolerance,
+    interpolation)``, so it runs offline in tests with random weights + a fake reader.
+
+    Args:
+        coordinates: ``(x, y)`` top-left locations in **level-0** pixel space (the hs2p
+            tiling convention; passed straight to ``read_region_at_spacing``).
+        requested_spacing_um: µm/px to read each region at.
+        target_size: supervision tile size (int or ``(h, w)``); the region is read at this
+            size at ``requested_spacing_um`` and the token grid registers to it.
+
+    Returns a ``float32`` array of dense grids in coordinate order. ``feature_kind``
+    selects ``encode_tiles_dense`` (patch grid) vs ``encode_tiles_attention`` (CLS-attention
+    grid); both produce a ``(C, gh, gw)`` grid and share this path.
+    """
+    if pad_mode not in _PAD_MODES:
+        raise ValueError(f"unsupported pad_mode {pad_mode!r}; expected one of {sorted(_PAD_MODES)}")
+    geometry = compute_dense_geometry(target_size=target_size, patch_size=model.patch_size)
+    if dense_transform is None:
+        dense_transform = model.get_dense_transform()
+    encode_fn = _resolve_encode_fn(
+        model,
+        feature_kind=feature_kind,
+        attention_blocks=attention_blocks,
+        attention_include_registers=attention_include_registers,
+    )
+    target_h, target_w = geometry.target_size
+
+    coords = [(int(x), int(y)) for x, y in coordinates]
+    grid_h, grid_w = geometry.grid_shape
+    if not coords:
+        return np.empty((0, 0, grid_h, grid_w), dtype=np.float32)
+
+    def _read_padded(location: tuple[int, int]) -> torch.Tensor:
+        region = wsi.read_region_at_spacing(
+            location,
+            float(requested_spacing_um),
+            (target_w, target_h),  # hs2p size is (width, height)
+            tolerance=float(tolerance),
+            interpolation="area",
+        )
+        region = np.ascontiguousarray(np.asarray(region)[..., :3])
+        tensor = torch.as_tensor(dense_transform(Image.fromarray(region))).as_subclass(torch.Tensor)
+        if tensor.ndim != 3:
+            raise ValueError(
+                f"dense transform at {location} produced a {tensor.ndim}-D tensor; expected (C, H, W)."
+            )
+        if tuple(int(s) for s in tensor.shape[-2:]) != (target_h, target_w):
+            raise ValueError(
+                f"region at {location} is {tuple(int(s) for s in tensor.shape[-2:])} after the dense "
+                f"transform, but target_size is {(target_h, target_w)}. The dense transform must be "
+                "normalization-only (no resize/crop)."
+            )
+        return pad_image_to_encoded(
+            tensor, geometry, pad_mode=pad_mode, image_pad_value=image_pad_value
+        )
+
+    grids: list[np.ndarray] = []
+    with torch.inference_mode(), slide_encode_autocast_ctx(device, precision):
+        for start in range(0, len(coords), max(1, int(batch_size))):
+            chunk = coords[start : start + max(1, int(batch_size))]
+            batch = torch.stack([_read_padded(loc) for loc in chunk]).to(device, non_blocking=True)
+            out = encode_fn(batch)
+            if out.ndim != 4:
+                raise ValueError(
+                    f"{feature_kind} encode returned a {out.ndim}-D tensor; expected (B, d, gh, gw)."
+                )
+            grids.append(out.detach().float().cpu().numpy())
+    return np.concatenate(grids, axis=0)

--- a/tests/test_dense_regions.py
+++ b/tests/test_dense_regions.py
@@ -1,0 +1,117 @@
+"""Tests for dense grid extraction over slide regions: ``encode_regions_dense``.
+
+Fully offline (``pretrained=False`` random weights) + an injected fake reader, so no
+weights, no real WSI. Checks (1) grid shapes over a batch of coordinates and (2) that the
+orchestration is a faithful wrapper — its per-region grid is byte-identical to a direct
+``encode_tiles_dense(transform → pad)`` of the same region.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime.dense_regions import (  # noqa: E402
+    compute_dense_geometry,
+    encode_regions_dense,
+    pad_image_to_encoded,
+)
+
+
+def _encoder(**kwargs) -> TimmTileEncoder:
+    return TimmTileEncoder("vit_tiny_patch16_224", pretrained=False, num_classes=0,
+                           dynamic_img_size=True, **kwargs)
+
+
+class _FakeWSI:
+    """Returns a deterministic RGB region per location (so reads are reproducible)."""
+
+    def __init__(self, *, target_h: int, target_w: int):
+        self._target_h = target_h
+        self._target_w = target_w
+        self.calls: list[tuple] = []
+
+    def read_region_at_spacing(self, location, requested_spacing_um, size, *, tolerance, interpolation):
+        self.calls.append((tuple(location), requested_spacing_um, tuple(size), tolerance, interpolation))
+        width, height = size
+        x, y = location
+        rng = np.random.default_rng(abs(hash((int(x), int(y)))) % (2**32))
+        return rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+
+
+def test_encode_regions_dense_shapes_over_coordinates():
+    enc = _encoder()
+    target_size = 64  # patch 16 -> grid 4x4, no padding
+    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    coords = [(0, 0), (64, 0), (0, 64)]
+
+    grids = encode_regions_dense(
+        model=enc,
+        device="cpu",
+        wsi=wsi,
+        coordinates=coords,
+        requested_spacing_um=0.5,
+        target_size=target_size,
+        batch_size=2,
+    )
+
+    assert grids.shape == (3, enc.encode_dim, 4, 4)
+    assert grids.dtype == np.float32
+    # Reads went through read_region_at_spacing at (target_w, target_h), area interp, level-0 coords.
+    assert [c[0] for c in wsi.calls] == [(0, 0), (64, 0), (0, 64)]
+    assert all(c[2] == (target_size, target_size) and c[4] == "area" for c in wsi.calls)
+
+
+def test_encode_regions_dense_pads_non_multiple_target():
+    enc = _encoder()
+    target_size = 60  # padded up to 64 -> grid 4x4
+    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    grids = encode_regions_dense(
+        model=enc, device="cpu", wsi=wsi, coordinates=[(0, 0)],
+        requested_spacing_um=0.5, target_size=target_size,
+    )
+    assert grids.shape == (1, enc.encode_dim, 4, 4)
+
+
+def test_encode_regions_dense_matches_direct_encode():
+    """The primitive is a faithful wrapper: parity vs a hand-rolled transform+pad+encode."""
+    enc = _encoder()
+    target_size = 64
+    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    coords = [(0, 0), (128, 256)]
+
+    grids = encode_regions_dense(
+        model=enc, device="cpu", wsi=wsi, coordinates=coords,
+        requested_spacing_um=0.5, target_size=target_size,
+    )
+
+    # Re-read the same regions (deterministic) and encode them directly.
+    from PIL import Image
+
+    geometry = compute_dense_geometry(target_size=target_size, patch_size=enc.patch_size)
+    transform = enc.get_dense_transform()
+    ref_wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    with torch.inference_mode():
+        for i, loc in enumerate(coords):
+            region = ref_wsi.read_region_at_spacing(
+                loc, 0.5, (target_size, target_size), tolerance=0.05, interpolation="area"
+            )
+            tensor = torch.as_tensor(transform(Image.fromarray(region))).as_subclass(torch.Tensor)
+            padded = pad_image_to_encoded(tensor, geometry, pad_mode="reflect", image_pad_value=None)
+            ref = enc.encode_tiles_dense(padded.unsqueeze(0)).detach().float().cpu().numpy()[0]
+            np.testing.assert_allclose(grids[i], ref, rtol=0, atol=1e-6)
+
+
+def test_encode_regions_dense_empty_coordinates():
+    enc = _encoder()
+    wsi = _FakeWSI(target_h=64, target_w=64)
+    grids = encode_regions_dense(
+        model=enc, device="cpu", wsi=wsi, coordinates=[],
+        requested_spacing_um=0.5, target_size=64,
+    )
+    assert grids.shape == (0, 0, 4, 4)
+    assert wsi.calls == []


### PR DESCRIPTION
## What

Adds `runtime/dense_regions.py::encode_regions_dense` — the **dense counterpart of the pooled coordinate path** (`compute_tile_embeddings_for_slide` → `run_forward_pass` → `encode_tiles`). Instead of pooling each sampled region to a single vector, it:

1. reads each ROI **spacing-aware** from the slide via hs2p `WSI.read_region_at_spacing` (finest level ≤ requested µm/px, downscaled with `area` to the exact target size),
2. applies the encoder's **normalization-only** dense transform (`get_dense_transform`, not the pooled transform which crops),
3. pads up to the encoder's patch multiple (bottom/right),
4. encodes via `encode_tiles_dense` (patch grid) or `encode_tiles_attention` (CLS-attention grid) into a `(d, gh, gw)` token grid,

returning `(N, d, gh, gw)` in coordinate order.

## Why

This is the **extraction half** of soma's slide-manifest segmentation path. slide2vec already owns the region reader *and* the dense encode, so dense-over-coordinates extraction belongs here, mirroring the pooled split exactly: slide2vec reads + encodes, soma sources the ROI coordinates (hs2p annotation sampling) and persists/caches the grids.

## Scope

- **Whole-tile only** — one padded forward per region. Sliding-window dense extraction over coordinates (`window_size` < input) is a deferred follow-up.
- Uses only **already-released** hs2p 4.1.0 (`read_region_at_spacing`) and slide2vec 4.6.4 (`encode_tiles_dense`, `get_dense_transform`, `slide_encode_autocast_ctx`) APIs — no changes to either layer.

## Tests

`tests/test_dense_regions.py` (4 tests, offline): the `model` and `wsi` are injectable, so the loop runs with a random-weight `vit_tiny` encoder + a fake reader — shapes over coords, padding on a non-multiple target, parity vs a direct `encode_tiles_dense(transform+pad)`, and the empty-coords case.