### PR TITLE
Per-annotation tile embeddings spine (#155)

### DIFF
--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import numpy as np
 import torch
+from hs2p.fileops import is_flattened_annotation
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -90,6 +91,19 @@ def _write_metadata(path: Path, metadata: dict[str, Any]) -> None:
     path.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
 
 
+def tile_embeddings_subdir(annotation: str | None) -> str:
+    """Namespace the ``tile_embeddings`` output dir per annotation class.
+
+    Reuses hs2p's flatten rule (the single source of truth): ``None`` and the sentinel
+    ``"tissue"`` collapse to the flat ``tile_embeddings`` root, so the default tissue-only
+    path is byte-for-byte unchanged; any real class label gets its own
+    ``tile_embeddings/<class>`` subdirectory.
+    """
+    if is_flattened_annotation(annotation):
+        return "tile_embeddings"
+    return f"tile_embeddings/{annotation}"
+
+
 def _setup_artifact_paths(
     output_dir: str | Path, subdir: str, sample_id: str, output_format: str
 ) -> tuple[Path, Path]:
@@ -142,9 +156,12 @@ def write_tile_embeddings(
     output_format: str = "pt",
     metadata: dict[str, Any] | None = None,
     tile_index: Any | None = None,
+    annotation: str | None = None,
 ) -> TileEmbeddingArtifact:
     output_format = _validate_output_format(output_format)
-    artifact_path, metadata_path = _setup_artifact_paths(output_dir, "tile_embeddings", sample_id, output_format)
+    artifact_path, metadata_path = _setup_artifact_paths(
+        output_dir, tile_embeddings_subdir(annotation), sample_id, output_format
+    )
     feature_array = _ensure_array(features)
     if output_format == "pt":
         torch.save(_ensure_tensor(features), artifact_path)
@@ -180,9 +197,12 @@ def write_tile_embedding_metadata(
     feature_dim: int | None = None,
     num_tiles: int = 0,
     metadata: dict[str, Any] | None = None,
+    annotation: str | None = None,
 ) -> Path:
     output_format = _validate_output_format(output_format)
-    _, metadata_path = _setup_artifact_paths(output_dir, "tile_embeddings", sample_id, output_format)
+    _, metadata_path = _setup_artifact_paths(
+        output_dir, tile_embeddings_subdir(annotation), sample_id, output_format
+    )
     tile_metadata = _build_tile_embedding_metadata(
         sample_id,
         output_format=output_format,

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -597,6 +597,7 @@ def embed_tiles(
                 features,
                 execution=execution,
                 metadata=metadata,
+                annotation=embedding.tiling_result_annotation(tiling_result),
             )
         artifacts.append(artifact)
     return artifacts

--- a/slide2vec/runtime/embedding.py
+++ b/slide2vec/runtime/embedding.py
@@ -17,6 +17,16 @@ from slide2vec.artifacts import (
 from slide2vec.runtime.hierarchical import resolve_hierarchical_geometry
 
 
+def tiling_result_annotation(tiling_result) -> str | None:
+    """Annotation class carried by a tiling result (from its process-list row).
+
+    ``None``/``"tissue"`` mean the flat tissue-only layout (see
+    :func:`slide2vec.artifacts.tile_embeddings_subdir`); any other label namespaces the
+    tile-embedding artifacts under a per-class subdirectory.
+    """
+    return getattr(tiling_result, "annotation", None)
+
+
 def should_persist_tile_embeddings(model, execution: ExecutionOptions) -> bool:
     if model.level in {"slide", "patient"}:
         return bool(execution.save_tile_embeddings)
@@ -100,6 +110,7 @@ def write_tile_embedding_artifact(
     *,
     execution: ExecutionOptions,
     metadata: dict[str, Any],
+    annotation: str | None = None,
 ) -> TileEmbeddingArtifact:
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required to persist tile embeddings")
@@ -110,6 +121,7 @@ def write_tile_embedding_artifact(
         output_format=execution.output_format,
         metadata=metadata,
         tile_index=np.arange(_num_rows(features), dtype=np.int64),
+        annotation=annotation,
     )
 
 

--- a/slide2vec/runtime/embedding_persist.py
+++ b/slide2vec/runtime/embedding_persist.py
@@ -16,6 +16,7 @@ from slide2vec.runtime.embedding import (
     build_tile_embedding_metadata,
     build_slide_embedding_metadata,
     should_persist_tile_embeddings,
+    tiling_result_annotation,
     write_hierarchical_embedding_artifact,
     write_slide_embedding_artifact,
     write_tile_embedding_artifact,
@@ -72,6 +73,7 @@ def persist_embedded_slide(
 ) -> tuple[TileEmbeddingArtifact | HierarchicalEmbeddingArtifact | None, SlideEmbeddingArtifact | None]:
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required to persist embedded slides")
+    annotation = tiling_result_annotation(tiling_result)
     if num_rows(embedded_slide.tile_embeddings) == 0:
         write_tile_embedding_metadata(
             embedded_slide.sample_id,
@@ -79,6 +81,7 @@ def persist_embedded_slide(
             output_format=execution.output_format,
             feature_dim=None,
             num_tiles=0,
+            annotation=annotation,
             metadata=build_tile_embedding_metadata(
                 model,
                 tiling_result=tiling_result,
@@ -110,6 +113,7 @@ def persist_embedded_slide(
             embedded_slide.sample_id,
             embedded_slide.tile_embeddings,
             execution=execution,
+            annotation=annotation,
             metadata=build_tile_embedding_metadata(
                 model,
                 tiling_result=tiling_result,

--- a/slide2vec/runtime/process_list.py
+++ b/slide2vec/runtime/process_list.py
@@ -17,7 +17,11 @@ from slide2vec.runtime.hierarchical import (
     num_tiles,
     resolve_hierarchical_geometry,
 )
-from slide2vec.runtime.embedding import build_hierarchical_embedding_metadata, build_tile_embedding_metadata
+from slide2vec.runtime.embedding import (
+    build_hierarchical_embedding_metadata,
+    build_tile_embedding_metadata,
+    tiling_result_annotation,
+)
 from slide2vec.runtime.tiling import resolve_slide_backend
 from slide2vec.utils.tiling_io import atomic_write_dataframe_csv, load_tiling_result_from_row
 
@@ -78,6 +82,7 @@ def write_zero_tile_embedding_sidecars(
             output_format=output_format,
             feature_dim=None,
             num_tiles=0,
+            annotation=tiling_result_annotation(tiling_result),
             metadata=build_tile_embedding_metadata(
                 model=model,
                 tiling_result=tiling_result,

--- a/slide2vec/runtime/tiling.py
+++ b/slide2vec/runtime/tiling.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import numpy as np
 from hs2p import FilterConfig, PreviewConfig, SegmentationConfig, load_tiling_result
-from hs2p.configs.resolvers import resolve_tiling_config
+from hs2p.configs.resolvers import resolve_sampling_request, resolve_tiling_config
 
 from slide2vec.api import PreprocessingConfig
 from slide2vec.runtime.hierarchical import is_hierarchical_preprocessing
@@ -63,6 +63,15 @@ def build_hs2p_configs(
         )
     )
     tiling_cfg = resolve_tiling_config(tiling_adapter)
+    # Resolve the annotation-sampling invocation from the same masks subtree. A masks block
+    # left at hs2p's shipped default ({background:0, tissue:1}) yields (None, None, None) so
+    # the plain binary-tissue path is byte-for-byte unchanged; any customization (a new class,
+    # an extra pixel value) opts the run into multi-label annotation sampling. The resolver
+    # validates the masks config (duplicate values, unsafe label names, out-of-range values)
+    # and raises ValueError up front, before any slide is opened.
+    sampling, selection_strategy, output_mode = resolve_sampling_request(
+        tiling_adapter, tiling=tiling_cfg
+    )
     segmentation_cfg = SegmentationConfig(**dict(preprocessing.segmentation))
     filtering_cfg = FilterConfig(**dict(preprocessing.filtering))
     preview_cfg = build_preview_config(dict(preprocessing.preview))
@@ -73,6 +82,9 @@ def build_hs2p_configs(
         preview_cfg,
         preprocessing.read_coordinates_from,
         preprocessing.resume,
+        sampling,
+        selection_strategy,
+        output_mode,
     )
 
 

--- a/slide2vec/runtime/tiling_pipeline.py
+++ b/slide2vec/runtime/tiling_pipeline.py
@@ -62,7 +62,17 @@ def tile_slides_call(
     num_workers: int,
 ) -> list[Any]:
     preload_asap_wholeslidedata(preprocessing)
-    tiling_cfg, segmentation_cfg, filtering_cfg, preview_cfg, read_coordinates_from, resume = build_hs2p_configs(preprocessing)
+    (
+        tiling_cfg,
+        segmentation_cfg,
+        filtering_cfg,
+        preview_cfg,
+        read_coordinates_from,
+        resume,
+        sampling,
+        selection_strategy,
+        output_mode,
+    ) = build_hs2p_configs(preprocessing)
     def _run_tile_slides():
         return tile_slides(
             slides,
@@ -76,6 +86,9 @@ def tile_slides_call(
             resume=resume,
             save_tiles=not preprocessing.on_the_fly and preprocessing.read_tiles_from is None,
             jpeg_backend=preprocessing.jpeg_backend,
+            sampling=sampling,
+            selection_strategy=selection_strategy,
+            output_mode=output_mode,
         )
 
     with bridge_hs2p_progress_to_slide2vec():
@@ -135,21 +148,24 @@ def prepare_tiled_slides(
     tiling_results = []
     successful_slides = []
     for slide in slide_records:
-        row = process_df.loc[process_df["sample_id"] == slide.sample_id]
-        if row.empty:
+        rows = process_df.loc[process_df["sample_id"] == slide.sample_id]
+        if rows.empty:
             raise ValueError(f"No process-list entry found for sample_id={slide.sample_id}")
-        row_dict = row.iloc[0].to_dict()
-        if "tiling_status" not in row_dict or row_dict["tiling_status"] != "success":
-            error_message = row_dict["error"] if "error" in row_dict else ""
-            raise RuntimeError(f"Tiling failed for {slide.sample_id}: {error_message}")
-        num_tiles = row_dict.get("num_tiles", 0)
-        if num_tiles == 0 or pd.isna(row_dict.get("coordinates_npz_path")):
-            logging.getLogger(__name__).warning(
-                f"Skipping {slide.sample_id}: no tiles extracted"
-            )
-            continue
-        successful_slides.append(slide)
-        tiling_results.append(load_tiling_result_from_row(row_dict))
+        # Annotation sampling emits one row per (sample_id, annotation); the plain tissue
+        # path emits exactly one. Walk every row so per-class results each get their own
+        # (slide, tiling_result) pair downstream — the tiling_result carries the annotation.
+        for row_dict in rows.to_dict("records"):
+            if "tiling_status" not in row_dict or row_dict["tiling_status"] != "success":
+                error_message = row_dict["error"] if "error" in row_dict else ""
+                raise RuntimeError(f"Tiling failed for {slide.sample_id}: {error_message}")
+            num_tiles = row_dict.get("num_tiles", 0)
+            if num_tiles == 0 or pd.isna(row_dict.get("coordinates_npz_path")):
+                logging.getLogger(__name__).warning(
+                    f"Skipping {slide.sample_id}: no tiles extracted"
+                )
+                continue
+            successful_slides.append(slide)
+            tiling_results.append(load_tiling_result_from_row(row_dict))
     return successful_slides, tiling_results, process_list_path
 
 

--- a/slide2vec/utils/tiling_io.py
+++ b/slide2vec/utils/tiling_io.py
@@ -238,6 +238,10 @@ def load_tiling_result_from_row(row):
     )
     setattr(tiling_result, "coordinates_npz_path", coordinates_npz_path)
     setattr(tiling_result, "coordinates_meta_path", coordinates_meta_path)
+    annotation = row.get("annotation")
+    if annotation is not None and pd.isna(annotation):
+        annotation = None
+    setattr(tiling_result, "annotation", annotation if annotation is None else str(annotation))
     setattr(tiling_result, "tiles_tar_path", _optional_path(row.get("tiles_tar_path")))
     setattr(tiling_result, "mask_preview_path", _optional_path(row.get("mask_preview_path")))
     setattr(tiling_result, "tiling_preview_path", _optional_path(row.get("tiling_preview_path")))

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -749,6 +749,125 @@ def test_preprocessing_from_config_reads_masks_block_and_independent_sampling():
     assert preprocessing.independent_sampling is False
 
 
+def _masks_preprocessing(masks, *, independent_sampling=True):
+    return PreprocessingConfig(
+        backend="asap",
+        requested_spacing_um=0.5,
+        requested_tile_size_px=224,
+        masks=masks,
+        independent_sampling=independent_sampling,
+        segmentation={"method": "hsv", "downsample": 64},
+        preview={
+            "save_mask_preview": False,
+            "save_tiling_preview": False,
+            "downsample": 32,
+            "tissue_contour_color": (157, 219, 129),
+            "mask_overlay_alpha": 0.5,
+        },
+    )
+
+
+def test_default_masks_block_yields_no_sampling():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = _masks_preprocessing({"min_coverage": {"tissue": 0.37}})
+
+    configs = build_hs2p_configs(preprocessing)
+    sampling, selection_strategy, output_mode = configs[-3], configs[-2], configs[-1]
+
+    assert sampling is None
+    assert selection_strategy is None
+    assert output_mode is None
+
+
+def test_customized_masks_block_yields_independent_per_annotation_sampling():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = _masks_preprocessing(
+        {
+            "pixel_mapping": {"tumor": 2},
+            "colors": {"tumor": [255, 0, 0]},
+            "min_coverage": {"tumor": 0.5},
+        },
+        independent_sampling=True,
+    )
+
+    configs = build_hs2p_configs(preprocessing)
+    sampling, selection_strategy, output_mode = configs[-3], configs[-2], configs[-1]
+
+    assert sampling is not None
+    assert "tumor" in sampling.active_annotations
+    assert selection_strategy == "independent_sampling"
+    assert output_mode == "per_annotation"
+
+
+def test_invalid_masks_block_with_duplicate_pixel_values_fails_fast():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = _masks_preprocessing(
+        {
+            "pixel_mapping": {"tumor": 1},
+            "min_coverage": {"tumor": 0.5},
+        }
+    )
+
+    with pytest.raises(ValueError, match="unique"):
+        build_hs2p_configs(preprocessing)
+
+
+def test_invalid_masks_block_with_unsafe_class_name_fails_fast():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = _masks_preprocessing(
+        {
+            "pixel_mapping": {"../escape": 2},
+            "min_coverage": {"../escape": 0.5},
+        }
+    )
+
+    with pytest.raises(ValueError, match="path component"):
+        build_hs2p_configs(preprocessing)
+
+
+def test_invalid_masks_block_with_out_of_range_value_fails_fast():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = _masks_preprocessing(
+        {
+            "pixel_mapping": {"tumor": 70000},
+            "min_coverage": {"tumor": 0.5},
+        }
+    )
+
+    with pytest.raises(ValueError, match="range"):
+        build_hs2p_configs(preprocessing)
+
+
+def test_write_tile_embeddings_namespaces_real_class_under_subdir(tmp_path: Path):
+    features = np.arange(8, dtype=np.float32).reshape(2, 4)
+    artifact = write_tile_embeddings(
+        "sample-a",
+        features,
+        output_dir=tmp_path,
+        output_format="npz",
+        annotation="tumor",
+    )
+    assert artifact.path == tmp_path / "tile_embeddings" / "tumor" / "sample-a.npz"
+
+
+def test_write_tile_embeddings_flattens_tissue_annotation(tmp_path: Path):
+    features = np.arange(8, dtype=np.float32).reshape(2, 4)
+    for annotation in (None, "tissue"):
+        artifact = write_tile_embeddings(
+            f"sample-{annotation}",
+            features,
+            output_dir=tmp_path,
+            output_format="npz",
+            annotation=annotation,
+        )
+        assert artifact.path == tmp_path / "tile_embeddings" / f"sample-{annotation}.npz"
+
+
 def test_preprocessing_config_defaults_backend_to_auto():
     assert DEFAULT_PREPROCESSING.backend == "auto"
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1660,6 +1660,9 @@ def test_tile_slides_forwards_spacing_at_level_0_to_hs2p(monkeypatch, tmp_path: 
             "preview",
             None,
             False,
+            None,
+            None,
+            None,
         ),
     )
 
@@ -1703,6 +1706,9 @@ def test_tile_slides_skips_saving_tiles_when_external_store_is_configured(monkey
             "preview",
             None,
             False,
+            None,
+            None,
+            None,
         ),
     )
 
@@ -1806,6 +1812,9 @@ def test_tile_slides_does_not_pre_resolve_backend_auto(monkeypatch, tmp_path: Pa
             "preview",
             None,
             False,
+            None,
+            None,
+            None,
         ),
     )
 
@@ -1853,9 +1862,17 @@ def test_build_hs2p_configs_constructs_preview_config():
         },
     )
 
-    tiling_cfg, segmentation_cfg, filtering_cfg, preview_cfg, read_coordinates_from, resume = (
-        runtime_tiling.build_hs2p_configs(preprocessing)
-    )
+    (
+        tiling_cfg,
+        segmentation_cfg,
+        filtering_cfg,
+        preview_cfg,
+        read_coordinates_from,
+        resume,
+        sampling,
+        selection_strategy,
+        output_mode,
+    ) = runtime_tiling.build_hs2p_configs(preprocessing)
 
     assert tiling_cfg.backend == "asap"
     assert tiling_cfg.tissue_threshold == pytest.approx(0.1)  # derived from masks.min_coverage.tissue
@@ -3917,7 +3934,7 @@ def test_persist_embedded_slide_records_resolved_backend_when_auto(monkeypatch, 
     monkeypatch.setattr(
         embedding_persist,
         "write_tile_embedding_artifact",
-        lambda sample_id, features, *, execution, metadata: captured.setdefault("metadata", metadata) or SimpleNamespace(),
+        lambda sample_id, features, *, execution, metadata, annotation=None: captured.setdefault("metadata", metadata) or SimpleNamespace(),
     )
 
     embedding_persist.persist_embedded_slide(
@@ -4334,3 +4351,254 @@ def test_scale_coordinates_identity_when_spacings_equal():
     coords = np.array([[10, 20], [30, 40]])
     result = scale_coordinates(coords, base_spacing_um=0.5, spacing=0.5)
     np.testing.assert_array_equal(result, [[10, 20], [30, 40]])
+
+
+# --- Issue #155: per-annotation tile-embedding spine (top-seam) ---
+
+
+def _write_process_list(path: Path, rows: list[dict]) -> None:
+    columns = [
+        "sample_id",
+        "annotation",
+        "image_path",
+        "mask_path",
+        "requested_backend",
+        "backend",
+        "spacing_at_level_0",
+        "tiling_status",
+        "num_tiles",
+        "coordinates_npz_path",
+        "coordinates_meta_path",
+        "tiles_tar_path",
+        "mask_preview_path",
+        "tiling_preview_path",
+        "error",
+        "traceback",
+    ]
+    pd.DataFrame(rows, columns=columns).to_csv(path, index=False)
+
+
+def _fake_tiling_result_loader(monkeypatch):
+    """Make tiling_io.load_tiling_result return a minimal in-memory result (no file IO)."""
+    def _fake_load_tiling_result(*, coordinates_npz_path, coordinates_meta_path):
+        return SimpleNamespace(
+            x=np.array([0], dtype=np.int64),
+            y=np.array([1], dtype=np.int64),
+            tile_size_lv0=224,
+            num_tiles=1,
+            backend="asap",
+        )
+
+    from slide2vec.utils import tiling_io
+    monkeypatch.setattr(tiling_io, "load_tiling_result", _fake_load_tiling_result)
+
+
+def test_prepare_tiled_slides_preserves_per_annotation_rows(monkeypatch, tmp_path: Path):
+    """A multi-label slide yields one (slide, tiling_result) pair per (sample_id, annotation),
+    each tiling_result carrying its annotation from the process-list row."""
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+    _fake_tiling_result_loader(monkeypatch)
+    monkeypatch.setattr(
+        tiling_pipeline, "tile_slides_with_progress", lambda *args, **kwargs: []
+    )
+    monkeypatch.setattr(
+        tiling_pipeline, "record_slide_metadata_in_process_list", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        tiling_pipeline, "restore_resume_metadata_after_tiling", lambda *args, **kwargs: None
+    )
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    successful_slides, tiling_results, returned_path = tiling_pipeline.prepare_tiled_slides(
+        [slide],
+        DEFAULT_PREPROCESSING,
+        output_dir=tmp_path,
+        num_workers=0,
+    )
+
+    assert returned_path == process_list_path
+    assert [s.sample_id for s in successful_slides] == ["slide-a", "slide-a"]
+    assert [tr.annotation for tr in tiling_results] == ["tumor", "stroma"]
+
+
+def test_persist_embedded_slide_namespaces_tile_embeddings_per_class(tmp_path: Path):
+    """Real classes land under tile_embeddings/<class>/; tissue/None stay flat."""
+    model = SimpleNamespace(name="virchow2", level="tile")
+    execution = ExecutionOptions(output_dir=tmp_path)
+
+    def _persist(annotation):
+        tiling_result = SimpleNamespace(
+            x=np.array([0], dtype=np.int64),
+            y=np.array([1], dtype=np.int64),
+            tile_size_lv0=224,
+            num_tiles=1,
+            backend="asap",
+            annotation=annotation,
+            coordinates_npz_path=Path("/tmp/c.npz"),
+            coordinates_meta_path=Path("/tmp/c.meta.json"),
+            tiles_tar_path=None,
+        )
+        embedded = EmbeddedSlide(
+            sample_id="slide-a",
+            tile_embeddings=np.zeros((1, 4), dtype=np.float32),
+            slide_embedding=None,
+            x=np.array([0], dtype=np.int64),
+            y=np.array([1], dtype=np.int64),
+            tile_size_lv0=224,
+            image_path=Path("/tmp/slide-a.svs"),
+            mask_path=Path("/tmp/slide-a-mask.png"),
+        )
+        tile_artifact, _ = embedding_persist.persist_embedded_slide(
+            model,
+            embedded,
+            tiling_result,
+            preprocessing=DEFAULT_PREPROCESSING,
+            execution=execution,
+        )
+        return tile_artifact
+
+    tumor_artifact = _persist("tumor")
+    assert tumor_artifact.path == tmp_path / "tile_embeddings" / "tumor" / "slide-a.pt"
+
+    tissue_artifact = _persist("tissue")
+    assert tissue_artifact.path == tmp_path / "tile_embeddings" / "slide-a.pt"
+
+    none_artifact = _persist(None)
+    assert none_artifact.path == tmp_path / "tile_embeddings" / "slide-a.pt"
+
+
+def test_tile_slides_call_forwards_sampling_and_mask_for_annotation_mode(monkeypatch, tmp_path: Path):
+    """Customized masks block forwards a sampling spec, selection strategy, output mode AND the
+    slide's annotation mask to hs2p — the wiring that lets hs2p enforce a required raster."""
+    captured = {}
+
+    def fake_tile_slides(slides, **kwargs):
+        captured["slides"] = list(slides)
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(tiling_pipeline, "tile_slides", fake_tile_slides)
+
+    preprocessing = replace(
+        DEFAULT_PREPROCESSING,
+        on_the_fly=True,
+        masks={
+            "pixel_mapping": {"tumor": 2},
+            "colors": {"tumor": [255, 0, 0]},
+            "min_coverage": {"tumor": 0.5},
+        },
+        independent_sampling=True,
+    )
+    slide = manifest.coerce_slide_spec(
+        {
+            "sample_id": "slide-a",
+            "image_path": "/tmp/slide-a.svs",
+            "mask_path": "/tmp/slide-a-mask.png",
+        }
+    )
+
+    tiling_pipeline.tile_slides_call(
+        [slide],
+        preprocessing,
+        output_dir=tmp_path,
+        num_workers=0,
+    )
+
+    assert captured["kwargs"]["sampling"] is not None
+    assert "tumor" in captured["kwargs"]["sampling"].active_annotations
+    assert captured["kwargs"]["selection_strategy"] == "independent_sampling"
+    assert captured["kwargs"]["output_mode"] == "per_annotation"
+    assert Path(captured["slides"][0].mask_path) == Path("/tmp/slide-a-mask.png")
+
+
+def test_tile_slides_call_default_masks_block_forwards_no_sampling(monkeypatch, tmp_path: Path):
+    """Default masks block leaves the plain tissue path unchanged: no sampling forwarded."""
+    captured = {}
+
+    def fake_tile_slides(slides, **kwargs):
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(tiling_pipeline, "tile_slides", fake_tile_slides)
+
+    tiling_pipeline.tile_slides_call(
+        [make_slide("slide-a")],
+        replace(DEFAULT_PREPROCESSING, on_the_fly=True),
+        output_dir=tmp_path,
+        num_workers=0,
+    )
+
+    assert captured["kwargs"]["sampling"] is None
+    assert captured["kwargs"]["selection_strategy"] is None
+    assert captured["kwargs"]["output_mode"] is None
+
+
+def test_zero_tile_sidecar_namespaces_per_class(tmp_path: Path):
+    """Zero-tile sidecars for a real class land under tile_embeddings/<class>/; tissue stays flat."""
+    model = SimpleNamespace(name="virchow2", level="tile")
+
+    def _sidecar(annotation):
+        tiling_result = SimpleNamespace(
+            x=np.array([], dtype=np.int64),
+            y=np.array([], dtype=np.int64),
+            tile_size_lv0=224,
+            num_tiles=0,
+            backend="asap",
+            annotation=annotation,
+            coordinates_npz_path=Path("/tmp/c.npz"),
+            coordinates_meta_path=Path("/tmp/c.meta.json"),
+            tiles_tar_path=None,
+        )
+        slide = make_slide("slide-z", mask_path=Path("/tmp/slide-z-mask.png"))
+        process_list.write_zero_tile_embedding_sidecars(
+            [(slide, tiling_result)],
+            model=model,
+            preprocessing=DEFAULT_PREPROCESSING,
+            output_dir=tmp_path,
+            output_format="pt",
+        )
+
+    _sidecar("tumor")
+    assert (tmp_path / "tile_embeddings" / "tumor" / "slide-z.meta.json").is_file()
+
+    _sidecar("tissue")
+    assert (tmp_path / "tile_embeddings" / "slide-z.meta.json").is_file()


### PR DESCRIPTION
Delivers the first end-to-end annotation-aware path: a run with a customized masks block (e.g. adding a `tumor` class with a pixel value and minimum coverage) produces tile embeddings restricted to that class, namespaced per class.

## What changed
- `build_hs2p_configs` now also calls hs2p's `resolve_sampling_request` (fed the same `SimpleNamespace` masks adapter from #154) and returns `(sampling, selection_strategy, output_mode)`. A default masks block yields `(None, None, None)` so the plain tissue path is unchanged; any customization opts into multi-label sampling. Invalid masks configs (duplicate pixel values, unsafe class names, out-of-range values) fail fast via the resolver.
- `tile_slides_call` forwards `sampling=`, `selection_strategy=`, `output_mode=` into `tile_slides`.
- `prepare_tiled_slides` walks every process-list row per `sample_id` so each `(sample_id, annotation)` pair becomes its own `(slide, tiling_result)`; `load_tiling_result_from_row` sets `tiling_result.annotation` from the row.
- `write_tile_embeddings` / `write_tile_embedding_metadata` gained an `annotation` param. A new `tile_embeddings_subdir` helper reuses `hs2p.fileops.is_flattened_annotation`: real classes land under `tile_embeddings/<class>/`, `tissue`/`None` stay flat.
- Annotation is threaded through `persist_embedded_slide`, the `embed_tiles` loop, and the zero-tile sidecar writer.

The annotation raster is supplied per slide via the existing `mask_path` column; hs2p enforces it in annotation mode.

## Scope
Tile embeddings only. Slide-level and hierarchical namespacing, plus per-class process-list `feature_path` keying / resume dedup, are later slices (#156/#157) and are intentionally not done here. The default tissue-only path (one row per sample_id) is unchanged.

## Tests
Config-translation unit tests (default / customized / invalid: duplicate / unsafe-name / out-of-range), artifact namespacing tests, and top-seam tests for per-annotation row preservation, per-class artifact namespacing, sampling+mask forwarding, and zero-tile sidecar namespacing.

`python -m pytest tests/ -o addopts="" -p no:cacheprovider -q` → 305 passed, 15 skipped.

Closes #155