### PR TITLE
ci: skip docs build for release-* bump PRs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,6 +20,8 @@ jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
+    # skip docs build for release-* bump PRs (version-only change)
+    if: ${{ !startsWith(github.head_ref, 'release-') }}
     timeout-minutes: 60
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## What

Follow-up to #150 (which skipped the test suite on `release-*` bump PRs): do the same for the `Build docs` job in `docs.yaml`.

`release.py`'s version-bump PR (head branch `release-<version>`) only edits `pyproject.toml`, so building the docs adds no signal.

## How

Adds a job-level `if: ${{ !startsWith(github.head_ref, 'release-') }}` to the docs `build` job. `github.head_ref` is empty for `push` and `workflow_dispatch`, so the docs deploy on `push: main` and manual runs still fire. A skipped job counts as success for branch protection.