### PR TITLE
Annotation-aware reconcile for distributed (multi-GPU) multi-class extraction

### DIFF
--- a/slide2vec/runtime/artifacts_collect.py
+++ b/slide2vec/runtime/artifacts_collect.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 from typing import Sequence
 
+import pandas as pd
 from hs2p import SlideSpec
+from hs2p.fileops import is_flattened_annotation
 
 from slide2vec.api import EmbeddedSlide, ExecutionOptions, PreprocessingConfig
 from slide2vec.artifacts import (
@@ -19,7 +21,10 @@ from slide2vec.runtime.persistence import (
     collect_pipeline_artifacts,
     update_process_list_after_embedding,
 )
-from slide2vec.runtime.persist_callbacks import pending_local_embedding_records
+from slide2vec.runtime.persist_callbacks import (
+    has_complete_local_embedding_outputs,
+    pending_local_embedding_records,
+)
 from slide2vec.runtime.process_list import resolved_process_list_output_variant
 from slide2vec.progress import emit_progress
 
@@ -52,6 +57,86 @@ def collect_local_pipeline_artifacts(
     return tile_artifacts, hierarchical_artifacts, slide_artifacts
 
 
+def _embeddable_annotation_groups(
+    process_list_path: Path,
+) -> dict[str, list[str | None]]:
+    """Map each ``sample_id`` to its embeddable per-class annotations, in process-list row order.
+
+    The process_list already carries one row per ``(sample_id, annotation)`` after hs2p tiling, so
+    it is the source of truth for which classes fanned out per slide (the distributed workers
+    re-load tiles from disk and have no in-memory tiling results to re-derive this from). Only rows
+    with ``num_tiles > 0`` are kept, because :func:`partition_slides_by_tile_count` drops zero-tile
+    rows before the embedding stage — so the kept annotations line up 1:1 with ``successful_slides``.
+    Flat-layout rows (see :func:`_normalized_row_annotation`) collapse to a ``None`` annotation so the
+    default tissue-only path stays on the flat embedding path. Row order is preserved (rather than
+    deduplicated) so each ``successful_slides`` entry can claim exactly one annotation.
+    """
+    if process_list_path is None or not Path(process_list_path).is_file():
+        return {}
+    df = pd.read_csv(process_list_path)
+    if "sample_id" not in df.columns:
+        return {}
+    has_annotation = "annotation" in df.columns
+    has_num_tiles = "num_tiles" in df.columns
+    groups: dict[str, list[str | None]] = {}
+    for _, row in df.iterrows():
+        if has_num_tiles and not _has_tiles(row["num_tiles"]):
+            continue
+        sample_id = str(row["sample_id"])
+        annotation = row["annotation"] if has_annotation else None
+        groups.setdefault(sample_id, []).append(_normalized_row_annotation(annotation))
+    return groups
+
+
+def _has_tiles(num_tiles) -> bool:
+    if num_tiles is None or (isinstance(num_tiles, float) and pd.isna(num_tiles)):
+        return False
+    try:
+        return int(num_tiles) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _normalized_row_annotation(annotation) -> str | None:
+    """Collapse a process-list ``annotation`` cell to the per-class key (``None`` for the flat path).
+
+    Mirrors the in-memory single-GPU path: ``None``/NaN and hs2p's flat-layout sentinels
+    (:func:`hs2p.fileops.is_flattened_annotation`, e.g. ``"tissue"``) land flat, and the merged
+    output-mode label ``"merged"`` is collapsed to ``None`` exactly as
+    :func:`slide2vec.utils.tiling_io.load_tiling_result_from_row` does — so the distributed reconcile
+    keys those rows to the flat embedding path with no per-class subdir.
+    """
+    if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
+        return None
+    annotation = str(annotation)
+    if annotation == "merged" or is_flattened_annotation(annotation):
+        return None
+    return annotation
+
+
+def _annotations_parallel_to_slides(
+    slides: Sequence[SlideSpec],
+    annotation_groups: dict[str, list[str | None]],
+) -> list[str | None]:
+    """Build an ``annotations`` list aligned 1:1 with ``slides``.
+
+    ``successful_slides`` already has one entry per ``(sample_id, annotation)`` row (the tiling spine
+    fans out per class before the embedding stage), but the :class:`SlideSpec` carries no annotation.
+    Consume each sample's recorded annotations in process-list row order so the i-th slide entry
+    claims the i-th annotation for that sample — exactly the parallel ``slides``/``annotations`` pair
+    the single-GPU reconcile threads through :func:`collect_pipeline_artifacts`. Samples with no
+    recorded class fall back to ``None`` (the flat path).
+    """
+    cursors: dict[str, int] = {}
+    annotations: list[str | None] = []
+    for slide in slides:
+        group = annotation_groups.get(slide.sample_id, [])
+        index = cursors.get(slide.sample_id, 0)
+        annotations.append(group[index] if index < len(group) else None)
+        cursors[slide.sample_id] = index + 1
+    return annotations
+
+
 def collect_distributed_pipeline_artifacts(
     *,
     model,
@@ -70,6 +155,13 @@ def collect_distributed_pipeline_artifacts(
     persist_hierarchical_embeddings = is_hierarchical_preprocessing(preprocessing)
     include_slide_embeddings = model.level == "slide"
     include_tile_embeddings = persist_tile_embeddings and not persist_hierarchical_embeddings
+    # Slide- and hierarchical-embedding artifacts fan out per (sample_id, annotation); the process
+    # list (one row per pair after hs2p tiling) is the source of truth for which classes exist.
+    # Tile embeddings are sample_id-keyed only, so they don't need the per-class resolution.
+    annotation_aware = include_slide_embeddings or persist_hierarchical_embeddings
+    annotation_groups = (
+        _embeddable_annotation_groups(process_list_path) if annotation_aware else {}
+    )
     pending_slides, _ = pending_local_embedding_records(
         successful_slides,
         [None] * len(successful_slides),
@@ -101,13 +193,35 @@ def collect_distributed_pipeline_artifacts(
         slide = slide_by_sample_id.get(sample_id)
         if slide is None or sample_id in live_updated_sample_ids:
             return
+        # A multi-class slide emits one finished event per (sample_id, annotation) item, and the
+        # other classes may still be running on another rank. Wait until *every* annotation row for
+        # the sample is persisted on disk before the whole-sample rewrite, so we never (a) load a
+        # sibling artifact that isn't there yet, nor (b) flip a still-running sibling's row to error.
+        sample_annotations = list(dict.fromkeys(annotation_groups.get(sample_id, [None]) or [None]))
+        all_ready = all(
+            has_complete_local_embedding_outputs(
+                sample_id,
+                output_dir=output_dir,
+                output_format=execution.output_format,
+                persist_tile_embeddings=persist_tile_embeddings,
+                persist_hierarchical_embeddings=persist_hierarchical_embeddings,
+                include_slide_embeddings=include_slide_embeddings,
+                save_latents=execution.save_latents,
+                annotation=annotation,
+            )
+            for annotation in sample_annotations
+        )
+        if not all_ready:
+            return
+        slides_for_update = [slide] * len(sample_annotations)
         tile_artifacts, hierarchical_artifacts, slide_artifacts = collect_pipeline_artifacts(
-            [slide],
+            slides_for_update,
             output_dir=output_dir,
             output_format=execution.output_format,
             include_tile_embeddings=include_tile_embeddings,
             include_hierarchical_embeddings=persist_hierarchical_embeddings,
             include_slide_embeddings=include_slide_embeddings,
+            annotations=sample_annotations if annotation_aware else None,
         )
         update_process_list_after_embedding(
             process_list_path,
@@ -132,6 +246,9 @@ def collect_distributed_pipeline_artifacts(
         tiling_input_dir=tiling_input_dir,
         on_progress_event=_update_process_list_for_finished_slide,
     )
+    # ``successful_slides`` is already one entry per (sample_id, annotation) row, so resolve a
+    # parallel annotations list (not an expansion) to re-read each entry's namespaced artifact.
+    annotations_for_collect = _annotations_parallel_to_slides(successful_slides, annotation_groups)
     tile_artifacts, hierarchical_artifacts, slide_artifacts = collect_pipeline_artifacts(
         successful_slides,
         output_dir=output_dir,
@@ -139,6 +256,7 @@ def collect_distributed_pipeline_artifacts(
         include_tile_embeddings=include_tile_embeddings,
         include_hierarchical_embeddings=persist_hierarchical_embeddings,
         include_slide_embeddings=include_slide_embeddings,
+        annotations=annotations_for_collect if annotation_aware else None,
     )
     update_process_list_after_embedding(
         process_list_path,

--- a/slide2vec/runtime/persistence.py
+++ b/slide2vec/runtime/persistence.py
@@ -261,16 +261,20 @@ def update_process_list_after_embedding(
 
 
 def _normalized_annotation(annotation: Any) -> str | None:
-    """Collapse the flat-layout sentinels (``None``/``"tissue"``) to a single ``None`` key.
+    """Collapse the flat-layout sentinels (``None``/``"tissue"``/``"merged"``) to a single ``None`` key.
 
     Keying the per-class feature-path map on this normalized value lets the flat tissue-only
     path and a real class share one matching rule without the sentinel leaking into lookups.
+    ``"merged"`` (hs2p's merged output-mode label) carries no class and is collapsed to ``None``
+    here, matching :func:`slide2vec.utils.tiling_io.load_tiling_result_from_row`, so its
+    process-list row resolves to the flat embedding path rather than being left unmatched.
     """
     if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
         return None
-    if is_flattened_annotation(str(annotation)):
+    annotation = str(annotation)
+    if annotation == "merged" or is_flattened_annotation(annotation):
         return None
-    return str(annotation)
+    return annotation
 
 
 def _row_annotation_series(df: pd.DataFrame) -> pd.Series:

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -346,7 +346,7 @@ def test_collect_distributed_pipeline_artifacts_runs_stage_collects_and_updates(
             "on_progress_event": on_progress_event,
         }
 
-    def fake_collect(slides, *, output_dir, output_format, include_tile_embeddings, include_hierarchical_embeddings, include_slide_embeddings):
+    def fake_collect(slides, *, output_dir, output_format, include_tile_embeddings, include_hierarchical_embeddings, include_slide_embeddings, annotations=None):
         captured["collect"] = {
             "slides": slides,
             "output_dir": output_dir,
@@ -354,6 +354,7 @@ def test_collect_distributed_pipeline_artifacts_runs_stage_collects_and_updates(
             "include_tile_embeddings": include_tile_embeddings,
             "include_hierarchical_embeddings": include_hierarchical_embeddings,
             "include_slide_embeddings": include_slide_embeddings,
+            "annotations": annotations,
         }
         return ["tile-artifact"], [], ["slide-artifact"]
 
@@ -408,6 +409,9 @@ def test_collect_distributed_pipeline_artifacts_runs_stage_collects_and_updates(
     assert captured["collect"]["include_tile_embeddings"] is True
     assert captured["collect"]["include_hierarchical_embeddings"] is False
     assert captured["collect"]["include_slide_embeddings"] is True
+    # No annotation rows in the process_list (none written) -> single flat (None) annotation, so the
+    # tissue-only / default path stays on the flat embedding path.
+    assert captured["collect"]["annotations"] == [None]
 
     assert captured["update"]["process_list_path"] == process_list_path
     assert captured["update"]["successful_slides"] == [slide]
@@ -516,6 +520,409 @@ def test_collect_distributed_pipeline_artifacts_resume_skips_completed_hierarchi
 
     assert [slide.sample_id for slide in captured["run_stage_slides"]] == ["slide-pending"]
     assert [slide.sample_id for slide in captured["collect_slides"]] == ["slide-done", "slide-pending"]
+
+
+def test_collect_distributed_pipeline_artifacts_records_per_class_slide_paths_for_multi_label(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """Issue #166: the distributed (multi-GPU) reconcile must record one process_list row per
+    (sample_id, annotation) with the correct per-class slide-embedding feature path, matching the
+    single-GPU annotation reconcile (rather than collapsing every annotation row onto the flat
+    path).
+    """
+    process_list_path = tmp_path / "process_list.csv"
+    # Mirror the fresh-run tiling process_list: one row per (sample_id, annotation), feature columns
+    # not yet present (the reconcile adds them).
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+    write_slide_embeddings(
+        "slide-a",
+        np.zeros((8,), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="tumor",
+    )
+    write_slide_embeddings(
+        "slide-a",
+        np.zeros((8,), dtype=np.float32),
+        output_dir=tmp_path,
+        annotation="stroma",
+    )
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=2, output_format="pt")
+    model = SimpleNamespace(name="prism", level="slide")
+
+    # No-op stage (no live finished events) so this asserts the END-OF-RUN reconcile alone records
+    # the per-class paths; the live per-finished-slide updater is covered separately.
+    monkeypatch.setattr(artifacts_collect, "run_distributed_embedding_stage", lambda *args, **kwargs: None)
+
+    # ``successful_slides`` carries one SlideSpec per (sample_id, annotation) row (the tiling spine
+    # already fanned out per class before the embedding stage).
+    artifacts_collect.collect_distributed_pipeline_artifacts(
+        model=model,
+        successful_slides=[slide, slide],
+        process_list_path=process_list_path,
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=execution,
+        output_dir=tmp_path,
+    )
+
+    df = pd.read_csv(process_list_path)
+    tumor_row = df[df["annotation"] == "tumor"].iloc[0]
+    stroma_row = df[df["annotation"] == "stroma"].iloc[0]
+    assert tumor_row["feature_path"] == str((tmp_path / "slide_embeddings" / "tumor" / "slide-a.pt").resolve())
+    assert stroma_row["feature_path"] == str((tmp_path / "slide_embeddings" / "stroma" / "slide-a.pt").resolve())
+    assert tumor_row["aggregation_status"] == "success"
+    assert stroma_row["aggregation_status"] == "success"
+
+
+@pytest.mark.parametrize("annotation", ["tissue", "merged", None])
+def test_collect_distributed_pipeline_artifacts_keeps_flat_path_for_flattened_annotation(
+    monkeypatch,
+    tmp_path: Path,
+    annotation,
+):
+    """Issue #166 (parity): tissue / merged / None annotations stay on the flat slide_embeddings
+    path (no per-class subdir) in the distributed reconcile, mirroring is_flattened_annotation.
+    """
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": annotation,
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": None,
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            }
+        ],
+    )
+    write_slide_embeddings("slide-a", np.zeros((8,), dtype=np.float32), output_dir=tmp_path)
+
+    slide = make_slide("slide-a")
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=2, output_format="pt")
+    model = SimpleNamespace(name="prism", level="slide")
+
+    monkeypatch.setattr(artifacts_collect, "run_distributed_embedding_stage", lambda *args, **kwargs: None)
+
+    artifacts_collect.collect_distributed_pipeline_artifacts(
+        model=model,
+        successful_slides=[slide],
+        process_list_path=process_list_path,
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=execution,
+        output_dir=tmp_path,
+    )
+
+    df = pd.read_csv(process_list_path)
+    row = df.iloc[0]
+    assert row["feature_path"] == str((tmp_path / "slide_embeddings" / "slide-a.pt").resolve())
+    assert "slide_embeddings/tissue" not in row["feature_path"]
+    assert "slide_embeddings/merged" not in row["feature_path"]
+
+
+def test_collect_distributed_pipeline_artifacts_aligns_annotations_skipping_zero_tile_rows(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """Issue #166 (alignment): when one class has zero tiles it is dropped from ``successful_slides``
+    before embedding, so the surviving slide entry must claim the embeddable class's annotation — not
+    the (positionally-first) zero-tile one.
+    """
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 0,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 3,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+    write_slide_embeddings("slide-a", np.zeros((8,), dtype=np.float32), output_dir=tmp_path, annotation="stroma")
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=2, output_format="pt")
+    model = SimpleNamespace(name="prism", level="slide")
+
+    monkeypatch.setattr(artifacts_collect, "run_distributed_embedding_stage", lambda *args, **kwargs: None)
+
+    # Only the stroma row is embeddable (tumor has zero tiles), so the single surviving slide entry
+    # must resolve to stroma's namespaced artifact.
+    _, _, slide_artifacts = artifacts_collect.collect_distributed_pipeline_artifacts(
+        model=model,
+        successful_slides=[slide],
+        process_list_path=process_list_path,
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=execution,
+        output_dir=tmp_path,
+    )
+
+    assert [a.annotation for a in slide_artifacts] == ["stroma"]
+    assert [a.path for a in slide_artifacts] == [tmp_path / "slide_embeddings" / "stroma" / "slide-a.pt"]
+    df = pd.read_csv(process_list_path)
+    stroma_row = df[df["annotation"] == "stroma"].iloc[0]
+    assert stroma_row["feature_path"] == str((tmp_path / "slide_embeddings" / "stroma" / "slide-a.pt").resolve())
+
+
+def test_distributed_live_updater_fans_out_multi_class_finished_slide(monkeypatch, tmp_path: Path):
+    """Issue #166 (live updater): a single ``embedding.slide.finished`` event for a multi-class slide
+    must update every (sample_id, annotation) row's feature path, not just the first. Isolates the
+    live updater by no-op'ing the end-of-run reconcile.
+    """
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+    write_slide_embeddings("slide-a", np.zeros((8,), dtype=np.float32), output_dir=tmp_path, annotation="tumor")
+    write_slide_embeddings("slide-a", np.zeros((8,), dtype=np.float32), output_dir=tmp_path, annotation="stroma")
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=2, output_format="pt")
+    model = SimpleNamespace(name="prism", level="slide")
+
+    captured = {}
+
+    def fake_run_stage(*, on_progress_event=None, **kwargs):
+        if on_progress_event is not None:
+            on_progress_event(
+                SimpleNamespace(kind="embedding.slide.finished", payload={"sample_id": "slide-a"})
+            )
+        # Snapshot the process_list *after* the live update but *before* the final reconcile.
+        captured["after_live_update"] = pd.read_csv(process_list_path)
+
+    monkeypatch.setattr(artifacts_collect, "run_distributed_embedding_stage", fake_run_stage)
+
+    artifacts_collect.collect_distributed_pipeline_artifacts(
+        model=model,
+        successful_slides=[slide],
+        process_list_path=process_list_path,
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=execution,
+        output_dir=tmp_path,
+    )
+
+    df = captured["after_live_update"]
+    tumor_row = df[df["annotation"] == "tumor"].iloc[0]
+    stroma_row = df[df["annotation"] == "stroma"].iloc[0]
+    assert tumor_row["feature_path"] == str((tmp_path / "slide_embeddings" / "tumor" / "slide-a.pt").resolve())
+    assert stroma_row["feature_path"] == str((tmp_path / "slide_embeddings" / "stroma" / "slide-a.pt").resolve())
+
+
+def test_distributed_live_updater_defers_until_all_classes_persisted(monkeypatch, tmp_path: Path):
+    """Issue #166 (live updater safety): a multi-class slide emits one finished event per class, and
+    siblings may still be running on another rank. An early event (only one class on disk) must NOT
+    crash loading the missing sibling and must NOT flip the unfinished row to error — it defers; a
+    later event (once both classes are persisted) does the full per-class update.
+    """
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+    # Only tumor is persisted at the first event; stroma is still in flight.
+    write_slide_embeddings("slide-a", np.zeros((8,), dtype=np.float32), output_dir=tmp_path, annotation="tumor")
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=2, output_format="pt")
+    model = SimpleNamespace(name="prism", level="slide")
+
+    captured = {}
+
+    def fake_run_stage(*, on_progress_event=None, **kwargs):
+        # First finished event: stroma's embedding not yet on disk.
+        on_progress_event(SimpleNamespace(kind="embedding.slide.finished", payload={"sample_id": "slide-a"}))
+        captured["after_first_event"] = pd.read_csv(process_list_path)
+        # Stroma finishes and persists, then its finished event arrives.
+        write_slide_embeddings("slide-a", np.zeros((8,), dtype=np.float32), output_dir=tmp_path, annotation="stroma")
+        on_progress_event(SimpleNamespace(kind="embedding.slide.finished", payload={"sample_id": "slide-a"}))
+        captured["after_second_event"] = pd.read_csv(process_list_path)
+
+    monkeypatch.setattr(artifacts_collect, "run_distributed_embedding_stage", fake_run_stage)
+
+    # Must not raise even though stroma's artifact is missing at the first event.
+    artifacts_collect.collect_distributed_pipeline_artifacts(
+        model=model,
+        successful_slides=[slide, slide],
+        process_list_path=process_list_path,
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=execution,
+        output_dir=tmp_path,
+    )
+
+    # The first event deferred: the process_list was left untouched (no feature columns written, so
+    # no row was flipped to error or given a path prematurely).
+    first = captured["after_first_event"]
+    assert "feature_path" not in first.columns
+    assert "aggregation_status" not in first.columns
+
+    # The second event (both classes persisted) records each class's namespaced path.
+    second = captured["after_second_event"]
+    tumor_row = second[second["annotation"] == "tumor"].iloc[0]
+    stroma_row = second[second["annotation"] == "stroma"].iloc[0]
+    assert tumor_row["feature_path"] == str((tmp_path / "slide_embeddings" / "tumor" / "slide-a.pt").resolve())
+    assert stroma_row["feature_path"] == str((tmp_path / "slide_embeddings" / "stroma" / "slide-a.pt").resolve())
+    assert tumor_row["aggregation_status"] == "success"
+    assert stroma_row["aggregation_status"] == "success"
 
 
 def test_has_complete_local_embedding_outputs_uses_hierarchical_artifacts_for_hierarchical_preprocessing(


### PR DESCRIPTION
Closes #166

## What

Make the multi-GPU (distributed) artifact-reconciliation path annotation-aware, so multi-class feature extraction records correct per-class `feature_path`s when run across multiple GPUs (parity with the single-GPU reconcile).

Previously the distributed reconcile called `collect_pipeline_artifacts(successful_slides, ...)` without `annotations=`, defaulting every row to `annotation=None` → flat path, and its live per-finished-slide updater keyed/deduped by `sample_id` (so a multi-row slide was updated once). This collapsed every `(sample_id, annotation)` row onto the flat feature path.

## How

- `_embeddable_annotation_groups` reads the on-disk `process_list` (one row per `(sample_id, annotation)` after hs2p tiling) — the source of truth the distributed workers lack — keeping only `num_tiles > 0` rows so they line up with `successful_slides`.
- `_annotations_parallel_to_slides` resolves an `annotations` list aligned 1:1 with `successful_slides` (which already fans out one entry per annotation), so the end-of-run `collect_pipeline_artifacts` re-reads each class's namespaced `slide_embeddings/<class>/<id>` (resp. `hierarchical_embeddings/<class>/<id>`) artifact — mirroring the single-GPU `_reconcile_embedding_process_list`.
- The live per-finished-slide updater now fans the single per-slide finished event back out to every annotation row, and waits until **every** class for the sample is persisted on disk before the whole-sample rewrite — so it never loads an in-flight sibling artifact nor flips a still-running row to error.
- `tissue` / `None` / `merged` annotations collapse to the flat path via the shared `is_flattened_annotation` rule (plus `merged` in `_normalized_annotation`), keeping tissue-only and single-GPU output byte-for-byte unchanged.

## Acceptance criteria

- [x] Distributed multi-label run records one row per `(sample_id, annotation)` with the correct per-class `feature_path` (`slide_embeddings/<class>/<id>.pt`), matching single-GPU.
- [x] The live per-finished-slide updater no longer collapses multi-class slides — every `(sample_id, annotation)` row is updated.
- [x] `tissue` / `None` / `merged` annotations stay on the flat path (no `tissue/` subdir), parity with `is_flattened_annotation`.
- [x] Single-GPU multi-class output and tissue-only (default) output are behaviorally unchanged.
- [x] Regression tests exercise the distributed reconcile with multi-class fixtures (per-class paths, live-updater fan-out + defer-until-ready, zero-tile annotation alignment, flat-path parity).

## Tests

`pytest -q` → **330 passed, 15 skipped**.

## Known limitation (follow-up)

The distributed **embedding stage** itself still identifies work by `sample_id` only (`run_distributed_embedding_stage` → `pipeline_worker` keys `paired_by_sample` by `sample_id`, and `assign_slides_to_ranks` returns sample-id lists). For a genuinely fresh multi-label distributed run this can collapse a slide's annotation rows so only one class is embedded. This reconcile PR is correct given the embedding stage produces every class (its stated premise) and is crash-safe when a class is missing (the live updater defers). Fixing the embedding-stage per-annotation fan-out requires reworking the rank-assignment protocol (shared with the direct-embed path) and is tracked separately.
