### PR TITLE
Add masks config block and unified tissue knob (#154)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -230,7 +230,7 @@ outputs:
        preprocessing=PreprocessingConfig(
            requested_spacing_um=0.5,
            requested_tile_size_px=224,
-           tissue_threshold=0.1,
+           masks={"min_coverage": {"tissue": 0.1}},
        ),
        execution=ExecutionOptions(output_dir="outputs/demo", num_gpus=2),
    )

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -75,7 +75,7 @@ Pass :class:`~slide2vec.PreprocessingConfig` to override tiling defaults:
    preprocessing = PreprocessingConfig(
        requested_spacing_um=0.5,
        requested_tile_size_px=224,
-       tissue_threshold=0.1,
+       masks={"min_coverage": {"tissue": 0.1}},
        backend="auto",
        segmentation={"method": "hsv"},
    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.0.8",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.1.1",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -88,7 +88,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.0.8",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.1.1",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/scripts/benchmark_embedding_throughput.py
+++ b/scripts/benchmark_embedding_throughput.py
@@ -791,7 +791,7 @@ def _build_model_pipeline_from_config(config: dict[str, Any]):
         requested_tile_size_px=int(params.get("requested_tile_size_px", 224)),
         tolerance=float(params.get("tolerance", 0.05)),
         overlap=float(params.get("overlap", 0.0)),
-        tissue_threshold=float(params.get("tissue_threshold", 0.01)),
+        masks={"min_coverage": {"tissue": float(params.get("tissue_threshold", 0.01))}},
         drop_holes=bool(params.get("drop_holes", False)),
         use_padding=bool(params.get("use_padding", True)),
         read_coordinates_from=(

--- a/scripts/benchmark_end_to_end_paths.py
+++ b/scripts/benchmark_end_to_end_paths.py
@@ -444,7 +444,7 @@ def _build_pipeline_from_config_dict(config: dict[str, Any]):
         requested_tile_size_px=int(params.get("requested_tile_size_px", 256)),
         tolerance=float(params.get("tolerance", 0.05)),
         overlap=float(params.get("overlap", 0.0)),
-        tissue_threshold=float(params.get("tissue_threshold", 0.01)),
+        masks={"min_coverage": {"tissue": float(params.get("tissue_threshold", 0.01))}},
         drop_holes=bool(params.get("drop_holes", False)),
         use_padding=bool(params.get("use_padding", True)),
         read_coordinates_from=None,

--- a/scripts/benchmark_tile_read_strategies.py
+++ b/scripts/benchmark_tile_read_strategies.py
@@ -514,7 +514,7 @@ def _build_pipeline_from_config_dict(config: dict[str, Any]):
         requested_tile_size_px=int(params.get("requested_tile_size_px", 256)),
         tolerance=float(params.get("tolerance", 0.05)),
         overlap=float(params.get("overlap", 0.0)),
-        tissue_threshold=float(params.get("tissue_threshold", 0.01)),
+        masks={"min_coverage": {"tissue": float(params.get("tissue_threshold", 0.01))}},
         drop_holes=bool(params.get("drop_holes", False)),
         use_padding=bool(params.get("use_padding", True)),
         read_coordinates_from=(

--- a/scripts/generate_gt.py
+++ b/scripts/generate_gt.py
@@ -31,9 +31,15 @@ TILING_PARAMS = dict(
     tolerance=0.07,
     requested_tile_size_px=224,
     overlap=0.0,
-    tissue_threshold=0.1,
     drop_holes=False,
     use_padding=True,
+)
+# min_coverage.tissue is the sole tissue threshold (was tissue_threshold=0.1)
+TILING_MASKS = dict(
+    output_mode="per_annotation",
+    pixel_mapping={"background": 0, "tissue": 1},
+    colors={"background": None, "tissue": [157, 219, 129]},
+    min_coverage={"background": None, "tissue": 0.1},
 )
 TILING_SEG_PARAMS = dict(
     downsample=64,
@@ -111,6 +117,8 @@ def main():
                 "read_tiles_from": None,
                 "on_the_fly": True,
                 "backend": "asap",
+                "independent_sampling": True,
+                "masks": TILING_MASKS,
                 "params": TILING_PARAMS,
                 "seg_params": TILING_SEG_PARAMS,
                 "filter_params": TILING_FILTER_PARAMS,

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -1,4 +1,5 @@
 
+import copy
 import logging
 import os
 from dataclasses import dataclass, field, replace
@@ -40,6 +41,55 @@ SlideSequence = Sequence[SlideInput]
 TilingResultsInput = Sequence[Any] | Mapping[str, Any]
 
 
+#: Default annotation-mask vocabulary — plain binary tissue tiling. Mirrors hs2p's
+#: shipped default ``{background: 0, tissue: 1}``; leaving it untouched keeps a run
+#: behaving exactly as a tissue-only run. ``min_coverage.tissue`` is the single source
+#: of truth for the tissue threshold (the standalone ``tissue_threshold`` knob is gone).
+#: A :class:`PreprocessingConfig` ``masks`` value is deep-merged over this default, so
+#: callers only state what they override (e.g. ``{"min_coverage": {"tissue": 0.1}}``).
+DEFAULT_MASKS: dict[str, Any] = {
+    "output_mode": "per_annotation",
+    "pixel_mapping": {"background": 0, "tissue": 1},
+    "colors": {"background": None, "tissue": [157, 219, 129]},
+    "min_coverage": {"background": None, "tissue": 0.01},
+}
+
+
+def _deep_merge_masks(base: Mapping[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:
+    """Deep-merge *override* onto a copy of *base* (nested dicts merge key-by-key)."""
+    merged = copy.deepcopy(dict(base))
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(value, Mapping) and isinstance(existing, dict):
+            merged[key] = _deep_merge_masks(existing, value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def resolve_masks(masks: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Complete a (possibly partial) ``masks`` mapping by merging it over :data:`DEFAULT_MASKS`."""
+    if not masks:
+        return copy.deepcopy(DEFAULT_MASKS)
+    return _deep_merge_masks(DEFAULT_MASKS, masks)
+
+
+def _masks_to_plain_dict(node: Any) -> dict[str, Any]:
+    """Normalize a masks config node (OmegaConf, mapping, or namespace) to a plain dict."""
+    if node is None:
+        return {}
+    try:
+        from omegaconf import OmegaConf
+
+        if OmegaConf.is_config(node):
+            return copy.deepcopy(OmegaConf.to_container(node, resolve=True))  # type: ignore[return-value]
+    except ImportError:
+        pass
+    if isinstance(node, Mapping):
+        return copy.deepcopy(dict(node))
+    return copy.deepcopy(dict(vars(node)))
+
+
 @dataclass(frozen=True, kw_only=True)
 class PreprocessingConfig:
     """Configuration for slide tiling and preprocessing."""
@@ -62,8 +112,6 @@ class PreprocessingConfig:
     tolerance: float = 0.05
     #: Fractional tile overlap (``0.0`` = no overlap).
     overlap: float = 0.0
-    #: Minimum tissue fraction required to keep a tile (default ``0.01``).
-    tissue_threshold: float = 0.01
     #: Directory containing pre-extracted tile coordinates to reuse, skipping tiling.
     read_coordinates_from: Path | None = None
     #: Directory containing pre-extracted tile images to skip the tiling step entirely.
@@ -90,6 +138,20 @@ class PreprocessingConfig:
     #: Controls whether hs2p writes mask and tiling preview images.
     #: Keys: ``save_mask_preview``, ``save_tiling_preview``, ``downsample``.
     preview: dict[str, Any] = field(default_factory=dict)
+    #: Annotation-mask vocabulary forwarded to hs2p's sampling resolver. Keys:
+    #: ``output_mode``, ``pixel_mapping``, ``colors``, ``min_coverage``. A partial
+    #: mapping is deep-merged over :data:`DEFAULT_MASKS`, so callers only state what
+    #: they override (e.g. ``{"min_coverage": {"tissue": 0.1}}``). The default
+    #: ``{background, tissue}`` block is plain tissue tiling; ``min_coverage.tissue``
+    #: is the single source of truth for the tissue threshold.
+    masks: dict[str, Any] = field(default_factory=dict)
+    #: When annotation sampling is active, tile each class independently (``True``)
+    #: vs jointly across classes (``False``).
+    independent_sampling: bool = True
+
+    def __post_init__(self) -> None:
+        # Complete a (possibly partial) masks mapping against the shipped default.
+        object.__setattr__(self, "masks", resolve_masks(self.masks))
 
     @classmethod
     def from_config(cls, cfg: Any) -> "PreprocessingConfig":
@@ -121,7 +183,8 @@ class PreprocessingConfig:
             region_tile_multiple=int(region_tile_multiple) if region_tile_multiple is not None else None,
             tolerance=float(tiling.params.tolerance),
             overlap=float(tiling.params.overlap),
-            tissue_threshold=float(tiling.params.tissue_threshold),
+            masks=_masks_to_plain_dict(getattr(tiling, "masks", None)),
+            independent_sampling=bool(getattr(tiling, "independent_sampling", True)),
             read_coordinates_from=Path(read_coordinates_from) if read_coordinates_from else None,
             read_tiles_from=(
                 Path(read_tiles_from) if read_tiles_from else None

--- a/slide2vec/configs/default.yaml
+++ b/slide2vec/configs/default.yaml
@@ -26,6 +26,24 @@ tiling:
   read_coordinates_from: # path to an existing directory containing pre-extracted `.coordinates.npz` / `.coordinates.meta.json` artifacts to reuse instead of starting tiling from scratch
   read_tiles_from: # path to an existing directory containing pre-extracted `.tiles.tar` tile stores to reuse instead of starting tiling from scratch
   backend: "auto" # backend to use for slide reading; "auto" lets hs2p resolve the best backend per slide, preferring cuCIM when available
+  independent_sampling: true # when annotation sampling is active, tile each class separately (independent selection) vs jointly across classes
+  masks:
+    # Annotation-mask vocabulary forwarded to hs2p's sampling resolver. The shipped default
+    # ({background:0, tissue:1}) is plain binary tissue tiling — leave it untouched and the run
+    # behaves exactly as a tissue-only run. Customising the vocabulary (e.g. adding a `tumor`
+    # class with its own pixel value + min_coverage) opts the run into annotation-aware sampling,
+    # where `mask_path` is read as a multi-label raster. The `tissue` min_coverage entry below is
+    # the single source of truth for the tissue threshold.
+    output_mode: per_annotation # per_annotation: one artifact set per sampled class | merged: one set per slide (union of tiles passing any class threshold)
+    pixel_mapping: # {class_name: integer pixel value in the mask raster}
+      background: 0
+      tissue: 1
+    colors: # {class_name: [r, g, b] | null} used when rendering previews
+      background:
+      tissue: [157, 219, 129]
+    min_coverage: # {class_name: float | null}; minimum fraction of a tile that must be covered to keep it; null = don't sample that class
+      background:
+      tissue: 0.1
   params:
     requested_spacing_um: # spacing at which to tile the slide, in microns per pixel; filled from a preset model when available
     tolerance: 0.05 # tolerance for matching the spacing (float between 0 and 1, deciding how much the spacing can deviate from the one specified in the slide metadata)
@@ -33,7 +51,6 @@ tiling:
     requested_region_size_px: # size of hierarchical parent regions in pixels; when unset and region_tile_multiple is set, derived from requested_tile_size_px * region_tile_multiple
     region_tile_multiple: # hierarchical region grid width/height in tiles; e.g. 6 means 6x6 tiles per region
     overlap: 0.0 # percentage of overlap between two consecutive tiles (float between 0 and 1)
-    tissue_threshold: 0.1 # minimum fraction of pixels that must be tissue to keep a tile (float between 0 and 1)
   seg_params:
     # downsample controls which pyramid level is read for tissue segmentation.
     # Larger values are faster and use less memory; smaller values can improve mask precision.

--- a/slide2vec/runtime/serialization.py
+++ b/slide2vec/runtime/serialization.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +24,8 @@ def serialize_preprocessing(preprocessing: PreprocessingConfig) -> dict[str, Any
         "region_tile_multiple": preprocessing.region_tile_multiple,
         "tolerance": preprocessing.tolerance,
         "overlap": preprocessing.overlap,
-        "tissue_threshold": preprocessing.tissue_threshold,
+        "masks": copy.deepcopy(preprocessing.masks),
+        "independent_sampling": preprocessing.independent_sampling,
         "read_coordinates_from": str(preprocessing.read_coordinates_from) if preprocessing.read_coordinates_from is not None else None,
         "read_tiles_from": str(preprocessing.read_tiles_from) if preprocessing.read_tiles_from is not None else None,
         "resume": preprocessing.resume,
@@ -84,7 +86,8 @@ def deserialize_preprocessing(payload: dict[str, Any]) -> PreprocessingConfig:
         ),
         tolerance=float(payload["tolerance"]),
         overlap=float(payload["overlap"]),
-        tissue_threshold=float(payload["tissue_threshold"]),
+        masks=copy.deepcopy(payload["masks"]) if "masks" in payload and payload["masks"] else {},
+        independent_sampling=bool(payload.get("independent_sampling", True)),
         read_coordinates_from=read_coordinates_from,
         read_tiles_from=read_tiles_from,
         resume=bool(payload["resume"]) if "resume" in payload else False,

--- a/slide2vec/runtime/tiling.py
+++ b/slide2vec/runtime/tiling.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
-from hs2p import FilterConfig, PreviewConfig, SegmentationConfig, TilingConfig, load_tiling_result
+from hs2p import FilterConfig, PreviewConfig, SegmentationConfig, load_tiling_result
+from hs2p.configs.resolvers import resolve_tiling_config
 
 from slide2vec.api import PreprocessingConfig
 from slide2vec.runtime.hierarchical import is_hierarchical_preprocessing
@@ -44,14 +46,23 @@ def build_hs2p_configs(
         if is_hierarchical_preprocessing(preprocessing)
         else preprocessing.requested_tile_size_px
     )
-    tiling_cfg = TilingConfig(
-        requested_spacing_um=preprocessing.requested_spacing_um,
-        requested_tile_size_px=requested_tile_size_px,
-        tolerance=preprocessing.tolerance,
-        overlap=preprocessing.overlap,
-        tissue_threshold=preprocessing.tissue_threshold,
-        backend=resolve_tiling_backend(preprocessing),
+    # Reuse hs2p's tiling-config resolver so the derived tissue_threshold comes from
+    # masks.min_coverage.tissue (the single source of truth) and independent_sampling
+    # is threaded consistently. The resolver reads attributes, so wrap the masks dict.
+    tiling_adapter = SimpleNamespace(
+        tiling=SimpleNamespace(
+            masks=SimpleNamespace(**dict(preprocessing.masks)),
+            params=SimpleNamespace(
+                requested_spacing_um=preprocessing.requested_spacing_um,
+                requested_tile_size_px=requested_tile_size_px,
+                tolerance=preprocessing.tolerance,
+                overlap=preprocessing.overlap,
+            ),
+            independent_sampling=preprocessing.independent_sampling,
+            backend=resolve_tiling_backend(preprocessing),
+        )
     )
+    tiling_cfg = resolve_tiling_config(tiling_adapter)
     segmentation_cfg = SegmentationConfig(**dict(preprocessing.segmentation))
     filtering_cfg = FilterConfig(**dict(preprocessing.filtering))
     preview_cfg = build_preview_config(dict(preprocessing.preview))

--- a/tests/test_output_consistency.py
+++ b/tests/test_output_consistency.py
@@ -20,7 +20,14 @@ TILING_PARAMS = dict(
     tolerance=0.07,           # override (default: 0.05)
     requested_tile_size_px=224,  # override (default: 256)
     overlap=0.0,
-    tissue_threshold=0.1,     # override (default: 0.01)
+)
+
+# -- tiling.masks -- (min_coverage.tissue is the sole tissue threshold; was tissue_threshold=0.1)
+TILING_MASKS = dict(
+    output_mode="per_annotation",
+    pixel_mapping={"background": 0, "tissue": 1},
+    colors={"background": None, "tissue": [157, 219, 129]},
+    min_coverage={"background": None, "tissue": 0.1},
 )
 
 # -- tiling.seg_params --
@@ -123,6 +130,8 @@ def test_output_consistency(wsi_path, mask_path, tmp_path):
             "read_tiles_from": None,
             "on_the_fly": True,
             "backend": "asap",
+            "independent_sampling": True,
+            "masks": TILING_MASKS,
             "params": TILING_PARAMS,
             "seg_params": TILING_SEG_PARAMS,
             "filter_params": TILING_FILTER_PARAMS,

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -653,7 +653,7 @@ def test_preprocessing_with_backend_preserves_other_fields():
         requested_tile_size_px=256,
         tolerance=0.1,
         overlap=0.2,
-        tissue_threshold=0.4,
+        masks={"min_coverage": {"tissue": 0.4}},
         read_coordinates_from=Path("/tmp/coordinates"),
         read_tiles_from=Path("/tmp/tiles"),
         resume=True,
@@ -673,6 +673,80 @@ def test_preprocessing_with_backend_preserves_other_fields():
     assert updated.read_coordinates_from == base.read_coordinates_from
     assert updated.read_tiles_from == base.read_tiles_from
     assert updated is not base
+
+
+def test_masks_min_coverage_tissue_drives_derived_tiling_threshold():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = PreprocessingConfig(
+        backend="asap",
+        requested_spacing_um=0.5,
+        requested_tile_size_px=224,
+        masks={"min_coverage": {"tissue": 0.37}},
+        independent_sampling=False,
+        segmentation={"method": "hsv", "downsample": 64},
+        preview={
+            "save_mask_preview": False,
+            "save_tiling_preview": False,
+            "downsample": 32,
+            "tissue_contour_color": (157, 219, 129),
+            "mask_overlay_alpha": 0.5,
+        },
+    )
+
+    # the partial masks dict is deep-merged over the default vocabulary
+    assert preprocessing.masks["pixel_mapping"] == {"background": 0, "tissue": 1}
+    assert preprocessing.masks["min_coverage"]["tissue"] == pytest.approx(0.37)
+
+    tiling_cfg = build_hs2p_configs(preprocessing)[0]
+
+    assert tiling_cfg.tissue_threshold == pytest.approx(0.37)
+    assert tiling_cfg.independent_sampling is False
+
+
+def test_preprocessing_from_config_reads_masks_block_and_independent_sampling():
+    cfg = SimpleNamespace(
+        output_dir="/tmp/run-masks",
+        resume=False,
+        speed=SimpleNamespace(num_cucim_workers=4),
+        tiling=SimpleNamespace(
+            backend="asap",
+            read_coordinates_from=None,
+            read_tiles_from=None,
+            on_the_fly=True,
+            gpu_decode=False,
+            adaptive_batching=False,
+            use_supertiles=True,
+            jpeg_backend="turbojpeg",
+            independent_sampling=False,
+            masks=SimpleNamespace(
+                output_mode="per_annotation",
+                pixel_mapping={"background": 0, "tissue": 1},
+                colors={"background": None, "tissue": [157, 219, 129]},
+                min_coverage={"background": None, "tissue": 0.42},
+            ),
+            params=SimpleNamespace(
+                requested_spacing_um=0.5,
+                requested_tile_size_px=224,
+                tolerance=0.05,
+                overlap=0.0,
+            ),
+            seg_params={"downsample": 64},
+            filter_params={"ref_tile_size": 224},
+            preview=SimpleNamespace(
+                save_mask_preview=False,
+                save_tiling_preview=False,
+                downsample=32,
+                tissue_contour_color=(157, 219, 129),
+                mask_overlay_alpha=0.5,
+            ),
+        ),
+    )
+
+    preprocessing = PreprocessingConfig.from_config(cfg)
+
+    assert preprocessing.masks["min_coverage"]["tissue"] == pytest.approx(0.42)
+    assert preprocessing.independent_sampling is False
 
 
 def test_preprocessing_config_defaults_backend_to_auto():
@@ -753,7 +827,6 @@ def test_cli_build_model_and_pipeline_delegates_to_public_api(monkeypatch, tmp_p
                 requested_tile_size_px=224,
                 tolerance=0.05,
                 overlap=0.0,
-                tissue_threshold=0.1,
             ),
             seg_params={"downsample": 64},
             filter_params={"ref_tile_size": 224},
@@ -980,7 +1053,6 @@ def test_preprocessing_config_from_config_preserves_tile_store_dir():
                 requested_tile_size_px=224,
                 tolerance=0.07,
                 overlap=0.0,
-                tissue_threshold=0.1,
             ),
             seg_params={"downsample": 64},
             filter_params={"ref_tile_size": 224},
@@ -1020,7 +1092,6 @@ def test_preprocessing_config_from_config_uses_explicit_speed_num_cucim_workers(
                 requested_tile_size_px=224,
                 tolerance=0.07,
                 overlap=0.0,
-                tissue_threshold=0.1,
             ),
             seg_params={"downsample": 64},
             filter_params={"ref_tile_size": 224},
@@ -1058,7 +1129,6 @@ def test_preprocessing_config_from_config_disables_gpu_decode_by_default():
                 requested_tile_size_px=224,
                 tolerance=0.07,
                 overlap=0.0,
-                tissue_threshold=0.1,
             ),
             seg_params={"downsample": 64},
             filter_params={"ref_tile_size": 224},

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1841,7 +1841,7 @@ def test_build_hs2p_configs_constructs_preview_config():
         requested_tile_size_px=224,
         tolerance=0.05,
         overlap=0.0,
-        tissue_threshold=0.1,
+        masks={"min_coverage": {"tissue": 0.1}},
         segmentation={"downsample": 64, "method": "hsv"},
         filtering={"ref_tile_size": 224},
         preview={
@@ -1858,6 +1858,7 @@ def test_build_hs2p_configs_constructs_preview_config():
     )
 
     assert tiling_cfg.backend == "asap"
+    assert tiling_cfg.tissue_threshold == pytest.approx(0.1)  # derived from masks.min_coverage.tissue
     assert segmentation_cfg.downsample == 64
     assert segmentation_cfg.method == "hsv"
     assert filtering_cfg.ref_tile_size == 224


### PR DESCRIPTION
## Summary

Slice 1/6 of annotation-aware feature extraction (PRD #153). Prefactor that establishes the `tiling.masks` config block and makes `min_coverage.tissue` the **sole** tissue threshold.

- Bump hs2p pin to `>=4.1.1` (the `merged` output-mode rename).
- Remove the standalone `tissue_threshold` entirely — config key, `PreprocessingConfig` field, and serialization (no alias).
- Add the `tiling.masks` block (`pixel_mapping`/`colors`/`min_coverage`, fully commented) and the `tiling.independent_sampling` flag to the default config.
- Derive `TilingConfig.tissue_threshold` from `masks.min_coverage.tissue` by reusing hs2p's `resolve_tiling_config`.
- `PreprocessingConfig.masks` accepts a **partial dict that deep-merges over `DEFAULT_MASKS`**, so callers state only overrides: `masks={"min_coverage": {"tissue": 0.1}}`.

The default tissue-only path is behaviourally unchanged.

## Acceptance criteria

- [x] hs2p pin updated to the rename release; the `merged` output-mode value is available
- [x] `tiling.masks` block present in the default config with the default `background`/`tissue` vocabulary, fully commented
- [x] `tiling.independent_sampling` flag present (default: independent)
- [x] standalone tissue-threshold config key, preprocessing-config field, and serialization removed entirely (no alias)
- [x] `min_coverage.tissue` derives the tiling threshold via hs2p's resolver
- [x] default tissue run produces identical results to before (regression test green)
- [x] config unit test: `min_coverage.tissue` flows into the derived tiling threshold

## Tests

`pytest tests/` → **293 passed, 15 skipped**.

Closes #154