### PR TITLE
Annotation-aware previews recorded per (sample_id, annotation) row

### DIFF
--- a/slide2vec/runtime/process_list.py
+++ b/slide2vec/runtime/process_list.py
@@ -149,14 +149,38 @@ def record_slide_metadata_in_process_list(
         for slide in slide_records
         if slide.spacing_at_level_0 is not None
     }
-    mask_preview_by_sample_id = {
-        str(artifact.sample_id): _resolve_path_str(artifact.mask_preview_path)
-        for artifact in tiling_artifacts
-    }
-    tiling_preview_by_sample_id = {
-        str(artifact.sample_id): _resolve_path_str(artifact.tiling_preview_path)
-        for artifact in tiling_artifacts
-    }
+    def _normalize_annotation(value: Any) -> str | None:
+        if value is None or (not isinstance(value, str) and pd.isna(value)):
+            return None
+        return str(value)
+
+    # Annotation mode emits one artifact per (sample_id, annotation); the tissue/default
+    # path emits a single artifact per sample_id (annotation tissue/None). Key previews on
+    # the (sample_id, annotation) pair so each per-class tiling preview lands on its own row
+    # instead of collapsing onto sample_id, while the multi-label mask preview (shared across
+    # a slide's classes) still maps correctly. A sample_id-only fallback keeps the plain
+    # tissue path — and any artifact that omits an annotation — byte-for-byte unchanged.
+    mask_preview_by_pair: dict[tuple[str, str], str | None] = {}
+    tiling_preview_by_pair: dict[tuple[str, str], str | None] = {}
+    mask_preview_by_sample_id: dict[str, str | None] = {}
+    tiling_preview_by_sample_id: dict[str, str | None] = {}
+    for artifact in tiling_artifacts:
+        sample_id = str(artifact.sample_id)
+        mask_path = _resolve_path_str(artifact.mask_preview_path)
+        tiling_path = _resolve_path_str(artifact.tiling_preview_path)
+        annotation = _normalize_annotation(getattr(artifact, "annotation", None))
+        if annotation is not None:
+            mask_preview_by_pair[(sample_id, annotation)] = mask_path
+            tiling_preview_by_pair[(sample_id, annotation)] = tiling_path
+        mask_preview_by_sample_id[sample_id] = mask_path
+        tiling_preview_by_sample_id[sample_id] = tiling_path
+
+    def _map_preview_path(row: dict, by_pair: dict, by_sample_id: dict) -> str | None:
+        sample_id = str(row["sample_id"])
+        annotation = _normalize_annotation(row.get("annotation"))
+        if annotation is not None and (sample_id, annotation) in by_pair:
+            return by_pair[(sample_id, annotation)]
+        return by_sample_id.get(sample_id)
     process_df = pd.read_csv(process_list_path)
     if "requested_backend" not in process_df.columns:
         process_df["requested_backend"] = [None] * len(process_df)
@@ -192,15 +216,31 @@ def record_slide_metadata_in_process_list(
     if backend_by_sample_id:
         mapped_backend = process_df["sample_id"].astype(str).map(backend_by_sample_id)
         process_df["backend"] = process_df["backend"].where(process_df["backend"].notna(), mapped_backend)
-    mapped_mask_preview_paths = process_df["sample_id"].astype(str).map(mask_preview_by_sample_id)
+    has_annotation_column = "annotation" in process_df.columns
+    mapped_mask_preview_paths = []
+    mapped_tiling_preview_paths = []
+    for row in process_df.to_dict("records"):
+        if not has_annotation_column:
+            row = {**row, "annotation": None}
+        mapped_mask_preview_paths.append(
+            _map_preview_path(row, mask_preview_by_pair, mask_preview_by_sample_id)
+        )
+        mapped_tiling_preview_paths.append(
+            _map_preview_path(row, tiling_preview_by_pair, tiling_preview_by_sample_id)
+        )
+    mapped_mask_preview_series = pd.Series(
+        mapped_mask_preview_paths, index=process_df.index, dtype="object"
+    )
+    mapped_tiling_preview_series = pd.Series(
+        mapped_tiling_preview_paths, index=process_df.index, dtype="object"
+    )
     process_df["mask_preview_path"] = process_df["mask_preview_path"].where(
         process_df["mask_preview_path"].notna(),
-        mapped_mask_preview_paths,
+        mapped_mask_preview_series,
     )
-    mapped_tiling_preview_paths = process_df["sample_id"].astype(str).map(tiling_preview_by_sample_id)
     process_df["tiling_preview_path"] = process_df["tiling_preview_path"].where(
         process_df["tiling_preview_path"].notna(),
-        mapped_tiling_preview_paths,
+        mapped_tiling_preview_series,
     )
     atomic_write_dataframe_csv(process_df, process_list_path)
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1957,6 +1957,56 @@ def test_prepare_tiled_slides_records_preview_paths_in_process_list(monkeypatch,
     assert Path(recorded.loc[0, "tiling_preview_path"]) == Path("/tmp/preview/tiling/slide-a.png").resolve()
 
 
+def test_prepare_tiled_slides_records_per_annotation_preview_paths_in_process_list(
+    monkeypatch, tmp_path: Path
+):
+    """In annotation mode hs2p emits one (sample_id, annotation) row plus one artifact per
+    class. Each row must record its own per-class tiling preview while sharing the
+    multi-label mask preview, instead of collapsing on sample_id alone."""
+    process_list_path = tmp_path / "process_list.csv"
+    process_list_path.write_text(
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
+        "slide-a,tumor,/tmp/slide-a.svs,,asap,asap,success,1,/tmp/slide-a.tumor.coordinates.npz,/tmp/slide-a.tumor.coordinates.meta.json,,\n"
+        "slide-a,stroma,/tmp/slide-a.svs,,asap,asap,success,1,/tmp/slide-a.stroma.coordinates.npz,/tmp/slide-a.stroma.coordinates.meta.json,,\n",
+        encoding="utf-8",
+    )
+
+    tiling_artifacts = [
+        SimpleNamespace(
+            sample_id="slide-a",
+            annotation="tumor",
+            mask_preview_path=Path("/tmp/preview/mask/slide-a.png"),
+            tiling_preview_path=Path("/tmp/preview/tiling/tumor/slide-a.png"),
+        ),
+        SimpleNamespace(
+            sample_id="slide-a",
+            annotation="stroma",
+            mask_preview_path=Path("/tmp/preview/mask/slide-a.png"),
+            tiling_preview_path=Path("/tmp/preview/tiling/stroma/slide-a.png"),
+        ),
+    ]
+
+    monkeypatch.setattr(tiling_pipeline, "tile_slides", lambda *args, **kwargs: tiling_artifacts)
+    monkeypatch.setattr(tiling_pipeline, "load_tiling_result_from_row", lambda row: SimpleNamespace())
+
+    slide = make_slide("slide-a")
+
+    tiling_pipeline.prepare_tiled_slides(
+        [slide],
+        DEFAULT_PREPROCESSING,
+        output_dir=tmp_path,
+        num_workers=0,
+    )
+
+    recorded = pd.read_csv(process_list_path).set_index("annotation")
+    # Shared multi-label mask preview on every row.
+    assert Path(recorded.loc["tumor", "mask_preview_path"]) == Path("/tmp/preview/mask/slide-a.png").resolve()
+    assert Path(recorded.loc["stroma", "mask_preview_path"]) == Path("/tmp/preview/mask/slide-a.png").resolve()
+    # Per-class tiling preview on its own row, not collapsed onto a single sample_id.
+    assert Path(recorded.loc["tumor", "tiling_preview_path"]) == Path("/tmp/preview/tiling/tumor/slide-a.png").resolve()
+    assert Path(recorded.loc["stroma", "tiling_preview_path"]) == Path("/tmp/preview/tiling/stroma/slide-a.png").resolve()
+
+
 def test_prepare_tiled_slides_resume_preserves_embedding_and_existing_preview_metadata(
     monkeypatch,
     tmp_path: Path,
@@ -4549,6 +4599,58 @@ def test_tile_slides_call_forwards_sampling_and_mask_for_annotation_mode(monkeyp
     assert captured["kwargs"]["selection_strategy"] == "independent_sampling"
     assert captured["kwargs"]["output_mode"] == "per_annotation"
     assert Path(captured["slides"][0].mask_path) == Path("/tmp/slide-a-mask.png")
+
+
+def test_tile_slides_call_forwards_preview_and_class_colors_for_annotation_mode(
+    monkeypatch, tmp_path: Path
+):
+    """Annotation mode must hand hs2p the PreviewConfig AND a sampling spec whose
+    color_mapping carries masks.colors, so the multi-label mask preview and per-class
+    tiling previews render with the configured colors."""
+    captured = {}
+
+    def fake_tile_slides(slides, **kwargs):
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(tiling_pipeline, "tile_slides", fake_tile_slides)
+
+    preprocessing = replace(
+        DEFAULT_PREPROCESSING,
+        on_the_fly=True,
+        masks={
+            "pixel_mapping": {"tumor": 2, "stroma": 3},
+            "colors": {"tumor": [255, 0, 0], "stroma": [0, 0, 255]},
+            "min_coverage": {"tumor": 0.5, "stroma": 0.5},
+        },
+        independent_sampling=True,
+    )
+    slide = manifest.coerce_slide_spec(
+        {
+            "sample_id": "slide-a",
+            "image_path": "/tmp/slide-a.svs",
+            "mask_path": "/tmp/slide-a-mask.png",
+        }
+    )
+
+    tiling_pipeline.tile_slides_call(
+        [slide],
+        preprocessing,
+        output_dir=tmp_path,
+        num_workers=0,
+    )
+
+    preview = captured["kwargs"]["preview"]
+    assert preview is not None
+    assert preview.save_mask_preview is True
+    assert preview.save_tiling_preview is True
+
+    sampling = captured["kwargs"]["sampling"]
+    assert sampling is not None
+    # masks.colors must reach the sampling spec hs2p uses to render the previews, so
+    # each class is drawn with its configured color.
+    assert sampling.color_mapping is not None
+    assert sampling.color_mapping["tumor"] == [255, 0, 0]
+    assert sampling.color_mapping["stroma"] == [0, 0, 255]
 
 
 def test_tile_slides_call_default_masks_block_forwards_no_sampling(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary

Issue 6/6 of the annotation feature-extraction series: ensure annotation-aware previews are produced and recorded.

- slide2vec already passes its hand-built `PreviewConfig` alongside the `sampling` spec into `tile_slides(...)`. The `sampling` spec's `color_mapping` carries `masks.colors` (wired in #155 via hs2p's `resolve_sampling_request`), so hs2p renders the multi-label mask preview (`preview/mask/`) and the per-class tiling previews (`preview/tiling/<class>/`) with the configured colors. No new rendering logic in slide2vec.
- Fix the process-list preview-path recording: it previously keyed on `sample_id` only, which collapsed annotation mode's one-row-per-`(sample_id, annotation)` layout (last-writer-wins, so every row got the same class's tiling preview). Recording now keys on the `(sample_id, annotation)` pair, so each per-class tiling preview lands on its own row. The multi-label mask preview (shared across a slide's classes) still maps to every row, and a `sample_id`-only fallback keeps the plain tissue/default path byte-for-byte unchanged.

## Tests

- `test_tile_slides_call_forwards_preview_and_class_colors_for_annotation_mode`: asserts `PreviewConfig` + `sampling` + `sampling.color_mapping` (carrying `masks.colors`) are forwarded together.
- `test_prepare_tiled_slides_records_per_annotation_preview_paths_in_process_list`: asserts per-class tiling previews are recorded on their own `(sample_id, annotation)` rows while the mask preview is shared.
- Existing tissue/default-path preview tests remain green (unchanged behavior).

Full suite: `python -m pytest tests/ -o addopts="" -p no:cacheprovider -q` -> 307 passed, 15 skipped.

Closes #159