### PR TITLE
Per-annotation slide embeddings (#156)

### DIFF
--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -30,6 +30,7 @@ class SlideEmbeddingArtifact:
     format: str
     feature_dim: int
     latent_path: Path | None = None
+    annotation: str | None = None
 
     @property
     def metadata(self) -> dict[str, Any]:
@@ -102,6 +103,26 @@ def tile_embeddings_subdir(annotation: str | None) -> str:
     if is_flattened_annotation(annotation):
         return "tile_embeddings"
     return f"tile_embeddings/{annotation}"
+
+
+def slide_embeddings_subdir(annotation: str | None) -> str:
+    """Namespace the ``slide_embeddings`` output dir per annotation class.
+
+    Reuses hs2p's flatten rule (the single source of truth, shared with
+    :func:`tile_embeddings_subdir`): ``None`` and the sentinel ``"tissue"`` collapse to the
+    flat ``slide_embeddings`` root, so the default tissue-only path is byte-for-byte
+    unchanged; any real class label gets its own ``slide_embeddings/<class>`` subdirectory.
+    """
+    if is_flattened_annotation(annotation):
+        return "slide_embeddings"
+    return f"slide_embeddings/{annotation}"
+
+
+def slide_latents_subdir(annotation: str | None) -> str:
+    """Namespace the ``slide_latents`` output dir per annotation class (mirrors slide embeddings)."""
+    if is_flattened_annotation(annotation):
+        return "slide_latents"
+    return f"slide_latents/{annotation}"
 
 
 def _setup_artifact_paths(
@@ -222,9 +243,12 @@ def write_slide_embeddings(
     output_format: str = "pt",
     metadata: dict[str, Any] | None = None,
     latents: Any | None = None,
+    annotation: str | None = None,
 ) -> SlideEmbeddingArtifact:
     output_format = _validate_output_format(output_format)
-    artifact_path, metadata_path = _setup_artifact_paths(output_dir, "slide_embeddings", sample_id, output_format)
+    artifact_path, metadata_path = _setup_artifact_paths(
+        output_dir, slide_embeddings_subdir(annotation), sample_id, output_format
+    )
     embedding_array = _ensure_array(embedding)
     latent_path = None
     if output_format == "pt":
@@ -232,7 +256,9 @@ def write_slide_embeddings(
     else:
         np.savez_compressed(artifact_path, features=embedding_array)
     if latents is not None:
-        latent_path, _ = _setup_artifact_paths(output_dir, "slide_latents", sample_id, output_format)
+        latent_path, _ = _setup_artifact_paths(
+            output_dir, slide_latents_subdir(annotation), sample_id, output_format
+        )
         if output_format == "pt":
             torch.save(_ensure_tensor(latents), latent_path)
         else:
@@ -254,6 +280,7 @@ def write_slide_embeddings(
         format=output_format,
         feature_dim=slide_metadata["feature_dim"],
         latent_path=latent_path,
+        annotation=annotation,
     )
 
 

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -156,6 +156,7 @@ def _reconcile_embedding_process_list(
     process_list_path,
     embeddable_slides,
     output_dir,
+    embeddable_tiling_results=None,
 ):
     """Reconcile the process_list with the embeddings on disk once, at end of run.
 
@@ -170,6 +171,15 @@ def _reconcile_embedding_process_list(
     persist_hierarchical_embeddings = hierarchical.is_hierarchical_preprocessing(preprocessing)
     include_slide_embeddings = model.level == "slide"
     include_tile_embeddings = persist_tile_embeddings and not persist_hierarchical_embeddings
+    annotations = None
+    if include_slide_embeddings and embeddable_tiling_results is not None:
+        # Re-read each class's namespaced slide-embedding artifact so the final reconcile
+        # records the per-class feature path instead of collapsing every annotation row
+        # onto the flat path. The default tissue-only path leaves annotations None.
+        annotations = [
+            embedding.tiling_result_annotation(tiling_result)
+            for tiling_result in embeddable_tiling_results
+        ]
     tile_artifacts, hierarchical_artifacts, slide_artifacts = artifacts_collect.collect_pipeline_artifacts(
         embeddable_slides,
         output_dir=output_dir,
@@ -177,6 +187,7 @@ def _reconcile_embedding_process_list(
         include_tile_embeddings=include_tile_embeddings,
         include_hierarchical_embeddings=persist_hierarchical_embeddings,
         include_slide_embeddings=include_slide_embeddings,
+        annotations=annotations,
     )
     if process_list_path is not None and Path(process_list_path).is_file():
         persistence.update_process_list_after_embedding(
@@ -323,6 +334,7 @@ def embed_slides(
                     process_list_path=process_list_path,
                     embeddable_slides=embeddable_slides,
                     output_dir=Path(execution.output_dir),
+                    embeddable_tiling_results=embeddable_tiling_results,
                 )
             emit_progress(
                 "embedding.finished",
@@ -855,6 +867,7 @@ def run_pipeline(
             process_list_path=process_list_path,
             embeddable_slides=embeddable_slides,
             output_dir=output_dir,
+            embeddable_tiling_results=embeddable_tiling_results,
         )
         emit_progress(
             "embedding.finished",
@@ -975,6 +988,7 @@ def run_pipeline_with_coordinates(
             process_list_path=process_list_path,
             embeddable_slides=embeddable_slides,
             output_dir=output_dir,
+            embeddable_tiling_results=embeddable_tiling_results,
         )
         return RunResult(
             tile_artifacts=tile_artifacts,

--- a/slide2vec/runtime/embedding.py
+++ b/slide2vec/runtime/embedding.py
@@ -138,6 +138,7 @@ def write_slide_embedding_artifact(
     execution: ExecutionOptions,
     metadata: dict[str, Any],
     latents=None,
+    annotation: str | None = None,
 ) -> SlideEmbeddingArtifact:
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required to persist slide embeddings")
@@ -148,6 +149,7 @@ def write_slide_embedding_artifact(
         output_format=execution.output_format,
         metadata=metadata,
         latents=latents,
+        annotation=annotation,
     )
 
 

--- a/slide2vec/runtime/embedding_persist.py
+++ b/slide2vec/runtime/embedding_persist.py
@@ -131,5 +131,6 @@ def persist_embedded_slide(
             execution=execution,
             metadata=build_slide_embedding_metadata(model, image_path=embedded_slide.image_path),
             latents=embedded_slide.latents,
+            annotation=annotation,
         )
     return tile_artifact, slide_artifact

--- a/slide2vec/runtime/persist_callbacks.py
+++ b/slide2vec/runtime/persist_callbacks.py
@@ -3,13 +3,18 @@
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
+import pandas as pd
 from hs2p import SlideSpec
+from hs2p.fileops import is_flattened_annotation
 
 from slide2vec.api import EmbeddedSlide, ExecutionOptions, PreprocessingConfig
 from slide2vec.artifacts import (
     HierarchicalEmbeddingArtifact,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
+    slide_embeddings_subdir,
+    slide_latents_subdir,
+    tile_embeddings_subdir,
 )
 from slide2vec.runtime.embedding import should_persist_tile_embeddings
 from slide2vec.runtime.embedding_persist import persist_embedded_slide
@@ -38,28 +43,52 @@ def has_complete_local_embedding_outputs(
     persist_hierarchical_embeddings: bool,
     include_slide_embeddings: bool,
     save_latents: bool,
+    annotation: str | None = None,
 ) -> bool:
+    tile_subdir = tile_embeddings_subdir(annotation)
     if persist_hierarchical_embeddings:
         hierarchical_artifact_path = output_dir / "hierarchical_embeddings" / f"{sample_id}.{output_format}"
         if not hierarchical_artifact_path.is_file():
             return False
     elif persist_tile_embeddings:
-        tile_artifact_path = output_dir / "tile_embeddings" / f"{sample_id}.{output_format}"
+        tile_artifact_path = output_dir / tile_subdir / f"{sample_id}.{output_format}"
         if not tile_artifact_path.is_file():
             return False
     if include_slide_embeddings:
-        slide_artifact_path = output_dir / "slide_embeddings" / f"{sample_id}.{output_format}"
+        slide_subdir = slide_embeddings_subdir(annotation)
+        slide_artifact_path = output_dir / slide_subdir / f"{sample_id}.{output_format}"
         if not slide_artifact_path.is_file():
             return False
         if save_latents:
             latent_suffix = "pt" if output_format == "pt" else "npz"
-            latent_path = output_dir / "slide_latents" / f"{sample_id}.{latent_suffix}"
+            latent_path = output_dir / slide_latents_subdir(annotation) / f"{sample_id}.{latent_suffix}"
             if not latent_path.is_file():
                 return False
     return True
 
 
-def completed_local_embedding_sample_ids(
+def _normalized_resume_annotation(annotation) -> str | None:
+    """Collapse flat-layout sentinels (``None``/NaN/``"tissue"``) to a single ``None`` key.
+
+    Resume keys must agree across the process-list rows (which carry ``"tissue"`` for the
+    default path) and the in-memory tiling results (which may carry ``None``), and must line
+    up with the namespaced slide-embedding artifact paths (where tissue/None are flat). One
+    normalization rule, shared by both sides, keeps the default tissue path's single resume
+    key stable while giving real classes their own keys.
+    """
+    if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
+        return None
+    if is_flattened_annotation(str(annotation)):
+        return None
+    return str(annotation)
+
+
+def _row_annotation(row) -> str | None:
+    """Normalized annotation carried by a process-list row (flat-layout aware)."""
+    return _normalized_resume_annotation(row.get("annotation"))
+
+
+def completed_local_embedding_keys(
     process_list_path: Path,
     *,
     output_dir: Path,
@@ -68,14 +97,23 @@ def completed_local_embedding_sample_ids(
     persist_hierarchical_embeddings: bool,
     include_slide_embeddings: bool,
     save_latents: bool,
-) -> set[str]:
+) -> set[tuple[str, str | None]]:
+    """Completed (sample_id, annotation) keys for local resume.
+
+    Keying by ``(sample_id, annotation)`` (rather than ``sample_id`` alone) lets a multi-
+    label slide resume per class: a class whose namespaced slide/tile artifact is still
+    missing stays pending even when a sibling class on the same slide is complete. The flat
+    tissue-only path normalizes its annotation to ``None`` so its single-row behaviour is
+    unchanged.
+    """
     process_df = load_embedding_process_df(
         process_list_path,
         include_aggregation_status=include_slide_embeddings,
     )
-    completed_ids: set[str] = set()
+    completed_keys: set[tuple[str, str | None]] = set()
     for row in process_df.to_dict("records"):
         sample_id = str(row["sample_id"])
+        annotation = _row_annotation(row)
         if "tiling_status" not in row or row["tiling_status"] != "success":
             continue
         if persist_tile_embeddings and ("feature_status" not in row or row["feature_status"] != "success"):
@@ -90,10 +128,11 @@ def completed_local_embedding_sample_ids(
             persist_hierarchical_embeddings=persist_hierarchical_embeddings,
             include_slide_embeddings=include_slide_embeddings,
             save_latents=save_latents,
+            annotation=annotation,
         ):
             continue
-        completed_ids.add(sample_id)
-    return completed_ids
+        completed_keys.add((sample_id, annotation))
+    return completed_keys
 
 
 def pending_local_embedding_records(
@@ -112,7 +151,7 @@ def pending_local_embedding_records(
     if not resume:
         return list(successful_slides), list(tiling_results)
 
-    completed_ids = completed_local_embedding_sample_ids(
+    completed_keys = completed_local_embedding_keys(
         process_list_path,
         output_dir=output_dir,
         output_format=output_format,
@@ -124,11 +163,22 @@ def pending_local_embedding_records(
     pending_slides: list[SlideSpec] = []
     pending_tiling_results: list[Any] = []
     for slide, tiling_result in zip(successful_slides, tiling_results):
-        if slide.sample_id in completed_ids:
+        annotation = _tiling_result_annotation(tiling_result)
+        if (slide.sample_id, annotation) in completed_keys:
             continue
         pending_slides.append(slide)
         pending_tiling_results.append(tiling_result)
     return pending_slides, pending_tiling_results
+
+
+def _tiling_result_annotation(tiling_result) -> str | None:
+    """Normalized annotation carried by a tiling result (flat-layout aware).
+
+    ``None`` placeholders (the distributed path passes ``None`` for each tiling result) and
+    the ``"tissue"`` sentinel collapse to ``None`` so resume keys line up with the flat
+    slide-embedding artifact paths.
+    """
+    return _normalized_resume_annotation(getattr(tiling_result, "annotation", None))
 
 
 def build_incremental_persist_callback(

--- a/slide2vec/runtime/persistence.py
+++ b/slide2vec/runtime/persistence.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Sequence
 
+import numpy as np
 import pandas as pd
 from hs2p import SlideSpec
+from hs2p.fileops import is_flattened_annotation
 
 from slide2vec.artifacts import (
     HierarchicalEmbeddingArtifact,
@@ -12,6 +14,8 @@ from slide2vec.artifacts import (
     TileEmbeddingArtifact,
     load_array,
     load_metadata,
+    slide_embeddings_subdir,
+    slide_latents_subdir,
 )
 from slide2vec.utils.tiling_io import atomic_write_dataframe_csv
 
@@ -24,15 +28,22 @@ def collect_pipeline_artifacts(
     include_tile_embeddings: bool,
     include_hierarchical_embeddings: bool,
     include_slide_embeddings: bool,
+    annotations: Sequence[str | None] | None = None,
 ) -> tuple[
     list[TileEmbeddingArtifact],
     list[HierarchicalEmbeddingArtifact],
     list[SlideEmbeddingArtifact],
 ]:
+    # ``annotations`` (parallel to ``slide_records``) namespaces the per-class slide-
+    # embedding artifacts back from disk so the end-of-run reconcile re-reads each class's
+    # own ``slide_embeddings/<class>/<id>`` path. When omitted (the default tissue-only
+    # path) slide artifacts load flat, byte-for-byte unchanged.
+    if annotations is None:
+        annotations = [None] * len(slide_records)
     tile_artifacts: list[TileEmbeddingArtifact] = []
     hierarchical_artifacts: list[HierarchicalEmbeddingArtifact] = []
     slide_artifacts: list[SlideEmbeddingArtifact] = []
-    for slide in slide_records:
+    for slide, annotation in zip(slide_records, annotations):
         if include_tile_embeddings:
             tile_artifacts.append(load_tile_artifact(slide.sample_id, output_dir=output_dir, output_format=output_format))
         if include_hierarchical_embeddings:
@@ -41,7 +52,12 @@ def collect_pipeline_artifacts(
             )
         if include_slide_embeddings:
             slide_artifacts.append(
-                load_slide_artifact(slide.sample_id, output_dir=output_dir, output_format=output_format)
+                load_slide_artifact(
+                    slide.sample_id,
+                    output_dir=output_dir,
+                    output_format=output_format,
+                    annotation=annotation,
+                )
             )
     return tile_artifacts, hierarchical_artifacts, slide_artifacts
 
@@ -96,9 +112,16 @@ def load_hierarchical_artifact(
     )
 
 
-def load_slide_artifact(sample_id: str, *, output_dir: Path, output_format: str) -> SlideEmbeddingArtifact:
-    artifact_path = output_dir / "slide_embeddings" / f"{sample_id}.{output_format}"
-    metadata_path = output_dir / "slide_embeddings" / f"{sample_id}.meta.json"
+def load_slide_artifact(
+    sample_id: str,
+    *,
+    output_dir: Path,
+    output_format: str,
+    annotation: str | None = None,
+) -> SlideEmbeddingArtifact:
+    slide_dir = output_dir / slide_embeddings_subdir(annotation)
+    artifact_path = slide_dir / f"{sample_id}.{output_format}"
+    metadata_path = slide_dir / f"{sample_id}.meta.json"
     if metadata_path.is_file():
         metadata = load_metadata(metadata_path)
         feature_dim = int(metadata["feature_dim"])
@@ -106,7 +129,7 @@ def load_slide_artifact(sample_id: str, *, output_dir: Path, output_format: str)
         embedding = load_array(artifact_path)
         feature_dim = int(embedding.shape[-1]) if getattr(embedding, "ndim", 0) else 1
     latent_suffix = "pt" if output_format == "pt" else "npz"
-    latent_path = output_dir / "slide_latents" / f"{sample_id}.{latent_suffix}"
+    latent_path = output_dir / slide_latents_subdir(annotation) / f"{sample_id}.{latent_suffix}"
     return SlideEmbeddingArtifact(
         sample_id=sample_id,
         path=artifact_path,
@@ -114,6 +137,7 @@ def load_slide_artifact(sample_id: str, *, output_dir: Path, output_format: str)
         format=output_format,
         feature_dim=feature_dim,
         latent_path=latent_path if latent_path.is_file() else None,
+        annotation=annotation,
     )
 
 
@@ -151,38 +175,109 @@ def update_process_list_after_embedding(
     tile_success_ids = {artifact.sample_id for artifact in tile_artifacts}
     hierarchical_success_ids = {artifact.sample_id for artifact in hierarchical_artifacts}
     slide_success_ids = {artifact.sample_id for artifact in slide_artifacts}
+    # Slide embeddings fan out per (sample_id, annotation): keep a per-class feature-path
+    # map (and per-class success set) so a multi-label slide records a distinct slide-
+    # embedding path on each annotation row instead of collapsing them all onto one path.
+    # Tissue/None annotations stay in the flat slot, so the default single-row path is
+    # byte-for-byte unchanged. Tile/hierarchical artifacts are sample_id-keyed (their per-
+    # class fan-out is wired by their own slices), so they map to a None annotation key.
+    slide_path_by_key = {
+        (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(artifact.path)
+        for artifact in slide_artifacts
+    }
+    slide_success_keys = {
+        (artifact.sample_id, _normalized_annotation(artifact.annotation)) for artifact in slide_artifacts
+    }
     if slide_artifacts:
-        feature_path_by_sample_id = {artifact.sample_id: _resolve_path_str(artifact.path) for artifact in slide_artifacts}
+        feature_path_by_key = slide_path_by_key
         feature_kind = "slide"
         feature_success_ids = slide_success_ids
     elif persist_hierarchical_embeddings:
-        feature_path_by_sample_id = {
-            artifact.sample_id: _resolve_path_str(artifact.path) for artifact in hierarchical_artifacts
+        feature_path_by_key = {
+            (artifact.sample_id, None): _resolve_path_str(artifact.path) for artifact in hierarchical_artifacts
         }
         feature_kind = "hierarchical"
         feature_success_ids = hierarchical_success_ids
     elif persist_tile_embeddings:
-        feature_path_by_sample_id = {
-            artifact.sample_id: _resolve_path_str(artifact.path) for artifact in tile_artifacts
+        feature_path_by_key = {
+            (artifact.sample_id, None): _resolve_path_str(artifact.path) for artifact in tile_artifacts
         }
         feature_kind = "tile"
         feature_success_ids = tile_success_ids
     else:
-        feature_path_by_sample_id = {}
+        feature_path_by_key = {}
         feature_kind = None
         feature_success_ids = {slide.sample_id for slide in successful_slides}
+    annotation_aware = bool(slide_artifacts)
+    row_annotations = _row_annotation_series(df)
     for slide in successful_slides:
         mask = df["sample_id"].astype(str) == slide.sample_id
         feature_status = "success" if slide.sample_id in feature_success_ids else "error"
         df.loc[mask, "feature_status"] = feature_status
-        mapped_feature_path = feature_path_by_sample_id.get(slide.sample_id)
-        if mapped_feature_path is not None:
-            df.loc[mask, "feature_path"] = mapped_feature_path
-            df.loc[mask, "encoder_name"] = encoder_name
-            df.loc[mask, "output_variant"] = output_variant
-            df.loc[mask, "feature_kind"] = feature_kind
-        if include_slide_embeddings:
-            df.loc[mask, "aggregation_status"] = (
-                "success" if slide.sample_id in slide_success_ids else "error"
-            )
+        if annotation_aware:
+            # Resolve each (sample_id, annotation) row independently so per-class paths and
+            # aggregation statuses don't bleed across the slide's other annotation rows.
+            for annotation in _row_annotations(row_annotations, mask):
+                # ``== None`` is element-wise False in pandas, so match the flat None key
+                # via isna() and real classes via equality.
+                if annotation is None:
+                    row_mask = mask & row_annotations.isna()
+                else:
+                    row_mask = mask & (row_annotations == annotation)
+                key = (slide.sample_id, annotation)
+                mapped_feature_path = feature_path_by_key.get(key)
+                if mapped_feature_path is not None:
+                    df.loc[row_mask, "feature_path"] = mapped_feature_path
+                    df.loc[row_mask, "encoder_name"] = encoder_name
+                    df.loc[row_mask, "output_variant"] = output_variant
+                    df.loc[row_mask, "feature_kind"] = feature_kind
+                if include_slide_embeddings:
+                    df.loc[row_mask, "aggregation_status"] = (
+                        "success" if key in slide_success_keys else "error"
+                    )
+        else:
+            mapped_feature_path = feature_path_by_key.get((slide.sample_id, None))
+            if mapped_feature_path is not None:
+                df.loc[mask, "feature_path"] = mapped_feature_path
+                df.loc[mask, "encoder_name"] = encoder_name
+                df.loc[mask, "output_variant"] = output_variant
+                df.loc[mask, "feature_kind"] = feature_kind
+            if include_slide_embeddings:
+                df.loc[mask, "aggregation_status"] = (
+                    "success" if slide.sample_id in slide_success_ids else "error"
+                )
     atomic_write_dataframe_csv(df, process_list_path)
+
+
+def _normalized_annotation(annotation: Any) -> str | None:
+    """Collapse the flat-layout sentinels (``None``/``"tissue"``) to a single ``None`` key.
+
+    Keying the per-class feature-path map on this normalized value lets the flat tissue-only
+    path and a real class share one matching rule without the sentinel leaking into lookups.
+    """
+    if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
+        return None
+    if is_flattened_annotation(str(annotation)):
+        return None
+    return str(annotation)
+
+
+def _row_annotation_series(df: pd.DataFrame) -> pd.Series:
+    """Per-row normalized annotation series aligned to the flat-layout key convention.
+
+    Flat-layout rows (``None``/NaN/``"tissue"``) become ``NaN`` so they can be matched with
+    ``isna()``; real classes keep their string label.
+    """
+    if "annotation" not in df.columns:
+        return pd.Series([np.nan] * len(df), index=df.index, dtype=object)
+    return df["annotation"].map(lambda value: _normalized_annotation(value) or np.nan)
+
+
+def _row_annotations(row_annotations: pd.Series, mask: pd.Series) -> list[str | None]:
+    """Distinct normalized annotations present in the masked rows (``None`` for flat rows)."""
+    seen: list[str | None] = []
+    for value in row_annotations[mask].tolist():
+        normalized = None if value is None or (isinstance(value, float) and pd.isna(value)) else value
+        if normalized not in seen:
+            seen.append(normalized)
+    return seen

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -4558,6 +4558,257 @@ def test_persist_embedded_slide_namespaces_tile_embeddings_per_class(tmp_path: P
     assert none_artifact.path == tmp_path / "tile_embeddings" / "slide-a.pt"
 
 
+# --- Issue #156: per-annotation slide embeddings (top-seam) ---
+
+
+def test_persist_embedded_slide_namespaces_slide_embeddings_per_class(tmp_path: Path):
+    """Slide embeddings land under slide_embeddings/<class>/ for real classes; tissue/None stay flat.
+
+    Each active class gets its own pooled slide embedding namespaced by class, reusing the
+    same flatten rule as tile embeddings, and the artifact carries its annotation.
+    """
+    model = SimpleNamespace(name="prov-gigapath", level="slide")
+    execution = ExecutionOptions(output_dir=tmp_path, save_tile_embeddings=False)
+
+    def _persist(annotation):
+        tiling_result = SimpleNamespace(
+            x=np.array([0], dtype=np.int64),
+            y=np.array([1], dtype=np.int64),
+            tile_size_lv0=224,
+            num_tiles=1,
+            backend="asap",
+            annotation=annotation,
+            coordinates_npz_path=Path("/tmp/c.npz"),
+            coordinates_meta_path=Path("/tmp/c.meta.json"),
+            tiles_tar_path=None,
+        )
+        embedded = EmbeddedSlide(
+            sample_id="slide-a",
+            tile_embeddings=np.zeros((1, 4), dtype=np.float32),
+            slide_embedding=np.zeros((8,), dtype=np.float32),
+            x=np.array([0], dtype=np.int64),
+            y=np.array([1], dtype=np.int64),
+            tile_size_lv0=224,
+            image_path=Path("/tmp/slide-a.svs"),
+            mask_path=Path("/tmp/slide-a-mask.png"),
+        )
+        _, slide_artifact = embedding_persist.persist_embedded_slide(
+            model,
+            embedded,
+            tiling_result,
+            preprocessing=DEFAULT_PREPROCESSING,
+            execution=execution,
+        )
+        return slide_artifact
+
+    tumor_artifact = _persist("tumor")
+    assert tumor_artifact.path == tmp_path / "slide_embeddings" / "tumor" / "slide-a.pt"
+    assert tumor_artifact.annotation == "tumor"
+
+    tissue_artifact = _persist("tissue")
+    assert tissue_artifact.path == tmp_path / "slide_embeddings" / "slide-a.pt"
+    assert tissue_artifact.annotation == "tissue"
+
+    none_artifact = _persist(None)
+    assert none_artifact.path == tmp_path / "slide_embeddings" / "slide-a.pt"
+    assert none_artifact.annotation is None
+
+
+def test_update_process_list_records_per_class_slide_feature_paths(tmp_path: Path):
+    """A multi-label slide records a distinct per-class slide-embedding feature path on each
+    (sample_id, annotation) row rather than collapsing them onto one path."""
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+
+    tumor_artifact = write_slide_embeddings(
+        "slide-a",
+        np.zeros((8,), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tumor",
+    )
+    stroma_artifact = write_slide_embeddings(
+        "slide-a",
+        np.zeros((8,), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="stroma",
+    )
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    persistence.update_process_list_after_embedding(
+        process_list_path,
+        successful_slides=[slide, slide],
+        persist_tile_embeddings=False,
+        persist_hierarchical_embeddings=False,
+        include_slide_embeddings=True,
+        encoder_name="prov-gigapath",
+        output_variant=None,
+        tile_artifacts=[],
+        hierarchical_artifacts=[],
+        slide_artifacts=[tumor_artifact, stroma_artifact],
+    )
+
+    df = pd.read_csv(process_list_path)
+    tumor_row = df[df["annotation"] == "tumor"].iloc[0]
+    stroma_row = df[df["annotation"] == "stroma"].iloc[0]
+    assert tumor_row["feature_path"] == str((tmp_path / "slide_embeddings" / "tumor" / "slide-a.pt").resolve())
+    assert stroma_row["feature_path"] == str((tmp_path / "slide_embeddings" / "stroma" / "slide-a.pt").resolve())
+    assert tumor_row["aggregation_status"] == "success"
+    assert stroma_row["aggregation_status"] == "success"
+
+
+def test_resume_gate_keys_slide_embeddings_by_sample_id_and_annotation(tmp_path: Path):
+    """Local resume dedups pending work by (sample_id, annotation) for slide embeddings: a class
+    whose slide artifact is missing stays pending even when a sibling class is complete."""
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+    # Mark both rows feature/aggregation success in the CSV...
+    df = pd.read_csv(process_list_path)
+    df["feature_status"] = "success"
+    df["aggregation_status"] = "success"
+    df.to_csv(process_list_path, index=False)
+
+    # ...but only the tumor slide artifact exists on disk.
+    write_slide_embeddings(
+        "slide-a",
+        np.zeros((8,), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tumor",
+    )
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    tumor_tr = SimpleNamespace(annotation="tumor")
+    stroma_tr = SimpleNamespace(annotation="stroma")
+    pending_slides, pending_results = persist_callbacks.pending_local_embedding_records(
+        [slide, slide],
+        [tumor_tr, stroma_tr],
+        process_list_path=process_list_path,
+        output_dir=tmp_path,
+        output_format="pt",
+        persist_tile_embeddings=False,
+        persist_hierarchical_embeddings=False,
+        include_slide_embeddings=True,
+        save_latents=False,
+        resume=True,
+    )
+
+    assert [tr.annotation for tr in pending_results] == ["stroma"]
+    assert len(pending_slides) == 1
+
+
+def test_collect_pipeline_artifacts_reloads_per_class_slide_embeddings(tmp_path: Path):
+    """The end-of-run reconcile reloads each class's namespaced slide-embedding artifact when
+    given per-row annotations, so the per-class feature path is recorded rather than the flat one."""
+    write_slide_embeddings(
+        "slide-a",
+        np.zeros((8,), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tumor",
+    )
+    write_slide_embeddings(
+        "slide-a",
+        np.zeros((8,), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="stroma",
+    )
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    _, _, slide_artifacts = persistence.collect_pipeline_artifacts(
+        [slide, slide],
+        output_dir=tmp_path,
+        output_format="pt",
+        include_tile_embeddings=False,
+        include_hierarchical_embeddings=False,
+        include_slide_embeddings=True,
+        annotations=["tumor", "stroma"],
+    )
+
+    assert [a.path for a in slide_artifacts] == [
+        tmp_path / "slide_embeddings" / "tumor" / "slide-a.pt",
+        tmp_path / "slide_embeddings" / "stroma" / "slide-a.pt",
+    ]
+    assert [a.annotation for a in slide_artifacts] == ["tumor", "stroma"]
+
+
 def test_tile_slides_call_forwards_sampling_and_mask_for_annotation_mode(monkeypatch, tmp_path: Path):
     """Customized masks block forwards a sampling spec, selection strategy, output mode AND the
     slide's annotation mask to hs2p — the wiring that lets hs2p enforce a required raster."""


### PR DESCRIPTION
## Annotation feature extraction 3/6: per-annotation slide embeddings

Extends the per-annotation fan-out (from #155) to slide embeddings. Each active class gets its own pooled slide embedding (mean-pool of that class's tiles), namespaced by class using the same `hs2p.fileops.is_flattened_annotation` flatten rule as tile embeddings: real classes land under `slide_embeddings/<class>/<id>`, while `tissue`/`None` stay flat.

### What changed
- `artifacts.py`: added `slide_embeddings_subdir` / `slide_latents_subdir` (mirroring `tile_embeddings_subdir`); threaded `annotation` through `write_slide_embeddings`; `SlideEmbeddingArtifact` now carries its `annotation`.
- `embedding.py` / `embedding_persist.py`: thread the tiling result's annotation onto the persisted slide-embedding artifact.
- `persistence.py`: resolved the #155 deferral — `update_process_list_after_embedding` now keys the slide-embedding `feature_path` (and `aggregation_status`) by `(sample_id, annotation)` so per-class rows each record their own path; `collect_pipeline_artifacts` / `load_slide_artifact` reload the namespaced artifact for the end-of-run reconcile.
- `persist_callbacks.py`: the local resume gate now dedups pending work by `(sample_id, annotation)`, so a class whose slide artifact is missing stays pending even when a sibling class is complete.
- `inference.py`: the single-GPU reconcile passes per-row annotations so it re-reads each class's namespaced slide embedding instead of collapsing onto the flat path.

The default tissue-only path (one flat row per `sample_id`) is unchanged.

### Scope
Slide-level embeddings only. Hierarchical/region embeddings (#157) are untouched.

### Testing
Top-seam tests added in `tests/test_regression_inference.py`, mirroring the #155 per-annotation tests:
- `test_persist_embedded_slide_namespaces_slide_embeddings_per_class`
- `test_update_process_list_records_per_class_slide_feature_paths`
- `test_resume_gate_keys_slide_embeddings_by_sample_id_and_annotation`
- `test_collect_pipeline_artifacts_reloads_per_class_slide_embeddings`

Full suite: `309 passed, 15 skipped`.

Closes #156