### PR TITLE
Annotation-aware fan-out for the distributed (multi-GPU) embedding stage

### DIFF
--- a/slide2vec/distributed/direct_embed_worker.py
+++ b/slide2vec/distributed/direct_embed_worker.py
@@ -49,12 +49,21 @@ def main(argv=None) -> int:
         )
         preprocessing = deserialize_preprocessing(request["preprocessing"])
         execution = deserialize_execution(request["execution"])
+        from slide2vec.runtime.distributed import (
+            decode_work_unit,
+            encode_work_unit,
+            work_unit_shard_stem,
+        )
+        from slide2vec.runtime.embedding import tiling_result_annotation
+
         load_successful_tiled_slides_fn = getattr(inference, "load_successful_tiled_slides", None)
         if not callable(load_successful_tiled_slides_fn):
             from slide2vec.runtime.manifest import load_successful_tiled_slides as load_successful_tiled_slides_fn
         slide_records, tiling_results = load_successful_tiled_slides_fn(output_dir)
-        paired_by_sample = {
-            slide.sample_id: (slide, tiling_result)
+        # Key by the composite (sample_id, annotation) work unit so a multi-class slide's sibling
+        # classes never overwrite each other; flat units collapse to the bare sample_id key.
+        paired_by_unit = {
+            encode_work_unit(slide.sample_id, tiling_result_annotation(tiling_result)): (slide, tiling_result)
             for slide, tiling_result in zip(slide_records, tiling_results)
         }
         progress_events_path = request.get("progress_events_path")
@@ -71,8 +80,9 @@ def main(argv=None) -> int:
 
         with context:
             if request["strategy"] == "tile_shard":
-                sample_id = request["sample_id"]
-                slide, tiling_result = paired_by_sample[sample_id]
+                work_unit = request["work_unit"]
+                shard_stem = work_unit_shard_stem(*decode_work_unit(work_unit))
+                slide, tiling_result = paired_by_unit[work_unit]
                 loaded = model._load_backend()
                 if is_hierarchical_preprocessing(preprocessing):
                     geometry = resolve_hierarchical_geometry(preprocessing, tiling_result)
@@ -103,7 +113,7 @@ def main(argv=None) -> int:
                         "flat_index": torch.as_tensor(shard_indices, dtype=torch.long),
                         "tile_embeddings": tile_embeddings.detach().cpu() if torch.is_tensor(tile_embeddings) else torch.as_tensor(tile_embeddings),
                     }
-                    torch.save(payload, coordination_dir / f"{sample_id}.hier.rank{global_rank}.pt")
+                    torch.save(payload, coordination_dir / f"{shard_stem}.hier.rank{global_rank}.pt")
                 else:
                     num_tiles = len(tiling_result.x)
                     tile_indices = np.array_split(np.arange(num_tiles, dtype=np.int64), world_size)[global_rank]
@@ -129,14 +139,14 @@ def main(argv=None) -> int:
                         "tile_index": torch.as_tensor(tile_indices, dtype=torch.long),
                         "tile_embeddings": tile_embeddings.detach().cpu() if torch.is_tensor(tile_embeddings) else torch.as_tensor(tile_embeddings),
                     }
-                    torch.save(payload, coordination_dir / f"{sample_id}.tiles.rank{global_rank}.pt")
+                    torch.save(payload, coordination_dir / f"{shard_stem}.tiles.rank{global_rank}.pt")
                 return 0
 
             assigned_ids = list(request.get("assignments", {}).get(str(global_rank), []))
             if not assigned_ids:
                 return 0
-            assigned_slides = [paired_by_sample[sample_id][0] for sample_id in assigned_ids]
-            assigned_tiling_results = [paired_by_sample[sample_id][1] for sample_id in assigned_ids]
+            assigned_slides = [paired_by_unit[unit_key][0] for unit_key in assigned_ids]
+            assigned_tiling_results = [paired_by_unit[unit_key][1] for unit_key in assigned_ids]
 
             def _persist_embedded_slide(slide, tiling_result, embedded_slide) -> None:
                 payload = {
@@ -144,7 +154,12 @@ def main(argv=None) -> int:
                     "slide_embedding": _to_cpu_payload(embedded_slide.slide_embedding),
                     "latents": _to_cpu_payload(embedded_slide.latents),
                 }
-                torch.save(payload, coordination_dir / f"{embedded_slide.sample_id}.embedded.pt")
+                # Stem by (sample_id, annotation) so two classes of one slide never overwrite each
+                # other; flat units keep the bare-sample_id filename for backward compatibility.
+                stem = work_unit_shard_stem(
+                    embedded_slide.sample_id, tiling_result_annotation(tiling_result)
+                )
+                torch.save(payload, coordination_dir / f"{stem}.embedded.pt")
 
             compute_embedded_slides_fn = getattr(inference, "_compute_embedded_slides", None)
             if not callable(compute_embedded_slides_fn):

--- a/slide2vec/distributed/pipeline_worker.py
+++ b/slide2vec/distributed/pipeline_worker.py
@@ -3,7 +3,8 @@ from contextlib import nullcontext
 import json
 from pathlib import Path
 
-from slide2vec.runtime.distributed import assign_slides_to_ranks
+from slide2vec.runtime.distributed import assign_slides_to_ranks, encode_work_unit
+from slide2vec.runtime.embedding import tiling_result_annotation
 
 
 def get_args_parser(add_help: bool = True) -> argparse.ArgumentParser:
@@ -48,26 +49,29 @@ def main(argv=None) -> int:
         if not callable(load_successful_tiled_slides_fn):
             from slide2vec.runtime.manifest import load_successful_tiled_slides as load_successful_tiled_slides_fn
         slide_records, tiling_results = load_successful_tiled_slides_fn(tiling_input_dir)
-        requested_sample_ids = request.get("sample_ids")
-        if requested_sample_ids is not None:
-            requested_sample_id_set = {str(sample_id) for sample_id in requested_sample_ids}
-            paired = [
-                (slide, tiling_result)
-                for slide, tiling_result in zip(slide_records, tiling_results)
-                if slide.sample_id in requested_sample_id_set
-            ]
-            slide_records = [slide for slide, _ in paired]
-            tiling_results = [tiling_result for _, tiling_result in paired]
+        # Each (sample_id, annotation) row is an independent work unit; key by the composite so a
+        # multi-class slide's sibling classes never overwrite each other. Flat units (None / tissue /
+        # merged) encode to the bare sample_id, byte-identical to pre-#168 single-class runs.
+        paired_by_unit = {
+            encode_work_unit(slide.sample_id, tiling_result_annotation(tiling_result)): (slide, tiling_result)
+            for slide, tiling_result in zip(slide_records, tiling_results)
+        }
+        requested_work_units = request.get("work_units")
+        if requested_work_units is not None:
+            requested_unit_set = {str(unit) for unit in requested_work_units}
+            paired_by_unit = {
+                unit_key: pair
+                for unit_key, pair in paired_by_unit.items()
+                if unit_key in requested_unit_set
+            }
+        slide_records = [slide for slide, _ in paired_by_unit.values()]
+        tiling_results = [tiling_result for _, tiling_result in paired_by_unit.values()]
         assignments = assign_slides_to_ranks(slide_records, tiling_results, num_gpus=world_size)
         assigned_ids = assignments.get(global_rank, [])
         if not assigned_ids:
             return 0
-        paired_by_sample = {
-            slide.sample_id: (slide, tiling_result)
-            for slide, tiling_result in zip(slide_records, tiling_results)
-        }
-        assigned_slides = [paired_by_sample[sample_id][0] for sample_id in assigned_ids]
-        assigned_tiling_results = [paired_by_sample[sample_id][1] for sample_id in assigned_ids]
+        assigned_slides = [paired_by_unit[unit_key][0] for unit_key in assigned_ids]
+        assigned_tiling_results = [paired_by_unit[unit_key][1] for unit_key in assigned_ids]
         progress_events_path = request.get("progress_events_path")
         reporter = (
             JsonlProgressReporter(

--- a/slide2vec/runtime/artifacts_collect.py
+++ b/slide2vec/runtime/artifacts_collect.py
@@ -137,6 +137,20 @@ def _annotations_parallel_to_slides(
     return annotations
 
 
+class _AnnotationPlaceholder:
+    """Minimal tiling-result stand-in carrying just an ``annotation`` for the resume gate.
+
+    The distributed reconcile has no in-memory tiling results (workers re-load tiles from disk), but
+    :func:`pending_local_embedding_records` keys resume by ``(sample_id, annotation)`` via the tiling
+    result's ``annotation`` attribute. This placeholder threads the process-list annotation through.
+    """
+
+    __slots__ = ("annotation",)
+
+    def __init__(self, annotation: str | None) -> None:
+        self.annotation = annotation
+
+
 def collect_distributed_pipeline_artifacts(
     *,
     model,
@@ -162,9 +176,20 @@ def collect_distributed_pipeline_artifacts(
     annotation_groups = (
         _embeddable_annotation_groups(process_list_path) if annotation_aware else {}
     )
-    pending_slides, _ = pending_local_embedding_records(
+    # The embedding *stage* must fan out per (sample_id, annotation) for every level (tile / slide /
+    # hierarchical) so each class's tiles are actually embedded — independent of whether the
+    # process-list *reconcile* is annotation-aware (tile artifacts stay sample_id-keyed in #167).
+    stage_annotation_groups = _embeddable_annotation_groups(process_list_path)
+    # One annotation per ``successful_slides`` entry (the tiling spine fans out per class). Carry each
+    # on a lightweight placeholder so the resume gate keys by (sample_id, annotation) and the surviving
+    # pending entries hand the stage the right per-class work units.
+    stage_annotations = _annotations_parallel_to_slides(successful_slides, stage_annotation_groups)
+    annotation_placeholders = [
+        _AnnotationPlaceholder(annotation) for annotation in stage_annotations
+    ]
+    pending_slides, pending_placeholders = pending_local_embedding_records(
         successful_slides,
-        [None] * len(successful_slides),
+        annotation_placeholders,
         process_list_path=process_list_path,
         output_dir=output_dir,
         output_format=execution.output_format,
@@ -174,6 +199,7 @@ def collect_distributed_pipeline_artifacts(
         save_latents=execution.save_latents,
         resume=preprocessing.resume,
     )
+    pending_annotations = [placeholder.annotation for placeholder in pending_placeholders]
     skipped_slide_count = len(successful_slides) - len(pending_slides)
     if preprocessing.resume and skipped_slide_count > 0:
         emit_progress(
@@ -244,6 +270,7 @@ def collect_distributed_pipeline_artifacts(
         execution=execution,
         output_dir=output_dir,
         tiling_input_dir=tiling_input_dir,
+        annotations=pending_annotations,
         on_progress_event=_update_process_list_for_finished_slide,
     )
     # ``successful_slides`` is already one entry per (sample_id, annotation) row, so resolve a

--- a/slide2vec/runtime/distributed.py
+++ b/slide2vec/runtime/distributed.py
@@ -66,6 +66,27 @@ def decode_work_unit(key: str) -> tuple[str, str | None]:
     return str(key), None
 
 
+# Reserved separator joining the (percent-encoded) sample_id and class in a composite shard stem.
+# Both halves are percent-encoded with ``safe=""`` so this token can never appear inside either,
+# which keeps the stem reversible and collision-free across (sample_id, annotation) pairs.
+_SHARD_STEM_SEP = ".__cls__."
+
+
+def work_unit_shard_stem(sample_id: str, annotation: str | None) -> str:
+    """Filesystem-safe coordination/shard filename stem for a ``(sample_id, annotation)`` unit.
+
+    Flat units (normalized annotation is ``None``) keep the bare ``sample_id`` unchanged so existing
+    runs produce byte-identical coordination filenames. A genuine per-class unit appends a reversible
+    percent-encoded suffix that cannot collide with another sample's flat stem or with a sibling class.
+    """
+    from urllib.parse import quote
+
+    normalized = normalize_work_unit_annotation(annotation)
+    if normalized is None:
+        return str(sample_id)
+    return f"{quote(str(sample_id), safe='')}{_SHARD_STEM_SEP}{quote(normalized, safe='')}"
+
+
 @contextmanager
 def distributed_coordination_dir(work_dir: Path):
     coordination_dir = Path(tempfile.mkdtemp(prefix="slide2vec-dist-", dir=work_dir))
@@ -241,10 +262,13 @@ def assign_slides_to_ranks(
     heapq.heapify(assigned_ranks)
     sortable = []
     for slide, tiling_result in zip(slide_records, tiling_results):
-        sortable.append((slide.sample_id, num_tiles(tiling_result)))
-    for sample_id, tile_count in sorted(sortable, key=lambda item: (-item[1], item[0])):
+        # Each (sample_id, annotation) is an independent unit balanced by its own tile count; a
+        # slide's classes may land on different ranks. Flat units encode to the bare sample_id.
+        unit_key = encode_work_unit(slide.sample_id, getattr(tiling_result, "annotation", None))
+        sortable.append((unit_key, num_tiles(tiling_result)))
+    for unit_key, tile_count in sorted(sortable, key=lambda item: (-item[1], item[0])):
         assigned_tiles, rank = heapq.heappop(assigned_ranks)
-        assignments[rank].append(sample_id)
+        assignments[rank].append(unit_key)
         heapq.heappush(assigned_ranks, (assigned_tiles + int(tile_count), rank))
     return assignments
 
@@ -287,16 +311,23 @@ def merge_hierarchical_embedding_shards(
     return merged.reshape(int(num_regions), int(tiles_per_region), int(merged.shape[-1]))
 
 
-def load_tile_embedding_shards(coordination_dir: Path, sample_id: str):
-    shard_paths = sorted(coordination_dir.glob(f"{sample_id}.tiles.rank*.pt"))
+def load_tile_embedding_shards(coordination_dir: Path, stem: str):
+    shard_paths = sorted(coordination_dir.glob(f"{glob_escape(stem)}.tiles.rank*.pt"))
     return [torch.load(path, map_location="cpu", weights_only=True) for path in shard_paths]
 
 
-def load_hierarchical_embedding_shards(coordination_dir: Path, sample_id: str):
-    shard_paths = sorted(coordination_dir.glob(f"{sample_id}.hier.rank*.pt"))
+def load_hierarchical_embedding_shards(coordination_dir: Path, stem: str):
+    shard_paths = sorted(coordination_dir.glob(f"{glob_escape(stem)}.hier.rank*.pt"))
     return [torch.load(path, map_location="cpu", weights_only=True) for path in shard_paths]
 
 
-def load_embedded_slide_payload(coordination_dir: Path, sample_id: str):
-    payload_path = coordination_dir / f"{sample_id}.embedded.pt"
+def load_embedded_slide_payload(coordination_dir: Path, stem: str):
+    payload_path = coordination_dir / f"{stem}.embedded.pt"
     return torch.load(payload_path, map_location="cpu", weights_only=True)
+
+
+def glob_escape(text: str) -> str:
+    """Escape glob metacharacters in a shard stem so a literal stem matches itself."""
+    from glob import escape
+
+    return escape(text)

--- a/slide2vec/runtime/distributed.py
+++ b/slide2vec/runtime/distributed.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import heapq
+import json
 import os
 import shutil
 import signal
@@ -16,9 +17,53 @@ from typing import Any, Callable, Sequence
 import numpy as np
 import torch
 from hs2p import SlideSpec
+from hs2p.fileops import is_flattened_annotation
 
 from slide2vec.progress import emit_progress_event, read_progress_events
 from slide2vec.runtime.hierarchical import num_tiles
+
+
+# Sentinel prefix for composite (sample_id, annotation) work-unit keys. Bare sample_ids never carry
+# this prefix, so a real per-class unit can never collide with another sample's flat key.
+_WORK_UNIT_PREFIX = "\x00s2v-unit\x00"
+
+
+def normalize_work_unit_annotation(annotation: str | None) -> str | None:
+    """Collapse flat-layout annotations to ``None`` so flat units key by bare ``sample_id``.
+
+    Mirrors the in-memory single-GPU path and the distributed reconcile
+    (:func:`slide2vec.runtime.artifacts_collect._normalized_row_annotation`): ``None``, hs2p's
+    flat-layout sentinels (:func:`hs2p.fileops.is_flattened_annotation`, e.g. ``"tissue"``), and the
+    merged output-mode label ``"merged"`` all collapse to ``None``. Only genuine per-class
+    annotations survive as a composite key.
+    """
+    if annotation is None:
+        return None
+    annotation = str(annotation)
+    if annotation == "merged" or is_flattened_annotation(annotation):
+        return None
+    return annotation
+
+
+def encode_work_unit(sample_id: str, annotation: str | None) -> str:
+    """Encode a ``(sample_id, annotation)`` distributed work unit as a single string key.
+
+    Flat units (normalized annotation is ``None``) return the bare ``sample_id`` unchanged, so
+    tissue-only / single-class / merged runs produce byte-identical assignments and coordination
+    filenames as before. A genuine per-class unit returns a reversible, collision-free composite.
+    """
+    normalized = normalize_work_unit_annotation(annotation)
+    if normalized is None:
+        return str(sample_id)
+    return _WORK_UNIT_PREFIX + json.dumps([str(sample_id), normalized])
+
+
+def decode_work_unit(key: str) -> tuple[str, str | None]:
+    """Inverse of :func:`encode_work_unit`: ``key`` -> ``(sample_id, annotation_or_none)``."""
+    if isinstance(key, str) and key.startswith(_WORK_UNIT_PREFIX):
+        sample_id, annotation = json.loads(key[len(_WORK_UNIT_PREFIX):])
+        return str(sample_id), annotation
+    return str(key), None
 
 
 @contextmanager

--- a/slide2vec/runtime/distributed_stage.py
+++ b/slide2vec/runtime/distributed_stage.py
@@ -16,6 +16,7 @@ from slide2vec.runtime.embedding_pipeline import aggregate_tile_embeddings_for_s
 from slide2vec.runtime.distributed import (
     distributed_coordination_dir,
     assign_slides_to_ranks,
+    encode_work_unit,
     load_embedded_slide_payload,
     load_hierarchical_embedding_shards,
     load_tile_embedding_shards,
@@ -23,7 +24,9 @@ from slide2vec.runtime.distributed import (
     merge_tile_embedding_shards,
     reset_progress_event_logs,
     run_torchrun_worker,
+    work_unit_shard_stem,
 )
+from slide2vec.runtime.embedding import tiling_result_annotation
 from slide2vec.runtime.hierarchical import (
     is_hierarchical_preprocessing,
     num_tiles,
@@ -49,7 +52,7 @@ def build_pipeline_worker_request_payload(
     execution: ExecutionOptions,
     *,
     tiling_input_dir: Path,
-    sample_ids: Sequence[str] | None = None,
+    work_units: Sequence[str] | None = None,
     progress_events_path: Path | None = None,
 ) -> dict[str, Any]:
     return {
@@ -57,7 +60,7 @@ def build_pipeline_worker_request_payload(
         "preprocessing": serialize_preprocessing(preprocessing),
         "execution": serialize_execution(execution, preprocessing=preprocessing),
         "tiling_input_dir": str(tiling_input_dir),
-        "sample_ids": list(sample_ids) if sample_ids is not None else None,
+        "work_units": list(work_units) if work_units is not None else None,
         "progress_events_path": str(progress_events_path) if progress_events_path is not None else None,
     }
 
@@ -84,7 +87,7 @@ def build_direct_embed_worker_request_payload(
     execution: ExecutionOptions,
     coordination_dir: Path,
     strategy: str,
-    sample_id: str | None,
+    work_unit: str | None,
     assignments: dict[int, list[str]] | None,
     progress_events_path: Path | None = None,
 ) -> dict[str, Any]:
@@ -94,8 +97,8 @@ def build_direct_embed_worker_request_payload(
         "preprocessing": serialize_preprocessing(preprocessing),
         "execution": serialize_execution(execution, preprocessing=preprocessing),
         "coordination_dir": str(coordination_dir),
-        "sample_id": sample_id,
-        "assignments": {str(rank): sample_ids for rank, sample_ids in (assignments or {}).items()},
+        "work_unit": work_unit,
+        "assignments": {str(rank): work_units for rank, work_units in (assignments or {}).items()},
         "progress_events_path": str(progress_events_path) if progress_events_path is not None else None,
     }
 
@@ -108,6 +111,7 @@ def run_distributed_embedding_stage(
     execution: ExecutionOptions,
     output_dir: Path,
     tiling_input_dir: Path | None = None,
+    annotations: Sequence[str | None] | None = None,
     on_progress_event: Callable[[Any], None] | None = None,
 ) -> None:
     if not successful_slides:
@@ -115,12 +119,20 @@ def run_distributed_embedding_stage(
     request_path = output_dir / "embedding_request.json"
     progress_events_path = output_dir / "logs" / "pipeline_worker.progress.jsonl"
     reset_progress_event_logs(progress_events_path)
+    # One composite work unit per (sample_id, annotation). Flat units encode to the bare sample_id,
+    # so tissue-only / single-class / merged runs send a byte-identical payload to pre-#168.
+    if annotations is None:
+        annotations = [None] * len(successful_slides)
+    work_units = [
+        encode_work_unit(slide.sample_id, annotation)
+        for slide, annotation in zip(successful_slides, annotations)
+    ]
     request_payload = build_pipeline_worker_request_payload(
         model,
         preprocessing,
         execution,
         tiling_input_dir=tiling_input_dir or output_dir,
-        sample_ids=[slide.sample_id for slide in successful_slides],
+        work_units=work_units,
         progress_events_path=progress_events_path,
     )
     request_path.write_text(json.dumps(request_payload, indent=2, sort_keys=True), encoding="utf-8")
@@ -154,7 +166,7 @@ def run_distributed_direct_embedding_stage(
     output_dir: Path,
     coordination_dir: Path,
     strategy: str,
-    sample_id: str | None = None,
+    work_unit: str | None = None,
     assignments: dict[int, list[str]] | None = None,
 ) -> None:
     request_path = coordination_dir / "direct_embedding_request.json"
@@ -166,7 +178,7 @@ def run_distributed_direct_embedding_stage(
         execution=execution,
         coordination_dir=coordination_dir,
         strategy=strategy,
-        sample_id=sample_id,
+        work_unit=work_unit,
         assignments=assignments,
         progress_events_path=progress_events_path,
     )
@@ -191,6 +203,9 @@ def embed_single_slide_distributed(
     execution: ExecutionOptions,
     work_dir: Path,
 ) -> EmbeddedSlide:
+    annotation = tiling_result_annotation(tiling_result)
+    work_unit = encode_work_unit(slide.sample_id, annotation)
+    shard_stem = work_unit_shard_stem(slide.sample_id, annotation)
     with distributed_coordination_dir(work_dir) as coordination_dir:
         run_distributed_direct_embedding_stage(
             model,
@@ -199,10 +214,10 @@ def embed_single_slide_distributed(
             output_dir=work_dir,
             coordination_dir=coordination_dir,
             strategy="tile_shard",
-            sample_id=slide.sample_id,
+            work_unit=work_unit,
         )
         if is_hierarchical_preprocessing(preprocessing):
-            shard_payloads = load_hierarchical_embedding_shards(coordination_dir, slide.sample_id)
+            shard_payloads = load_hierarchical_embedding_shards(coordination_dir, shard_stem)
             geometry = resolve_hierarchical_geometry(preprocessing, tiling_result)
             tile_embeddings = merge_hierarchical_embedding_shards(
                 shard_payloads,
@@ -210,7 +225,7 @@ def embed_single_slide_distributed(
                 tiles_per_region=int(geometry["tiles_per_region"]),
             )
         else:
-            shard_payloads = load_tile_embedding_shards(coordination_dir, slide.sample_id)
+            shard_payloads = load_tile_embedding_shards(coordination_dir, shard_stem)
             tile_embeddings = merge_tile_embedding_shards(shard_payloads)
         if model.level != "slide":
             return make_embedded_slide(
@@ -263,7 +278,10 @@ def embed_multi_slides_distributed(
         )
         results = []
         for slide, tiling_result in zip(slide_records, tiling_results):
-            payload = load_embedded_slide_payload(coordination_dir, slide.sample_id)
+            shard_stem = work_unit_shard_stem(
+                slide.sample_id, tiling_result_annotation(tiling_result)
+            )
+            payload = load_embedded_slide_payload(coordination_dir, shard_stem)
             slide_embedding = payload["slide_embedding"] if "slide_embedding" in payload else None
             latents = payload["latents"] if "latents" in payload else None
             results.append(

--- a/slide2vec/runtime/embedding_pipeline.py
+++ b/slide2vec/runtime/embedding_pipeline.py
@@ -411,6 +411,9 @@ def compute_embedded_slides(
         emit_progress(
             "embedding.slide.finished",
             sample_id=slide.sample_id,
+            # Carry the per-class annotation so the distributed live updater (#167) matches the right
+            # (sample_id, annotation) row rather than collapsing siblings onto the first finished one.
+            annotation=getattr(tiling_result, "annotation", None),
             num_tiles=num_embedding_items(tiling_result, preprocessing),
         )
     return embedded_slides

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -578,7 +578,7 @@ def test_build_direct_embed_worker_request_payload_includes_progress_events_path
         execution=inference.ExecutionOptions(output_dir=tmp_path),
         coordination_dir=tmp_path / "coord",
         strategy="slide_shard",
-        sample_id=None,
+        work_unit=None,
         assignments={0: ["slide-a"]},
         progress_events_path=tmp_path / "logs" / "direct.progress.jsonl",
     )

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -334,6 +334,7 @@ def test_collect_distributed_pipeline_artifacts_runs_stage_collects_and_updates(
         execution,
         output_dir,
         tiling_input_dir=None,
+        annotations=None,
         on_progress_event=None,
     ):
         captured["run_stage"] = {
@@ -343,6 +344,7 @@ def test_collect_distributed_pipeline_artifacts_runs_stage_collects_and_updates(
             "execution": execution,
             "output_dir": output_dir,
             "tiling_input_dir": tiling_input_dir,
+            "annotations": annotations,
             "on_progress_event": on_progress_event,
         }
 
@@ -1598,7 +1600,7 @@ def test_pipeline_worker_disables_result_collection_when_streaming(monkeypatch, 
                 "preprocessing": {},
                 "execution": {},
                 "tiling_input_dir": str(tmp_path),
-                "sample_ids": ["slide-a"],
+                "work_units": ["slide-a"],
             }
         ),
         encoding="utf-8",
@@ -1664,7 +1666,7 @@ def test_pipeline_worker_filters_to_requested_sample_ids(monkeypatch, tmp_path: 
                 "preprocessing": {},
                 "execution": {},
                 "tiling_input_dir": str(tmp_path),
-                "sample_ids": ["slide-b"],
+                "work_units": ["slide-b"],
             }
         ),
         encoding="utf-8",
@@ -5848,3 +5850,180 @@ def test_decode_work_unit_returns_flat_annotation_as_none():
 
     assert decode_work_unit(encode_work_unit("slide-a", None)) == ("slide-a", None)
     assert decode_work_unit("slide-a") == ("slide-a", None)
+
+
+def test_assign_slides_to_ranks_balances_per_class_unit_and_splits_siblings():
+    """A multi-class slide fans out into independent (sample_id, annotation) units, each balanced by
+    its own tile count; a slide's classes may land on different ranks (decision #4)."""
+    from slide2vec.runtime.distributed import assign_slides_to_ranks, decode_work_unit
+
+    slides = [make_slide("slide-a"), make_slide("slide-a")]
+    tiling_results = [
+        SimpleNamespace(x=np.arange(9), y=np.arange(9), tile_size_lv0=224, annotation="tumor"),
+        SimpleNamespace(x=np.arange(8), y=np.arange(8), tile_size_lv0=224, annotation="stroma"),
+    ]
+
+    assignments = assign_slides_to_ranks(slides, tiling_results, num_gpus=2)
+
+    decoded = {rank: [decode_work_unit(key) for key in keys] for rank, keys in assignments.items()}
+    # Each class is its own unit; the two classes of slide-a land on different ranks.
+    assert decoded == {
+        0: [("slide-a", "tumor")],
+        1: [("slide-a", "stroma")],
+    }
+
+
+def test_assign_slides_to_ranks_flat_units_stay_byte_identical_to_bare_sample_ids():
+    """Tissue-only / merged / None units must produce the exact pre-#168 bare-sample_id assignment."""
+    from slide2vec.runtime.distributed import assign_slides_to_ranks
+
+    slides = [make_slide("slide-a"), make_slide("slide-b")]
+    tiling_results = [
+        SimpleNamespace(x=np.arange(9), y=np.arange(9), tile_size_lv0=224, annotation="tissue"),
+        SimpleNamespace(x=np.arange(8), y=np.arange(8), tile_size_lv0=224, annotation=None),
+    ]
+
+    assignments = assign_slides_to_ranks(slides, tiling_results, num_gpus=2)
+
+    assert assignments == {0: ["slide-a"], 1: ["slide-b"]}
+
+
+@pytest.mark.parametrize("annotation", [None, "tissue", "merged"])
+def test_work_unit_shard_stem_flat_keeps_bare_sample_id(annotation):
+    """Flat units keep the exact pre-#168 bare-sample_id coordination/shard filename stem."""
+    from slide2vec.runtime.distributed import work_unit_shard_stem
+
+    assert work_unit_shard_stem("slide-a", annotation) == "slide-a"
+
+
+def test_work_unit_shard_stem_real_class_is_unique_and_filesystem_safe():
+    from slide2vec.runtime.distributed import work_unit_shard_stem
+
+    tumor = work_unit_shard_stem("slide-a", "tumor")
+    stroma = work_unit_shard_stem("slide-a", "stroma")
+    other = work_unit_shard_stem("slide-b", "tumor")
+
+    # Two classes of one slide on the same rank do not collide, nor with another sample's flat key.
+    assert len({tumor, stroma, other}) == 3
+    assert tumor != "slide-a"
+    # Filesystem-safe: no path separators or NUL bytes that would break a glob/path.
+    for stem in (tumor, stroma, other):
+        assert "/" not in stem and "\x00" not in stem
+
+
+def test_direct_embed_worker_slide_shard_writes_per_class_payloads_without_collision(monkeypatch, tmp_path: Path):
+    """Two classes of one slide assigned to the same rank must persist to distinct .embedded.pt
+    files (per (sample_id, annotation) stem), so a sibling class is never overwritten."""
+    import torch.distributed as dist
+
+    import slide2vec.distributed as distributed
+    import slide2vec.runtime.serialization as serialization
+    from slide2vec.api import Model
+    from slide2vec.distributed import direct_embed_worker
+    from slide2vec.runtime.distributed import encode_work_unit
+
+    coordination_dir = tmp_path / "coordination"
+    coordination_dir.mkdir()
+    request_path = tmp_path / "request.json"
+    tumor_unit = encode_work_unit("slide-a", "tumor")
+    stroma_unit = encode_work_unit("slide-a", "stroma")
+    request_path.write_text(
+        json.dumps(
+            {
+                "model": {"name": "virchow2", "allow_non_recommended_settings": False},
+                "preprocessing": {},
+                "execution": {},
+                "coordination_dir": str(coordination_dir),
+                "strategy": "slide_shard",
+                "assignments": {"0": [tumor_unit, stroma_unit]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    slide = make_slide("slide-a")
+    tumor_tr = SimpleNamespace(x=np.array([0]), y=np.array([1]), tile_size_lv0=224, annotation="tumor")
+    stroma_tr = SimpleNamespace(x=np.array([2]), y=np.array([3]), tile_size_lv0=224, annotation="stroma")
+
+    monkeypatch.setattr(distributed, "enable", lambda overwrite=True: None)
+    monkeypatch.setattr(distributed, "get_local_rank", lambda: 0)
+    monkeypatch.setattr(distributed, "get_global_rank", lambda: 0)
+    monkeypatch.setattr(distributed, "get_global_size", lambda: 1)
+    monkeypatch.setattr(dist, "is_available", lambda: False)
+    monkeypatch.setattr(dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(Model, "from_preset", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(serialization, "deserialize_preprocessing", lambda payload: DEFAULT_PREPROCESSING)
+    monkeypatch.setattr(serialization, "deserialize_execution", lambda payload: ExecutionOptions(output_dir=tmp_path))
+    monkeypatch.setattr(direct_embed_worker, "_to_cpu_payload", lambda value: value)
+    monkeypatch.setattr(
+        manifest,
+        "load_successful_tiled_slides",
+        lambda output_dir: ([slide, slide], [tumor_tr, stroma_tr]),
+    )
+
+    def fake_compute(_model, slides, tiling_results, *, on_embedded_slide, **kwargs):
+        for s, tr in zip(slides, tiling_results):
+            embedded = EmbeddedSlide(
+                sample_id=s.sample_id,
+                tile_embeddings=np.zeros((1, 2), dtype=np.float32),
+                slide_embedding=None,
+                x=tr.x,
+                y=tr.y,
+                tile_size_lv0=tr.tile_size_lv0,
+                image_path=s.image_path,
+                mask_path=None,
+            )
+            on_embedded_slide(s, tr, embedded)
+        return []
+
+    monkeypatch.setattr(embedding_pipeline, "compute_embedded_slides", fake_compute)
+
+    assert direct_embed_worker.main(["--output-dir", str(tmp_path), "--request-path", str(request_path)]) == 0
+
+    from slide2vec.runtime.distributed import work_unit_shard_stem
+
+    tumor_path = coordination_dir / f"{work_unit_shard_stem('slide-a', 'tumor')}.embedded.pt"
+    stroma_path = coordination_dir / f"{work_unit_shard_stem('slide-a', 'stroma')}.embedded.pt"
+    assert tumor_path.is_file()
+    assert stroma_path.is_file()
+    assert tumor_path != stroma_path
+
+
+def test_compute_embedded_slides_finished_event_carries_annotation(monkeypatch):
+    """The embedding.slide.finished payload must carry the per-class annotation so the #167 live
+    updater matches the right (sample_id, annotation) row."""
+    import slide2vec.progress as progress
+
+    slide = make_slide("slide-a")
+    tiling_result = SimpleNamespace(x=np.array([0]), y=np.array([1]), tile_size_lv0=224, annotation="tumor")
+
+    loaded = SimpleNamespace()
+    model = SimpleNamespace(level="tile", _load_backend=lambda: loaded)
+
+    monkeypatch.setattr(
+        embedding_pipeline,
+        "compute_tile_embeddings_for_slide",
+        lambda *args, **kwargs: np.zeros((1, 2), dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        embedding_pipeline,
+        "aggregate_tile_embeddings_for_slide",
+        lambda *args, **kwargs: (None, None),
+    )
+
+    events = []
+    monkeypatch.setattr(progress, "emit_progress", lambda kind, **payload: events.append((kind, payload)))
+    monkeypatch.setattr(embedding_pipeline, "emit_progress", lambda kind, **payload: events.append((kind, payload)))
+
+    embedding_pipeline.compute_embedded_slides(
+        model,
+        [slide],
+        [tiling_result],
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=ExecutionOptions(output_dir=None),
+        collect_results=False,
+    )
+
+    finished = [payload for kind, payload in events if kind == "embedding.slide.finished"]
+    assert finished, "expected an embedding.slide.finished event"
+    assert finished[0]["annotation"] == "tumor"

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -5812,3 +5812,39 @@ def test_zero_tile_hierarchical_sidecar_namespaces_per_class(monkeypatch, tmp_pa
 
     _sidecar("tissue")
     assert (tmp_path / "hierarchical_embeddings" / "slide-z.meta.json").is_file()
+
+
+# --- Issue #168: annotation-aware fan-out for the distributed embedding stage ---
+
+
+@pytest.mark.parametrize("annotation", [None, "tissue", "merged"])
+def test_encode_work_unit_collapses_flat_annotation_to_bare_sample_id(annotation):
+    """Flat annotations (None / tissue / merged) must encode to the bare sample_id, byte-identical
+    to the pre-#168 sample_id-keyed assignment and coordination filenames."""
+    from slide2vec.runtime.distributed import encode_work_unit
+
+    assert encode_work_unit("slide-a", annotation) == "slide-a"
+
+
+def test_encode_work_unit_encodes_real_class_reversibly_without_collision():
+    from slide2vec.runtime.distributed import decode_work_unit, encode_work_unit
+
+    tumor = encode_work_unit("slide-a", "tumor")
+    stroma = encode_work_unit("slide-a", "stroma")
+    other_slide = encode_work_unit("slide-b", "tumor")
+
+    # Composite keys for distinct (sample_id, annotation) pairs never collide.
+    assert tumor != stroma
+    assert tumor != other_slide
+    assert tumor != "slide-a"
+
+    # Reversible back to the original (sample_id, normalized annotation) pair.
+    assert decode_work_unit(tumor) == ("slide-a", "tumor")
+    assert decode_work_unit(stroma) == ("slide-a", "stroma")
+
+
+def test_decode_work_unit_returns_flat_annotation_as_none():
+    from slide2vec.runtime.distributed import decode_work_unit, encode_work_unit
+
+    assert decode_work_unit(encode_work_unit("slide-a", None)) == ("slide-a", None)
+    assert decode_work_unit("slide-a") == ("slide-a", None)

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -618,6 +618,83 @@ def test_collect_distributed_pipeline_artifacts_records_per_class_slide_paths_fo
     assert stroma_row["aggregation_status"] == "success"
 
 
+def test_collect_distributed_pipeline_artifacts_fans_out_per_class_annotations_to_stage(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """Issue #168: the distributed embedding stage must receive one work unit per (sample_id,
+    annotation), so every class is embedded. The parent passes the per-class annotations (resolved
+    from the process_list) parallel to the slides."""
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "tumor",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.tumor.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.tumor.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+            {
+                "sample_id": "slide-a",
+                "annotation": "stroma",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.stroma.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.stroma.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            },
+        ],
+    )
+    write_slide_embeddings("slide-a", np.zeros((8,), dtype=np.float32), output_dir=tmp_path, annotation="tumor")
+    write_slide_embeddings("slide-a", np.zeros((8,), dtype=np.float32), output_dir=tmp_path, annotation="stroma")
+
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=2, output_format="pt")
+    model = SimpleNamespace(name="prism", level="slide")
+
+    captured = {}
+
+    def fake_stage(*, annotations, successful_slides, **kwargs):
+        captured["annotations"] = list(annotations)
+        captured["sample_ids"] = [s.sample_id for s in successful_slides]
+
+    monkeypatch.setattr(artifacts_collect, "run_distributed_embedding_stage", fake_stage)
+
+    artifacts_collect.collect_distributed_pipeline_artifacts(
+        model=model,
+        successful_slides=[slide, slide],
+        process_list_path=process_list_path,
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=execution,
+        output_dir=tmp_path,
+    )
+
+    assert captured["sample_ids"] == ["slide-a", "slide-a"]
+    assert captured["annotations"] == ["tumor", "stroma"]
+
+
 @pytest.mark.parametrize("annotation", ["tissue", "merged", None])
 def test_collect_distributed_pipeline_artifacts_keeps_flat_path_for_flattened_annotation(
     monkeypatch,
@@ -6027,3 +6104,64 @@ def test_compute_embedded_slides_finished_event_carries_annotation(monkeypatch):
     finished = [payload for kind, payload in events if kind == "embedding.slide.finished"]
     assert finished, "expected an embedding.slide.finished event"
     assert finished[0]["annotation"] == "tumor"
+
+
+def test_pipeline_worker_embeds_every_class_of_a_multi_class_slide(monkeypatch, tmp_path: Path):
+    """Pipeline-worker path: a multi-label slide's classes must NOT collapse by sample_id — every
+    (sample_id, annotation) unit is computed (the bug #168 fixes)."""
+    import torch.distributed as dist
+
+    import slide2vec.distributed as distributed
+    import slide2vec.runtime.serialization as serialization
+    from slide2vec.api import Model
+    from slide2vec.distributed import pipeline_worker
+    from slide2vec.runtime.distributed import encode_work_unit
+
+    tumor_unit = encode_work_unit("slide-a", "tumor")
+    stroma_unit = encode_work_unit("slide-a", "stroma")
+    request_path = tmp_path / "request.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "model": {"name": "virchow2", "allow_non_recommended_settings": False},
+                "preprocessing": {},
+                "execution": {},
+                "tiling_input_dir": str(tmp_path),
+                "work_units": [tumor_unit, stroma_unit],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    slide = make_slide("slide-a")
+    tumor_tr = SimpleNamespace(x=np.array([0]), y=np.array([1]), tile_size_lv0=224, annotation="tumor")
+    stroma_tr = SimpleNamespace(x=np.array([2]), y=np.array([3]), tile_size_lv0=224, annotation="stroma")
+    captured = {}
+
+    monkeypatch.setattr(distributed, "enable", lambda overwrite=True: None)
+    monkeypatch.setattr(distributed, "get_local_rank", lambda: 0)
+    monkeypatch.setattr(distributed, "get_global_rank", lambda: 0)
+    monkeypatch.setattr(distributed, "get_global_size", lambda: 1)
+    monkeypatch.setattr(dist, "is_available", lambda: False)
+    monkeypatch.setattr(dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(Model, "from_preset", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(serialization, "deserialize_preprocessing", lambda payload: DEFAULT_PREPROCESSING)
+    monkeypatch.setattr(serialization, "deserialize_execution", lambda payload: ExecutionOptions(output_dir=tmp_path))
+    monkeypatch.setattr(
+        manifest,
+        "load_successful_tiled_slides",
+        lambda tiling_input_dir: ([slide, slide], [tumor_tr, stroma_tr]),
+    )
+    monkeypatch.setattr(persist_callbacks, "build_incremental_persist_callback",
+        lambda **kwargs: (lambda *args, **kwargs: None, [], []),
+    )
+
+    def fake_compute(_model, slides, tiling_results, **kwargs):
+        captured["annotations"] = [tr.annotation for tr in tiling_results]
+        return []
+
+    monkeypatch.setattr(embedding_pipeline, "compute_embedded_slides", fake_compute)
+
+    assert pipeline_worker.main(["--output-dir", str(tmp_path), "--request-path", str(request_path)]) == 0
+    # Both classes of the single slide are embedded — sibling annotations are NOT overwritten.
+    assert sorted(captured["annotations"]) == ["stroma", "tumor"]


### PR DESCRIPTION
## Annotation-aware fan-out for the distributed (multi-GPU) embedding stage

Closes #168

#167 made the distributed *reconcile / process_list bookkeeping* annotation-aware. This PR is the complementary half: the distributed *embedding work itself* now fans out per `(sample_id, annotation)`, so a multi-label distributed run actually embeds **every** class for every slide instead of silently dropping all but one class per slide before the workers start.

### What changed

Introduced a composite work-unit key threaded through both distributed mechanisms, normalized so flat units stay byte-identical:

- `runtime/distributed.py`
  - `normalize_work_unit_annotation` / `encode_work_unit` / `decode_work_unit` — collapse `None` / `tissue` / `merged` (via `hs2p.fileops.is_flattened_annotation`) to the bare `sample_id`; genuine per-class annotations get a reversible, collision-free composite key.
  - `work_unit_shard_stem` — filesystem-safe coordination/shard filename stem; flat units keep the **exact** bare-`sample_id` filename, real classes get a reversible percent-encoded suffix that cannot collide with a sibling class or another sample.
  - `assign_slides_to_ranks` now balances each `(sample_id, annotation)` as an independent unit by its own tile count (siblings may land on different ranks) and returns composite keys. Flat runs produce identical assignments.
  - shard/payload loaders key by stem (with `glob.escape`).
- **Pipeline-worker path** (`distributed/pipeline_worker.py`, `runtime/distributed_stage.py`): request payload carries `work_units` (composite keys); the worker's pairing dict is keyed by the composite so sibling classes no longer overwrite each other.
- **Direct-embed path** (`distributed/direct_embed_worker.py`, `runtime/distributed_stage.py`): assignment + coordination shard files keyed per `(sample_id, annotation)` for both `tile_shard` and `slide_shard` strategies.
- `runtime/artifacts_collect.py`: resolves per-class annotations from the process_list and threads them (parallel to the pending slides) into the stage, so every class is embedded — independent of whether the #167 reconcile is annotation-aware. The crash-safe live updater (defer whole-row rewrite until all siblings persisted) is preserved.
- `runtime/embedding_pipeline.py`: `embedding.slide.finished` now carries `annotation`.

### Backward-compat invariant

Tissue-only / single-class / `merged` runs produce byte-identical **rank assignments** and **coordination filenames** as before; single-GPU paths are unchanged. (The pipeline-worker request payload renames the internal `sample_ids` key to `work_units`; the list values for flat runs are identical bare sample_ids — parent and worker are updated in lockstep, so this is an internal protocol detail.)

### Acceptance criteria

- [x] A multi-label distributed run embeds every class for every slide (per-class artifact at the correct path).
- [x] Both distributed mechanisms fixed (pipeline-worker AND direct-embed).
- [x] `assign_slides_to_ranks` balances per `(sample_id, annotation)` unit; siblings may land on different ranks.
- [x] Coordination/shard files unique per `(sample_id, annotation)`; two classes of one slide on the same rank do not collide.
- [x] `None` / `tissue` / `merged` runs byte-identical (assignments + coordination filenames); single-GPU paths unchanged.
- [x] Regression tests exercise both distributed paths with a multi-class fixture (per-class fan-out, no shard collision, normalized-flat parity).
- [x] Full suite green.

### Tests

`pytest -q` → `345 passed, 15 skipped`.
