### PR TITLE
Merged output mode + sampling-strategy knob (#158)

### DIFF
--- a/slide2vec/configs/default.yaml
+++ b/slide2vec/configs/default.yaml
@@ -26,7 +26,7 @@ tiling:
   read_coordinates_from: # path to an existing directory containing pre-extracted `.coordinates.npz` / `.coordinates.meta.json` artifacts to reuse instead of starting tiling from scratch
   read_tiles_from: # path to an existing directory containing pre-extracted `.tiles.tar` tile stores to reuse instead of starting tiling from scratch
   backend: "auto" # backend to use for slide reading; "auto" lets hs2p resolve the best backend per slide, preferring cuCIM when available
-  independent_sampling: true # when annotation sampling is active, tile each class separately (independent selection) vs jointly across classes
+  independent_sampling: true # selection strategy when annotation sampling is active. true: sample each class independently against its own binary mask (independent selection); false: sample once over the union of active classes, then post-filter per class by coverage (joint selection). Ignored when the masks vocabulary is left at the tissue-only default.
   masks:
     # Annotation-mask vocabulary forwarded to hs2p's sampling resolver. The shipped default
     # ({background:0, tissue:1}) is plain binary tissue tiling — leave it untouched and the run
@@ -34,7 +34,7 @@ tiling:
     # class with its own pixel value + min_coverage) opts the run into annotation-aware sampling,
     # where `mask_path` is read as a multi-label raster. The `tissue` min_coverage entry below is
     # the single source of truth for the tissue threshold.
-    output_mode: per_annotation # per_annotation: one artifact set per sampled class | merged: one set per slide (union of tiles passing any class threshold)
+    output_mode: per_annotation # how sampled tiles are grouped into artifacts. per_annotation: one flat artifact set per sampled class, namespaced under a `<class>/` subdir (the `tissue` class collapses to the flat root). merged: a single flat artifact set per slide over the union of tiles passing any active class threshold — it carries no class label, so it lands at the flat output root (no `<class>/` subdir).
     pixel_mapping: # {class_name: integer pixel value in the mask raster}
       background: 0
       tissue: 1

--- a/slide2vec/utils/tiling_io.py
+++ b/slide2vec/utils/tiling_io.py
@@ -241,7 +241,15 @@ def load_tiling_result_from_row(row):
     annotation = row.get("annotation")
     if annotation is not None and pd.isna(annotation):
         annotation = None
-    setattr(tiling_result, "annotation", annotation if annotation is None else str(annotation))
+    annotation = annotation if annotation is None else str(annotation)
+    # The merged output mode (hs2p's CoordinateOutputMode.MERGED) emits a single per-slide
+    # coordinate set over the union of tiles passing any active class threshold. hs2p labels
+    # that process-list row "merged" so it is not mistaken for plain tissue, but it carries no
+    # class — collapse it to None here so the flatten rule (is_flattened_annotation) lands its
+    # artifacts at the flat output root, with no per-class subdir.
+    if annotation == "merged":
+        annotation = None
+    setattr(tiling_result, "annotation", annotation)
     setattr(tiling_result, "tiles_tar_path", _optional_path(row.get("tiles_tar_path")))
     setattr(tiling_result, "mask_preview_path", _optional_path(row.get("mask_preview_path")))
     setattr(tiling_result, "tiling_preview_path", _optional_path(row.get("tiling_preview_path")))

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -801,6 +801,85 @@ def test_customized_masks_block_yields_independent_per_annotation_sampling():
     assert output_mode == "per_annotation"
 
 
+def test_merged_output_mode_yields_merged_with_joint_selection():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = _masks_preprocessing(
+        {
+            "output_mode": "merged",
+            "pixel_mapping": {"tumor": 2},
+            "colors": {"tumor": [255, 0, 0]},
+            "min_coverage": {"tumor": 0.5},
+        },
+        independent_sampling=False,
+    )
+
+    configs = build_hs2p_configs(preprocessing)
+    sampling, selection_strategy, output_mode = configs[-3], configs[-2], configs[-1]
+
+    assert sampling is not None
+    assert output_mode == "merged"
+    assert selection_strategy == "joint_sampling"
+
+
+def test_independent_sampling_toggle_selects_selection_strategy():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    customized = {
+        "pixel_mapping": {"tumor": 2},
+        "colors": {"tumor": [255, 0, 0]},
+        "min_coverage": {"tumor": 0.5},
+    }
+
+    independent = build_hs2p_configs(
+        _masks_preprocessing(customized, independent_sampling=True)
+    )
+    joint = build_hs2p_configs(
+        _masks_preprocessing(customized, independent_sampling=False)
+    )
+
+    assert independent[-2] == "independent_sampling"
+    assert joint[-2] == "joint_sampling"
+
+
+def test_merged_annotation_label_collapses_to_flat_root(tmp_path: Path):
+    """A merged tiling row is labelled ``merged`` by hs2p, but carries no class — it must
+    collapse to the flat output root (no per-class subdir), exactly like tissue/None."""
+    from slide2vec.utils.tiling_io import load_tiling_result_from_row
+
+    coordinates_meta_path = tmp_path / "slide-a.coordinates.meta.json"
+    coordinates_meta_path.write_text("{}", encoding="utf-8")
+
+    def fake_load_tiling_result(**kwargs):
+        return SimpleNamespace()
+
+    import slide2vec.utils.tiling_io as tiling_io
+
+    original = tiling_io.load_tiling_result
+    tiling_io.load_tiling_result = fake_load_tiling_result
+    try:
+        result = load_tiling_result_from_row(
+            {
+                "annotation": "merged",
+                "coordinates_npz_path": str(tmp_path / "slide-a.coordinates.npz"),
+                "coordinates_meta_path": str(coordinates_meta_path),
+            }
+        )
+    finally:
+        tiling_io.load_tiling_result = original
+
+    # Merged carries no class label; the flatten rule sends it to the flat root.
+    assert result.annotation is None
+    artifact = write_tile_embeddings(
+        "slide-a",
+        np.arange(8, dtype=np.float32).reshape(2, 4),
+        output_dir=tmp_path,
+        output_format="npz",
+        annotation=result.annotation,
+    )
+    assert artifact.path == tmp_path / "tile_embeddings" / "slide-a.npz"
+
+
 def test_invalid_masks_block_with_duplicate_pixel_values_fails_fast():
     from slide2vec.runtime.tiling import build_hs2p_configs
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1722,6 +1722,117 @@ def test_tile_slides_skips_saving_tiles_when_external_store_is_configured(monkey
     assert captured["kwargs"]["save_tiles"] is False
 
 
+def test_tile_slides_forwards_merged_output_mode_and_selection_strategy(monkeypatch, tmp_path: Path):
+    """End-to-end seam: a ``merged`` masks block with ``independent_sampling: false`` must
+    forward output_mode=merged and selection_strategy=joint_sampling into hs2p's tile_slides."""
+    import slide2vec.inference as inference
+
+    captured = {}
+
+    def fake_tile_slides(slides, **kwargs):
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(tiling_pipeline, "tile_slides", fake_tile_slides)
+
+    preprocessing = replace(
+        DEFAULT_PREPROCESSING,
+        backend="asap",
+        requested_spacing_um=0.5,
+        requested_tile_size_px=224,
+        masks={
+            "output_mode": "merged",
+            "pixel_mapping": {"tumor": 2},
+            "colors": {"tumor": [255, 0, 0]},
+            "min_coverage": {"tumor": 0.5},
+        },
+        independent_sampling=False,
+    )
+
+    tiling_pipeline.tile_slides_call(
+        [make_slide("slide-a")],
+        preprocessing,
+        output_dir=tmp_path,
+        num_workers=0,
+    )
+
+    assert captured["kwargs"]["output_mode"] == "merged"
+    assert captured["kwargs"]["selection_strategy"] == "joint_sampling"
+    assert captured["kwargs"]["sampling"] is not None
+
+
+def test_tile_slides_forwards_independent_sampling_selection_strategy(monkeypatch, tmp_path: Path):
+    import slide2vec.inference as inference
+
+    captured = {}
+
+    def fake_tile_slides(slides, **kwargs):
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(tiling_pipeline, "tile_slides", fake_tile_slides)
+
+    preprocessing = replace(
+        DEFAULT_PREPROCESSING,
+        backend="asap",
+        requested_spacing_um=0.5,
+        requested_tile_size_px=224,
+        masks={
+            "pixel_mapping": {"tumor": 2},
+            "colors": {"tumor": [255, 0, 0]},
+            "min_coverage": {"tumor": 0.5},
+        },
+        independent_sampling=True,
+    )
+
+    tiling_pipeline.tile_slides_call(
+        [make_slide("slide-a")],
+        preprocessing,
+        output_dir=tmp_path,
+        num_workers=0,
+    )
+
+    assert captured["kwargs"]["selection_strategy"] == "independent_sampling"
+    assert captured["kwargs"]["output_mode"] == "per_annotation"
+
+
+def test_prepare_tiled_slides_collapses_merged_row_to_flat_root(monkeypatch, tmp_path: Path):
+    """A merged tiling row (hs2p labels it ``merged``) must load with annotation=None so its
+    embedding artifacts land at the flat output root, not under a ``merged/`` subdir."""
+    process_list_path = tmp_path / "process_list.csv"
+    process_list_path.write_text(
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
+        "slide-a,merged,/tmp/slide-a.svs,,asap,asap,success,1,/tmp/slide-a.coordinates.npz,/tmp/slide-a.coordinates.meta.json,,\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(tiling_pipeline, "tile_slides", lambda *args, **kwargs: None)
+
+    captured = {}
+
+    def fake_load(row):
+        from slide2vec.utils.tiling_io import load_tiling_result_from_row
+        import slide2vec.utils.tiling_io as tiling_io
+
+        original = tiling_io.load_tiling_result
+        tiling_io.load_tiling_result = lambda **kwargs: SimpleNamespace()
+        try:
+            result = load_tiling_result_from_row(row)
+        finally:
+            tiling_io.load_tiling_result = original
+        captured["annotation"] = result.annotation
+        return result
+
+    monkeypatch.setattr(tiling_pipeline, "load_tiling_result_from_row", fake_load)
+
+    tiling_pipeline.prepare_tiled_slides(
+        [make_slide("slide-a")],
+        DEFAULT_PREPROCESSING,
+        output_dir=tmp_path,
+        num_workers=0,
+    )
+
+    assert captured["annotation"] is None
+
+
 def test_tile_slides_does_not_pre_resolve_backend_auto(monkeypatch, tmp_path: Path):
     import slide2vec.inference as inference
     import slide2vec.progress as progress


### PR DESCRIPTION
Expose the **merged output mode** and the **joint/independent selection strategy** end-to-end (issue 5/6).

## What changed
- `output_mode: merged` now collapses to the flat output root. hs2p emits one merged coordinate set per slide (the union of tiles passing any active class threshold) and labels that process-list row `"merged"` so it is not mistaken for plain tissue. Since the merged set carries no class label, `load_tiling_result_from_row` normalizes `"merged"` -> `None` on read, so the existing flatten rule (`hs2p.fileops.is_flattened_annotation`) lands its artifacts at the flat root with no `<class>/` subdir.
- `independent_sampling` toggles joint vs independent selection. It was already threaded through `build_hs2p_configs` -> `resolve_sampling_request` and forwarded into `tile_slides` (from #155); this change adds top-seam coverage that toggling it produces the matching `CoordinateSelectionStrategy`.
- Expanded inline docs for `masks.output_mode` and `independent_sampling` in the default config.

## Scope
Tiling/resolver/config layer + tests only. No changes to embedding-artifact namespacing or hierarchical code. Default tissue path unchanged.

## Tests
- `tests/test_regression_core.py`: merged output mode yields `merged` + the matching selection strategy; `independent_sampling` true/false -> independent/joint strategy; a merged annotation row collapses to the flat root.
- `tests/test_regression_inference.py`: the top seam forwards `output_mode=merged` + `selection_strategy=joint_sampling` (and `per_annotation` + `independent_sampling`) into `tile_slides`; a merged process-list row loads with `annotation=None`.

Full suite: `317 passed, 15 skipped`.

Closes #158