### PR TITLE
Preserve informative annotation labels through the tiling-result round-trip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.1.1",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.1.2",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -88,7 +88,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.1.1",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.1.2",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/slide2vec/runtime/artifacts_collect.py
+++ b/slide2vec/runtime/artifacts_collect.py
@@ -101,15 +101,14 @@ def _normalized_row_annotation(annotation) -> str | None:
     """Collapse a process-list ``annotation`` cell to the per-class key (``None`` for the flat path).
 
     Mirrors the in-memory single-GPU path: ``None``/NaN and hs2p's flat-layout sentinels
-    (:func:`hs2p.fileops.is_flattened_annotation`, e.g. ``"tissue"``) land flat, and the merged
-    output-mode label ``"merged"`` is collapsed to ``None`` exactly as
-    :func:`slide2vec.utils.tiling_io.load_tiling_result_from_row` does — so the distributed reconcile
-    keys those rows to the flat embedding path with no per-class subdir.
+    (:func:`hs2p.fileops.is_flattened_annotation` — the single source of truth, which flattens
+    ``None``/``"tissue"``/``"merged"``) land flat — so the distributed reconcile keys those rows
+    to the flat embedding path with no per-class subdir.
     """
     if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
         return None
     annotation = str(annotation)
-    if annotation == "merged" or is_flattened_annotation(annotation):
+    if is_flattened_annotation(annotation):
         return None
     return annotation
 

--- a/slide2vec/runtime/distributed.py
+++ b/slide2vec/runtime/distributed.py
@@ -32,15 +32,15 @@ def normalize_work_unit_annotation(annotation: str | None) -> str | None:
     """Collapse flat-layout annotations to ``None`` so flat units key by bare ``sample_id``.
 
     Mirrors the in-memory single-GPU path and the distributed reconcile
-    (:func:`slide2vec.runtime.artifacts_collect._normalized_row_annotation`): ``None``, hs2p's
-    flat-layout sentinels (:func:`hs2p.fileops.is_flattened_annotation`, e.g. ``"tissue"``), and the
-    merged output-mode label ``"merged"`` all collapse to ``None``. Only genuine per-class
+    (:func:`slide2vec.runtime.artifacts_collect._normalized_row_annotation`): hs2p's flat-layout
+    sentinels (:func:`hs2p.fileops.is_flattened_annotation`, the single source of truth — it
+    flattens ``None``/``"tissue"``/``"merged"``) all collapse to ``None``. Only genuine per-class
     annotations survive as a composite key.
     """
     if annotation is None:
         return None
     annotation = str(annotation)
-    if annotation == "merged" or is_flattened_annotation(annotation):
+    if is_flattened_annotation(annotation):
         return None
     return annotation
 

--- a/slide2vec/runtime/persistence.py
+++ b/slide2vec/runtime/persistence.py
@@ -265,14 +265,15 @@ def _normalized_annotation(annotation: Any) -> str | None:
 
     Keying the per-class feature-path map on this normalized value lets the flat tissue-only
     path and a real class share one matching rule without the sentinel leaking into lookups.
-    ``"merged"`` (hs2p's merged output-mode label) carries no class and is collapsed to ``None``
-    here, matching :func:`slide2vec.utils.tiling_io.load_tiling_result_from_row`, so its
-    process-list row resolves to the flat embedding path rather than being left unmatched.
+    Flattening is decided solely by :func:`hs2p.fileops.is_flattened_annotation` (the single
+    source of truth), which flattens ``None``/``"tissue"``/``"merged"`` to the flat root, so
+    ``"merged"`` (hs2p's merged output-mode label, which carries no class) resolves to the flat
+    embedding path rather than being left unmatched.
     """
     if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
         return None
     annotation = str(annotation)
-    if annotation == "merged" or is_flattened_annotation(annotation):
+    if is_flattened_annotation(annotation):
         return None
     return annotation
 

--- a/slide2vec/utils/tiling_io.py
+++ b/slide2vec/utils/tiling_io.py
@@ -244,11 +244,10 @@ def load_tiling_result_from_row(row):
     annotation = annotation if annotation is None else str(annotation)
     # The merged output mode (hs2p's CoordinateOutputMode.MERGED) emits a single per-slide
     # coordinate set over the union of tiles passing any active class threshold. hs2p labels
-    # that process-list row "merged" so it is not mistaken for plain tissue, but it carries no
-    # class — collapse it to None here so the flatten rule (is_flattened_annotation) lands its
-    # artifacts at the flat output root, with no per-class subdir.
-    if annotation == "merged":
-        annotation = None
+    # that process-list row "merged" so it is not mistaken for plain tissue. The informative
+    # label is preserved verbatim here — artifact placement is decided downstream solely by
+    # hs2p.fileops.is_flattened_annotation (which flattens None/"tissue"/"merged" to the flat
+    # output root), so "merged" still lands flat without erasing its self-describing label.
     setattr(tiling_result, "annotation", annotation)
     setattr(tiling_result, "tiles_tar_path", _optional_path(row.get("tiles_tar_path")))
     setattr(tiling_result, "mask_preview_path", _optional_path(row.get("mask_preview_path")))

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -842,9 +842,10 @@ def test_independent_sampling_toggle_selects_selection_strategy():
     assert joint[-2] == "joint_sampling"
 
 
-def test_merged_annotation_label_collapses_to_flat_root(tmp_path: Path):
-    """A merged tiling row is labelled ``merged`` by hs2p, but carries no class — it must
-    collapse to the flat output root (no per-class subdir), exactly like tissue/None."""
+def test_merged_annotation_label_survives_round_trip_to_flat_root(tmp_path: Path):
+    """A merged tiling row is labelled ``merged`` by hs2p. The informative label must
+    survive the round-trip (no collapse to ``None``), yet artifacts still land at the flat
+    output root because hs2p's ``is_flattened_annotation`` flattens ``"merged"``."""
     from slide2vec.utils.tiling_io import load_tiling_result_from_row
 
     coordinates_meta_path = tmp_path / "slide-a.coordinates.meta.json"
@@ -868,8 +869,8 @@ def test_merged_annotation_label_collapses_to_flat_root(tmp_path: Path):
     finally:
         tiling_io.load_tiling_result = original
 
-    # Merged carries no class label; the flatten rule sends it to the flat root.
-    assert result.annotation is None
+    # The informative label survives the round-trip; it is not blanked to None.
+    assert result.annotation == "merged"
     artifact = write_tile_embeddings(
         "slide-a",
         np.arange(8, dtype=np.float32).reshape(2, 4),
@@ -877,7 +878,82 @@ def test_merged_annotation_label_collapses_to_flat_root(tmp_path: Path):
         output_format="npz",
         annotation=result.annotation,
     )
+    # ...but placement is decided by is_flattened_annotation, so it still lands flat.
     assert artifact.path == tmp_path / "tile_embeddings" / "slide-a.npz"
+
+
+def test_tissue_annotation_survives_round_trip_to_flat_root(tmp_path: Path):
+    """A ``"tissue"`` row keeps its informative label through the round-trip while still
+    resolving to flat-root placement via ``is_flattened_annotation``."""
+    from slide2vec.utils.tiling_io import load_tiling_result_from_row
+
+    coordinates_meta_path = tmp_path / "slide-t.coordinates.meta.json"
+    coordinates_meta_path.write_text("{}", encoding="utf-8")
+
+    def fake_load_tiling_result(**kwargs):
+        return SimpleNamespace()
+
+    import slide2vec.utils.tiling_io as tiling_io
+
+    original = tiling_io.load_tiling_result
+    tiling_io.load_tiling_result = fake_load_tiling_result
+    try:
+        result = load_tiling_result_from_row(
+            {
+                "annotation": "tissue",
+                "coordinates_npz_path": str(tmp_path / "slide-t.coordinates.npz"),
+                "coordinates_meta_path": str(coordinates_meta_path),
+            }
+        )
+    finally:
+        tiling_io.load_tiling_result = original
+
+    assert result.annotation == "tissue"
+    artifact = write_tile_embeddings(
+        "slide-t",
+        np.arange(8, dtype=np.float32).reshape(2, 4),
+        output_dir=tmp_path,
+        output_format="npz",
+        annotation=result.annotation,
+    )
+    assert artifact.path == tmp_path / "tile_embeddings" / "slide-t.npz"
+
+
+def test_real_class_annotation_survives_round_trip_to_per_class_subdir(tmp_path: Path):
+    """A genuine class label (e.g. ``"tumor"``) survives the round-trip and routes to its
+    own per-class subdir, since ``is_flattened_annotation`` does not flatten it."""
+    from slide2vec.utils.tiling_io import load_tiling_result_from_row
+
+    coordinates_meta_path = tmp_path / "slide-u.coordinates.meta.json"
+    coordinates_meta_path.write_text("{}", encoding="utf-8")
+
+    def fake_load_tiling_result(**kwargs):
+        return SimpleNamespace()
+
+    import slide2vec.utils.tiling_io as tiling_io
+
+    original = tiling_io.load_tiling_result
+    tiling_io.load_tiling_result = fake_load_tiling_result
+    try:
+        result = load_tiling_result_from_row(
+            {
+                "annotation": "tumor",
+                "coordinates_npz_path": str(tmp_path / "slide-u.coordinates.npz"),
+                "coordinates_meta_path": str(coordinates_meta_path),
+            }
+        )
+    finally:
+        tiling_io.load_tiling_result = original
+
+    assert result.annotation == "tumor"
+    artifact = write_tile_embeddings(
+        "slide-u",
+        np.arange(8, dtype=np.float32).reshape(2, 4),
+        output_dir=tmp_path,
+        output_format="npz",
+        annotation=result.annotation,
+    )
+    assert artifact.path == tmp_path / "tile_embeddings" / "tumor" / "slide-u.npz"
 
 
 def test_invalid_masks_block_with_duplicate_pixel_values_fails_fast():

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -2280,9 +2280,10 @@ def test_tile_slides_forwards_independent_sampling_selection_strategy(monkeypatc
     assert captured["kwargs"]["output_mode"] == "per_annotation"
 
 
-def test_prepare_tiled_slides_collapses_merged_row_to_flat_root(monkeypatch, tmp_path: Path):
-    """A merged tiling row (hs2p labels it ``merged``) must load with annotation=None so its
-    embedding artifacts land at the flat output root, not under a ``merged/`` subdir."""
+def test_prepare_tiled_slides_preserves_merged_row_label(monkeypatch, tmp_path: Path):
+    """A merged tiling row (hs2p labels it ``merged``) must load with its informative label
+    intact (annotation == "merged"), not blanked to None. Artifact placement still flattens
+    to the output root downstream via hs2p's ``is_flattened_annotation``."""
     process_list_path = tmp_path / "process_list.csv"
     process_list_path.write_text(
         "sample_id,annotation,image_path,mask_path,requested_backend,backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
@@ -2316,7 +2317,10 @@ def test_prepare_tiled_slides_collapses_merged_row_to_flat_root(monkeypatch, tmp
         num_workers=0,
     )
 
-    assert captured["annotation"] is None
+    assert captured["annotation"] == "merged"
+    from hs2p.fileops import is_flattened_annotation
+
+    assert is_flattened_annotation(captured["annotation"]) is True
 
 
 def test_tile_slides_does_not_pre_resolve_backend_auto(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary

Foundation for self-describing annotation bags: the informative annotation label now survives the trip from a persisted process-list row back into an in-memory tiling result, without disturbing artifact placement.

- Pin `hs2p` to `>=4.1.2` (both occurrences in `pyproject.toml`), the release that flattens the `merged` label via `is_flattened_annotation`.
- Stop collapsing `"merged"` to `None` in `load_tiling_result_from_row` — the label is preserved verbatim.
- Artifact placement (flat-root vs. per-class subdir) is decided **solely** through `hs2p.fileops.is_flattened_annotation`, the single source of truth. `"tissue"`/`"merged"` keep their labels yet still land at the flat root; a real class (e.g. `"tumor"`) gets its own per-class subdir.
- Dropped the now-redundant `annotation == "merged"` guards in the keying normalizers (`persistence`, `distributed`, `artifacts_collect`) since hs2p 4.1.2 flattens `"merged"` itself; behavior is unchanged.

Inert for the default tissue-only path: it only removes the label-erasing collapse and routes placement through the shared rule.

## Acceptance criteria
- [x] hs2p pinned to the release that flattens `merged` (>= 4.1.2).
- [x] A process-list row labeled `"merged"` round-trips into a tiling result whose annotation is `"merged"`, not `None`.
- [x] `"tissue"` and `"merged"` resolve to flat-root placement via `is_flattened_annotation`; a real class (`"tumor"`) resolves to its own per-class subdir.
- [x] The existing tissue-only round-trip is behaviorally unchanged.

## Tests
- Rewrote `test_merged_annotation_label_collapses_to_flat_root` -> `test_merged_annotation_label_survives_round_trip_to_flat_root` (label survives, still flat).
- Added `test_tissue_annotation_survives_round_trip_to_flat_root` and `test_real_class_annotation_survives_round_trip_to_per_class_subdir`.
- Updated `test_prepare_tiled_slides_collapses_merged_row_to_flat_root` -> `test_prepare_tiled_slides_preserves_merged_row_label`.
- Full suite: `347 passed, 15 skipped`.

Closes #172