### PR TITLE
ci: skip test suite for release-* bump PRs

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -13,8 +13,8 @@ jobs:
       contents: read
       actions: write  # needed for Buildx GHA cache
 
-    # don't run secret-using job on forked PRs
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # don't run on forked PRs (no secrets) or release-* bump PRs (version-only change)
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !startsWith(github.head_ref, 'release-') }}
 
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}


### PR DESCRIPTION
## What

Skip the `docker-test` job when the PR head branch starts with `release-`.

`release.py` opens the version bump as a PR from a `release-<version>` branch that only edits `pyproject.toml`. Running the full Docker build + test suite (60-min job) on a version-string-only change is costly and adds no signal.

## How

Extends the existing job-level `if` (the fork guard) with `&& !startsWith(github.head_ref, 'release-')`.

- `github.head_ref` is populated only for `pull_request` events; it's empty for `workflow_dispatch`, so **manual runs still fire**.
- A job skipped via `if` reports as *skipped*, which counts as success for branch protection — it won't block the bump PR from merging.

Targeted, reversible, no behavior change for normal feature PRs.