### PR TITLE
Stamp every EmbeddedSlide with its annotation label

### DIFF
--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -351,6 +351,11 @@ class EmbeddedSlide:
     image_path: Path
     #: Path to the tissue mask used for tiling, if any.
     mask_path: Path | None = None
+    #: Annotation class this bag of tiles was sampled for. ``"tissue"`` for the
+    #: default tissue-only path, ``"merged"`` for the union output mode, or the
+    #: class name (e.g. ``"tumor"``) when annotation-aware sampling fans a slide
+    #: out into one bag per class. See :ref:`annotation-aware-sampling`.
+    annotation: str | None = None
     #: Number of tiles extracted from the slide.
     num_tiles: int | None = None
     #: Path to the mask preview image, if generated.

--- a/slide2vec/runtime/embedding_persist.py
+++ b/slide2vec/runtime/embedding_persist.py
@@ -56,6 +56,7 @@ def make_embedded_slide(
         tile_size_lv0=int(tiling_result.tile_size_lv0),
         image_path=slide.image_path,
         mask_path=slide.mask_path,
+        annotation=tiling_result_annotation(tiling_result),
         num_tiles=int(n_tiles) if n_tiles is not None else len(x_values),
         mask_preview_path=Path(mask_preview_path) if mask_preview_path is not None else None,
         tiling_preview_path=Path(tiling_preview_path) if tiling_preview_path is not None else None,

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1557,6 +1557,27 @@ def test_make_embedded_slide_carries_tiling_artifact_fields():
     assert embedded.num_tiles == 7
     assert embedded.mask_preview_path == Path("/tmp/slide-a-mask-preview.png")
     assert embedded.tiling_preview_path == Path("/tmp/slide-a-tiling-preview.png")
+    # A tiling_result with no annotation attr yields the helper default (None).
+    assert embedded.annotation is None
+
+
+@pytest.mark.parametrize("annotation", ["tissue", "merged", "tumor"])
+def test_make_embedded_slide_carries_per_class_annotation(annotation):
+    slide = make_slide("slide-a")
+    tiling_result = SimpleNamespace(
+        x=np.array([0], dtype=np.int64),
+        y=np.array([1], dtype=np.int64),
+        tile_size_lv0=224,
+        num_tiles=3,
+        annotation=annotation,
+    )
+    embedded = embedding_persist.make_embedded_slide(
+        slide=slide,
+        tiling_result=tiling_result,
+        tile_embeddings=np.zeros((1, 2), dtype=np.float32),
+        slide_embedding=None,
+    )
+    assert embedded.annotation == annotation
 
 
 def test_run_pipeline_local_branch_uses_incremental_persist_callback(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## What

Make every returned `EmbeddedSlide` self-describing by carrying the informative annotation label of the bag it represents:

- `"tissue"` for the default tissue-only path
- `"merged"` for the union output mode
- the class name (e.g. `"tumor"`) for an annotation-aware class

The label is sourced from the bag's tiling result, so a caller can tell a tumor bag from a stroma bag (and tissue from merged) without re-deriving the mapping. No returned bag carries a bare `None`.

## Changes

- `slide2vec/api.py`: add an `annotation: str | None` field to the `EmbeddedSlide` dataclass (after `mask_path`).
- `slide2vec/runtime/embedding_persist.py`: stamp `annotation=tiling_result_annotation(tiling_result)` in `make_embedded_slide(...)`. After #172 the tiling result carries `"tissue"`/`"merged"`/class verbatim from the process-list row.
- `tests/test_regression_inference.py`: assert the helper default (`None`) in the existing artifact-fields test, and add a parametrized test covering `"tissue"`, `"merged"`, and a per-class (`"tumor"`) label.

Scope is the field + stamping only. No `embed_slide`/`embed_slides` selector or return-shape changes (those belong to #174).

## Tests

`pytest -q`: 348 passed, 15 skipped.

Closes #173