### PR TITLE
Per-annotation hierarchical (region) embeddings (#157)

### DIFF
--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -60,6 +60,7 @@ class HierarchicalEmbeddingArtifact:
     feature_dim: int
     num_regions: int
     tiles_per_region: int
+    annotation: str | None = None
 
     @property
     def metadata(self) -> dict[str, Any]:
@@ -123,6 +124,20 @@ def slide_latents_subdir(annotation: str | None) -> str:
     if is_flattened_annotation(annotation):
         return "slide_latents"
     return f"slide_latents/{annotation}"
+
+
+def hierarchical_embeddings_subdir(annotation: str | None) -> str:
+    """Namespace the ``hierarchical_embeddings`` output dir per annotation class.
+
+    Reuses hs2p's flatten rule (the single source of truth, shared with
+    :func:`tile_embeddings_subdir` and :func:`slide_embeddings_subdir`): ``None`` and the
+    sentinel ``"tissue"`` collapse to the flat ``hierarchical_embeddings`` root, so the
+    default tissue-only path is byte-for-byte unchanged; any real class label gets its own
+    ``hierarchical_embeddings/<class>`` subdirectory.
+    """
+    if is_flattened_annotation(annotation):
+        return "hierarchical_embeddings"
+    return f"hierarchical_embeddings/{annotation}"
 
 
 def _setup_artifact_paths(
@@ -330,9 +345,12 @@ def write_hierarchical_embeddings(
     output_dir: str | Path,
     output_format: str = "pt",
     metadata: dict[str, Any] | None = None,
+    annotation: str | None = None,
 ) -> HierarchicalEmbeddingArtifact:
     output_format = _validate_output_format(output_format)
-    artifact_path, metadata_path = _setup_artifact_paths(output_dir, "hierarchical_embeddings", sample_id, output_format)
+    artifact_path, metadata_path = _setup_artifact_paths(
+        output_dir, hierarchical_embeddings_subdir(annotation), sample_id, output_format
+    )
     feature_array = _ensure_array(features)
     if feature_array.ndim != 3:
         raise ValueError(
@@ -362,4 +380,5 @@ def write_hierarchical_embeddings(
         feature_dim=int(hierarchical_metadata["feature_dim"]),
         num_regions=int(hierarchical_metadata["num_regions"]),
         tiles_per_region=int(hierarchical_metadata["tiles_per_region"]),
+        annotation=annotation,
     )

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -172,10 +172,11 @@ def _reconcile_embedding_process_list(
     include_slide_embeddings = model.level == "slide"
     include_tile_embeddings = persist_tile_embeddings and not persist_hierarchical_embeddings
     annotations = None
-    if include_slide_embeddings and embeddable_tiling_results is not None:
-        # Re-read each class's namespaced slide-embedding artifact so the final reconcile
-        # records the per-class feature path instead of collapsing every annotation row
-        # onto the flat path. The default tissue-only path leaves annotations None.
+    if (include_slide_embeddings or persist_hierarchical_embeddings) and embeddable_tiling_results is not None:
+        # Re-read each class's namespaced slide- or hierarchical-embedding artifact so the
+        # final reconcile records the per-class feature path instead of collapsing every
+        # annotation row onto the flat path. The default tissue-only path leaves annotations
+        # None.
         annotations = [
             embedding.tiling_result_annotation(tiling_result)
             for tiling_result in embeddable_tiling_results
@@ -586,6 +587,7 @@ def embed_tiles(
                     backend=tiling.resolve_slide_backend(resolved_preprocessing, tiling_result),
                     preprocessing=resolved_preprocessing,
                 ),
+                annotation=embedding.tiling_result_annotation(tiling_result),
             )
         else:
             features = embedding_pipeline.compute_tile_embeddings_for_slide(

--- a/slide2vec/runtime/embedding.py
+++ b/slide2vec/runtime/embedding.py
@@ -159,6 +159,7 @@ def write_hierarchical_embedding_artifact(
     *,
     execution: ExecutionOptions,
     metadata: dict[str, Any],
+    annotation: str | None = None,
 ) -> HierarchicalEmbeddingArtifact:
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required to persist hierarchical embeddings")
@@ -168,4 +169,5 @@ def write_hierarchical_embedding_artifact(
         output_dir=execution.output_dir,
         output_format=execution.output_format,
         metadata=metadata,
+        annotation=annotation,
     )

--- a/slide2vec/runtime/embedding_persist.py
+++ b/slide2vec/runtime/embedding_persist.py
@@ -105,6 +105,7 @@ def persist_embedded_slide(
                 backend=resolve_slide_backend(preprocessing, tiling_result),
                 preprocessing=preprocessing,
             ),
+            annotation=annotation,
         )
         return hierarchical_artifact, None
     tile_artifact = None

--- a/slide2vec/runtime/persist_callbacks.py
+++ b/slide2vec/runtime/persist_callbacks.py
@@ -12,6 +12,7 @@ from slide2vec.artifacts import (
     HierarchicalEmbeddingArtifact,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
+    hierarchical_embeddings_subdir,
     slide_embeddings_subdir,
     slide_latents_subdir,
     tile_embeddings_subdir,
@@ -47,7 +48,8 @@ def has_complete_local_embedding_outputs(
 ) -> bool:
     tile_subdir = tile_embeddings_subdir(annotation)
     if persist_hierarchical_embeddings:
-        hierarchical_artifact_path = output_dir / "hierarchical_embeddings" / f"{sample_id}.{output_format}"
+        hierarchical_subdir = hierarchical_embeddings_subdir(annotation)
+        hierarchical_artifact_path = output_dir / hierarchical_subdir / f"{sample_id}.{output_format}"
         if not hierarchical_artifact_path.is_file():
             return False
     elif persist_tile_embeddings:

--- a/slide2vec/runtime/persistence.py
+++ b/slide2vec/runtime/persistence.py
@@ -12,6 +12,7 @@ from slide2vec.artifacts import (
     HierarchicalEmbeddingArtifact,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
+    hierarchical_embeddings_subdir,
     load_array,
     load_metadata,
     slide_embeddings_subdir,
@@ -34,10 +35,11 @@ def collect_pipeline_artifacts(
     list[HierarchicalEmbeddingArtifact],
     list[SlideEmbeddingArtifact],
 ]:
-    # ``annotations`` (parallel to ``slide_records``) namespaces the per-class slide-
-    # embedding artifacts back from disk so the end-of-run reconcile re-reads each class's
-    # own ``slide_embeddings/<class>/<id>`` path. When omitted (the default tissue-only
-    # path) slide artifacts load flat, byte-for-byte unchanged.
+    # ``annotations`` (parallel to ``slide_records``) namespaces the per-class slide- and
+    # hierarchical-embedding artifacts back from disk so the end-of-run reconcile re-reads
+    # each class's own ``slide_embeddings/<class>/<id>`` (resp.
+    # ``hierarchical_embeddings/<class>/<id>``) path. When omitted (the default tissue-only
+    # path) both load flat, byte-for-byte unchanged.
     if annotations is None:
         annotations = [None] * len(slide_records)
     tile_artifacts: list[TileEmbeddingArtifact] = []
@@ -48,7 +50,12 @@ def collect_pipeline_artifacts(
             tile_artifacts.append(load_tile_artifact(slide.sample_id, output_dir=output_dir, output_format=output_format))
         if include_hierarchical_embeddings:
             hierarchical_artifacts.append(
-                load_hierarchical_artifact(slide.sample_id, output_dir=output_dir, output_format=output_format)
+                load_hierarchical_artifact(
+                    slide.sample_id,
+                    output_dir=output_dir,
+                    output_format=output_format,
+                    annotation=annotation,
+                )
             )
         if include_slide_embeddings:
             slide_artifacts.append(
@@ -88,9 +95,11 @@ def load_hierarchical_artifact(
     *,
     output_dir: Path,
     output_format: str,
+    annotation: str | None = None,
 ) -> HierarchicalEmbeddingArtifact:
-    artifact_path = output_dir / "hierarchical_embeddings" / f"{sample_id}.{output_format}"
-    metadata_path = output_dir / "hierarchical_embeddings" / f"{sample_id}.meta.json"
+    hierarchical_dir = output_dir / hierarchical_embeddings_subdir(annotation)
+    artifact_path = hierarchical_dir / f"{sample_id}.{output_format}"
+    metadata_path = hierarchical_dir / f"{sample_id}.meta.json"
     if metadata_path.is_file():
         metadata = load_metadata(metadata_path)
         feature_dim = int(metadata["feature_dim"])
@@ -109,6 +118,7 @@ def load_hierarchical_artifact(
         feature_dim=feature_dim,
         num_regions=num_regions,
         tiles_per_region=tiles_per_region,
+        annotation=annotation,
     )
 
 
@@ -175,12 +185,12 @@ def update_process_list_after_embedding(
     tile_success_ids = {artifact.sample_id for artifact in tile_artifacts}
     hierarchical_success_ids = {artifact.sample_id for artifact in hierarchical_artifacts}
     slide_success_ids = {artifact.sample_id for artifact in slide_artifacts}
-    # Slide embeddings fan out per (sample_id, annotation): keep a per-class feature-path
-    # map (and per-class success set) so a multi-label slide records a distinct slide-
-    # embedding path on each annotation row instead of collapsing them all onto one path.
+    # Slide and hierarchical embeddings fan out per (sample_id, annotation): keep a per-class
+    # feature-path map (and per-class success set) so a multi-label slide records a distinct
+    # feature path on each annotation row instead of collapsing them all onto one path.
     # Tissue/None annotations stay in the flat slot, so the default single-row path is
-    # byte-for-byte unchanged. Tile/hierarchical artifacts are sample_id-keyed (their per-
-    # class fan-out is wired by their own slices), so they map to a None annotation key.
+    # byte-for-byte unchanged. Tile artifacts are sample_id-keyed (their per-class fan-out is
+    # wired by their own slice), so they map to a None annotation key.
     slide_path_by_key = {
         (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(artifact.path)
         for artifact in slide_artifacts
@@ -194,7 +204,8 @@ def update_process_list_after_embedding(
         feature_success_ids = slide_success_ids
     elif persist_hierarchical_embeddings:
         feature_path_by_key = {
-            (artifact.sample_id, None): _resolve_path_str(artifact.path) for artifact in hierarchical_artifacts
+            (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(artifact.path)
+            for artifact in hierarchical_artifacts
         }
         feature_kind = "hierarchical"
         feature_success_ids = hierarchical_success_ids
@@ -208,7 +219,7 @@ def update_process_list_after_embedding(
         feature_path_by_key = {}
         feature_kind = None
         feature_success_ids = {slide.sample_id for slide in successful_slides}
-    annotation_aware = bool(slide_artifacts)
+    annotation_aware = bool(slide_artifacts) or (persist_hierarchical_embeddings and bool(hierarchical_artifacts))
     row_annotations = _row_annotation_series(df)
     for slide in successful_slides:
         mask = df["sample_id"].astype(str) == slide.sample_id

--- a/slide2vec/runtime/process_list.py
+++ b/slide2vec/runtime/process_list.py
@@ -74,6 +74,7 @@ def write_zero_tile_embedding_sidecars(
                     backend=resolve_slide_backend(preprocessing, tiling_result),
                     preprocessing=preprocessing,
                 ),
+                annotation=tiling_result_annotation(tiling_result),
             )
             continue
         write_tile_embedding_metadata(

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -5066,3 +5066,342 @@ def test_zero_tile_sidecar_namespaces_per_class(tmp_path: Path):
 
     _sidecar("tissue")
     assert (tmp_path / "tile_embeddings" / "slide-z.meta.json").is_file()
+
+
+# --- Issue #157: per-annotation hierarchical (region) embeddings (top-seam) ---
+
+
+HIERARCHICAL_PREPROCESSING = replace(
+    DEFAULT_PREPROCESSING,
+    requested_region_size_px=448,
+    region_tile_multiple=2,
+)
+
+
+def test_write_hierarchical_embeddings_namespaces_per_class(tmp_path: Path):
+    """Region embeddings land under hierarchical_embeddings/<class>/ for real classes; tissue/None
+    stay flat. The artifact carries its annotation, reusing the shared flatten rule."""
+    tumor_artifact = write_hierarchical_embeddings(
+        "slide-a",
+        np.zeros((1, 4, 8), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tumor",
+    )
+    assert tumor_artifact.path == tmp_path / "hierarchical_embeddings" / "tumor" / "slide-a.pt"
+    assert tumor_artifact.annotation == "tumor"
+
+    tissue_artifact = write_hierarchical_embeddings(
+        "slide-a",
+        np.zeros((1, 4, 8), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tissue",
+    )
+    assert tissue_artifact.path == tmp_path / "hierarchical_embeddings" / "slide-a.pt"
+    assert tissue_artifact.annotation == "tissue"
+
+    none_artifact = write_hierarchical_embeddings(
+        "slide-a",
+        np.zeros((1, 4, 8), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation=None,
+    )
+    assert none_artifact.path == tmp_path / "hierarchical_embeddings" / "slide-a.pt"
+    assert none_artifact.annotation is None
+
+
+def test_persist_embedded_slide_namespaces_hierarchical_embeddings_per_class(monkeypatch, tmp_path: Path):
+    """When region tiling is enabled, per-class region embeddings land under
+    hierarchical_embeddings/<class>/; tissue/None stay flat. The artifact carries its annotation."""
+    model = SimpleNamespace(name="virchow2", level="tile")
+    execution = ExecutionOptions(output_dir=tmp_path)
+
+    # build_hierarchical_embedding_metadata resolves region geometry from the tiling result; stub
+    # it so the test stays IO-free while still exercising the per-class namespacing seam.
+    monkeypatch.setattr(
+        embedding_persist,
+        "build_hierarchical_embedding_metadata",
+        lambda *args, **kwargs: {"image_path": "/tmp/slide-a.svs"},
+    )
+
+    def _persist(annotation):
+        tiling_result = SimpleNamespace(
+            x=np.array([0, 1, 2, 3], dtype=np.int64),
+            y=np.array([0, 0, 1, 1], dtype=np.int64),
+            tile_size_lv0=224,
+            num_tiles=4,
+            backend="asap",
+            annotation=annotation,
+            coordinates_npz_path=Path("/tmp/c.npz"),
+            coordinates_meta_path=Path("/tmp/c.meta.json"),
+            tiles_tar_path=None,
+        )
+        embedded = EmbeddedSlide(
+            sample_id="slide-a",
+            tile_embeddings=np.zeros((1, 4, 8), dtype=np.float32),
+            slide_embedding=None,
+            x=np.array([0], dtype=np.int64),
+            y=np.array([1], dtype=np.int64),
+            tile_size_lv0=224,
+            image_path=Path("/tmp/slide-a.svs"),
+            mask_path=Path("/tmp/slide-a-mask.png"),
+        )
+        hierarchical_artifact, _ = embedding_persist.persist_embedded_slide(
+            model,
+            embedded,
+            tiling_result,
+            preprocessing=HIERARCHICAL_PREPROCESSING,
+            execution=execution,
+        )
+        return hierarchical_artifact
+
+    tumor_artifact = _persist("tumor")
+    assert tumor_artifact.path == tmp_path / "hierarchical_embeddings" / "tumor" / "slide-a.pt"
+    assert tumor_artifact.annotation == "tumor"
+
+    tissue_artifact = _persist("tissue")
+    assert tissue_artifact.path == tmp_path / "hierarchical_embeddings" / "slide-a.pt"
+    assert tissue_artifact.annotation == "tissue"
+
+    none_artifact = _persist(None)
+    assert none_artifact.path == tmp_path / "hierarchical_embeddings" / "slide-a.pt"
+    assert none_artifact.annotation is None
+
+
+def test_update_process_list_records_per_class_hierarchical_feature_paths(tmp_path: Path):
+    """A multi-label slide records a distinct per-class hierarchical feature path on each
+    (sample_id, annotation) row rather than collapsing them onto one path."""
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 4,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 4,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+
+    tumor_artifact = write_hierarchical_embeddings(
+        "slide-a",
+        np.zeros((1, 4, 8), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tumor",
+    )
+    stroma_artifact = write_hierarchical_embeddings(
+        "slide-a",
+        np.zeros((1, 4, 8), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="stroma",
+    )
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    persistence.update_process_list_after_embedding(
+        process_list_path,
+        successful_slides=[slide, slide],
+        persist_tile_embeddings=False,
+        persist_hierarchical_embeddings=True,
+        include_slide_embeddings=False,
+        encoder_name="virchow2",
+        output_variant=None,
+        tile_artifacts=[],
+        hierarchical_artifacts=[tumor_artifact, stroma_artifact],
+        slide_artifacts=[],
+    )
+
+    df = pd.read_csv(process_list_path)
+    tumor_row = df[df["annotation"] == "tumor"].iloc[0]
+    stroma_row = df[df["annotation"] == "stroma"].iloc[0]
+    assert tumor_row["feature_path"] == str(
+        (tmp_path / "hierarchical_embeddings" / "tumor" / "slide-a.pt").resolve()
+    )
+    assert stroma_row["feature_path"] == str(
+        (tmp_path / "hierarchical_embeddings" / "stroma" / "slide-a.pt").resolve()
+    )
+    assert tumor_row["feature_kind"] == "hierarchical"
+    assert stroma_row["feature_kind"] == "hierarchical"
+
+
+def test_resume_gate_keys_hierarchical_embeddings_by_sample_id_and_annotation(tmp_path: Path):
+    """Local resume dedups pending work by (sample_id, annotation) for hierarchical embeddings: a
+    class whose region artifact is missing stays pending even when a sibling class is complete."""
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 4,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 4,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+    df = pd.read_csv(process_list_path)
+    df["feature_status"] = "success"
+    df.to_csv(process_list_path, index=False)
+
+    # Only the tumor region artifact exists on disk.
+    write_hierarchical_embeddings(
+        "slide-a",
+        np.zeros((1, 4, 8), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tumor",
+    )
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    tumor_tr = SimpleNamespace(annotation="tumor")
+    stroma_tr = SimpleNamespace(annotation="stroma")
+    pending_slides, pending_results = persist_callbacks.pending_local_embedding_records(
+        [slide, slide],
+        [tumor_tr, stroma_tr],
+        process_list_path=process_list_path,
+        output_dir=tmp_path,
+        output_format="pt",
+        persist_tile_embeddings=True,
+        persist_hierarchical_embeddings=True,
+        include_slide_embeddings=False,
+        save_latents=False,
+        resume=True,
+    )
+
+    assert [tr.annotation for tr in pending_results] == ["stroma"]
+    assert len(pending_slides) == 1
+
+
+def test_collect_pipeline_artifacts_reloads_per_class_hierarchical_embeddings(tmp_path: Path):
+    """The end-of-run reconcile reloads each class's namespaced hierarchical artifact when given
+    per-row annotations, so the per-class feature path is recorded rather than the flat one."""
+    write_hierarchical_embeddings(
+        "slide-a",
+        np.zeros((1, 4, 8), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tumor",
+    )
+    write_hierarchical_embeddings(
+        "slide-a",
+        np.zeros((1, 4, 8), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="stroma",
+    )
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    _, hierarchical_artifacts, _ = persistence.collect_pipeline_artifacts(
+        [slide, slide],
+        output_dir=tmp_path,
+        output_format="pt",
+        include_tile_embeddings=False,
+        include_hierarchical_embeddings=True,
+        include_slide_embeddings=False,
+        annotations=["tumor", "stroma"],
+    )
+
+    assert [a.path for a in hierarchical_artifacts] == [
+        tmp_path / "hierarchical_embeddings" / "tumor" / "slide-a.pt",
+        tmp_path / "hierarchical_embeddings" / "stroma" / "slide-a.pt",
+    ]
+    assert [a.annotation for a in hierarchical_artifacts] == ["tumor", "stroma"]
+
+
+def test_zero_tile_hierarchical_sidecar_namespaces_per_class(monkeypatch, tmp_path: Path):
+    """Zero-tile hierarchical sidecars for a real class land under hierarchical_embeddings/<class>/;
+    tissue stays flat."""
+    model = SimpleNamespace(name="virchow2", level="tile")
+    monkeypatch.setattr(
+        process_list,
+        "build_hierarchical_embedding_metadata",
+        lambda *args, **kwargs: {"image_path": "/tmp/slide-z.svs"},
+    )
+    monkeypatch.setattr(
+        process_list,
+        "resolve_hierarchical_geometry",
+        lambda *args, **kwargs: {"tiles_per_region": 4},
+    )
+
+    def _sidecar(annotation):
+        tiling_result = SimpleNamespace(
+            x=np.array([], dtype=np.int64),
+            y=np.array([], dtype=np.int64),
+            tile_size_lv0=224,
+            num_tiles=0,
+            backend="asap",
+            annotation=annotation,
+            coordinates_npz_path=Path("/tmp/c.npz"),
+            coordinates_meta_path=Path("/tmp/c.meta.json"),
+            tiles_tar_path=None,
+        )
+        slide = make_slide("slide-z", mask_path=Path("/tmp/slide-z-mask.png"))
+        process_list.write_zero_tile_embedding_sidecars(
+            [(slide, tiling_result)],
+            model=model,
+            preprocessing=HIERARCHICAL_PREPROCESSING,
+            output_dir=tmp_path,
+            output_format="pt",
+        )
+
+    _sidecar("tumor")
+    assert (tmp_path / "hierarchical_embeddings" / "tumor" / "slide-z.meta.json").is_file()
+
+    _sidecar("tissue")
+    assert (tmp_path / "hierarchical_embeddings" / "slide-z.meta.json").is_file()


### PR DESCRIPTION
Extend the per-annotation fan-out to hierarchical (region) embeddings (issue 4/6).

When region tiling is enabled (`region_tile_multiple`), region embeddings are computed over each class's coordinates and namespaced by class:
- `hierarchical_embeddings/<class>/<id>` for real classes; `tissue`/None stay flat (`hierarchical_embeddings/<id>`), via the shared `hierarchical_embeddings_subdir` helper (built on `hs2p.fileops.is_flattened_annotation`).
- The region geometry/index is already derived from the per-`(sample_id, annotation)` tiling result, so each class resolves over its own coordinates (not the union).

Mirrors the #156 slide-embedding pattern:
- `annotation` threaded onto `HierarchicalEmbeddingArtifact` and through `write_hierarchical_embeddings` -> `write_hierarchical_embedding_artifact` -> `persist_embedded_slide`.
- `update_process_list_after_embedding` keys hierarchical `feature_path`/`feature_kind` by `(sample_id, annotation)` (annotation-aware loop, `.isna()` match for the flat None key).
- Local resume gate (`persist_callbacks.has_complete_local_embedding_outputs`) and the end-of-run reconcile (`collect_pipeline_artifacts` / `load_hierarchical_artifact`) namespace by annotation.
- Zero-tile hierarchical sidecar namespaced per class too.

Default tissue-only hierarchical path stays byte-for-byte unchanged. The distributed multi-class reconcile (`collect_distributed_pipeline_artifacts`) stays flat-only for multi-class, mirroring #156's deferral; the default path is correct.

Testing: `python -m pytest tests/ -o addopts="" -p no:cacheprovider -q` -> 317 passed, 15 skipped.

Closes #157