### PR TITLE
Annotation-aware public API: embed_slide selector + embed_slides nested dict

### DIFF
--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -354,7 +354,7 @@ class EmbeddedSlide:
     #: Annotation class this bag of tiles was sampled for. ``"tissue"`` for the
     #: default tissue-only path, ``"merged"`` for the union output mode, or the
     #: class name (e.g. ``"tumor"``) when annotation-aware sampling fans a slide
-    #: out into one bag per class. See :ref:`annotation-aware-sampling`.
+    #: out into one bag per class. See the annotation-aware sampling documentation.
     annotation: str | None = None
     #: Number of tiles extracted from the slide.
     num_tiles: int | None = None
@@ -447,12 +447,13 @@ class Model:
         self,
         slide: SlideInput,
         *,
+        annotation: str | list[str] | None = None,
         preprocessing: PreprocessingConfig | None = None,
         execution: ExecutionOptions | None = None,
         sample_id: str | None = None,
         mask_path: PathLike | None = None,
         spacing_at_level_0: float | None = None,
-    ) -> EmbeddedSlide:
+    ) -> EmbeddedSlide | list[EmbeddedSlide]:
         if isinstance(slide, (str, Path)):
             slide = {
                 "sample_id": sample_id or Path(slide).stem,
@@ -464,31 +465,42 @@ class Model:
             raise ValueError(
                 "sample_id, mask_path, and spacing_at_level_0 overrides are only supported when slide is a path-like input"
             )
-        return self.embed_slides(
+        requested = None if isinstance(annotation, str) else annotation
+        grouped = self.embed_slides(
             [slide],
+            annotations=requested,
             preprocessing=preprocessing,
             execution=execution,
-        )[0]
+        )
+        # Single slide in → at most one outer key out. Flatten to the inner
+        # {label: EmbeddedSlide} mapping (empty when the run produced nothing).
+        bags: dict[str, EmbeddedSlide] = {}
+        for inner in grouped.values():
+            bags = inner
+            break
+        return _select_embedded_bag(bags, annotation)
 
     def embed_slides(
         self,
         slides: SlideSequence,
         *,
+        annotations: list[str] | None = None,
         preprocessing: PreprocessingConfig | None = None,
         execution: ExecutionOptions | None = None,
-    ) -> list[EmbeddedSlide]:
+    ) -> dict[str, dict[str, EmbeddedSlide]]:
         from slide2vec.inference import embed_slides
 
         resolved = _coerce_execution_options(execution, model=self)
         resolved_preprocessing = _resolve_direct_api_preprocessing(self, preprocessing)
         with _auto_progress_reporting(output_dir=resolved.output_dir):
             _validate_model_config(self, resolved_preprocessing, resolved)
-            return embed_slides(
+            embedded = embed_slides(
                 self,
                 slides,
                 preprocessing=resolved_preprocessing,
                 execution=resolved,
             )
+        return _group_embedded_slides(embedded, annotations=annotations)
 
     def embed_patient(
         self,
@@ -653,6 +665,77 @@ class Pipeline:
                 preprocessing=resolved_preprocessing,
                 execution=self.execution,
             )
+
+
+def _select_embedded_bag(
+    bags: Mapping[str, EmbeddedSlide],
+    annotation: str | list[str] | None,
+) -> EmbeddedSlide | list[EmbeddedSlide]:
+    """Select per-class bag(s) from a single slide's ``{label: EmbeddedSlide}`` map.
+
+    numpy-style shape-in/shape-out:
+
+    - a single class string returns one :class:`EmbeddedSlide`;
+    - a list of class strings returns a list in the requested order;
+    - ``None`` returns the single bag when the run produced exactly one,
+      otherwise raises naming the available bags and directing to
+      :meth:`Model.embed_slides`.
+
+    Requesting a class the run did not produce raises naming what is available.
+    """
+    available = sorted(bags)
+    if isinstance(annotation, str):
+        if annotation not in bags:
+            raise ValueError(
+                f"embed_slide() found no '{annotation}' annotation bag for this "
+                f"slide; available bags: {available}."
+            )
+        return bags[annotation]
+    if annotation is not None:
+        selected: list[EmbeddedSlide] = []
+        for label in annotation:
+            if label not in bags:
+                raise ValueError(
+                    f"embed_slide() found no '{label}' annotation bag for this "
+                    f"slide; available bags: {available}."
+                )
+            selected.append(bags[label])
+        return selected
+    if len(bags) == 1:
+        return next(iter(bags.values()))
+    raise ValueError(
+        f"embed_slide() received {len(bags)} annotation bags for this slide "
+        f"({available}); annotation-aware sampling produces one bag per class. "
+        "Pass annotation=... to select a class, or use Model.embed_slides(...) "
+        "to receive every per-class EmbeddedSlide (each carries its .annotation)."
+    )
+
+
+def _group_embedded_slides(
+    embedded: Sequence[EmbeddedSlide],
+    *,
+    annotations: list[str] | None = None,
+) -> dict[str, dict[str, EmbeddedSlide]]:
+    """Group flat per-row :class:`EmbeddedSlide` results into a nested mapping.
+
+    The outer key is ``sample_id``; the inner key is the bag's informative
+    annotation label (``"tissue"``/``"merged"``/class name), never ``None``.
+    A bag whose ``.annotation`` is ``None`` (defensive — post-#173 real runs
+    always carry a label) does not produce a ``None`` key.
+
+    When *annotations* is given, the inner keys are restricted to the named
+    classes (in encounter order).
+    """
+    requested = None if annotations is None else set(annotations)
+    grouped: dict[str, dict[str, EmbeddedSlide]] = {}
+    for bag in embedded:
+        label = bag.annotation
+        if label is None:
+            continue
+        if requested is not None and label not in requested:
+            continue
+        grouped.setdefault(bag.sample_id, {})[label] = bag
+    return grouped
 
 
 def _coerce_execution_options(

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1138,6 +1138,7 @@ def test_model_embed_slide_updates_process_list_feature_status_and_path_in_distr
         tile_size_lv0=224,
         image_path=slide_path,
         mask_path=None,
+        annotation="tissue",
         num_tiles=1,
     )
 

--- a/tests/test_regression_models.py
+++ b/tests/test_regression_models.py
@@ -23,6 +23,20 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PREPROCESSING = PreprocessingConfig(requested_spacing_um=0.5, requested_tile_size_px=224)
 
 
+def _make_embedded_slide(sample_id="slide-a", annotation="tissue", image_path=None):
+    return EmbeddedSlide(
+        sample_id=sample_id,
+        tile_embeddings=np.zeros((1, 2), dtype=np.float32),
+        slide_embedding=None,
+        x=np.array([0], dtype=np.int64),
+        y=np.array([0], dtype=np.int64),
+        tile_size_lv0=224,
+        image_path=Path(image_path or f"/tmp/{sample_id}.svs"),
+        mask_path=None,
+        annotation=annotation,
+    )
+
+
 def test_model_embed_slide_uses_direct_api_and_returns_first_result(monkeypatch):
     model = Model.from_preset("virchow2")
     expected = EmbeddedSlide(
@@ -34,6 +48,7 @@ def test_model_embed_slide_uses_direct_api_and_returns_first_result(monkeypatch)
         tile_size_lv0=224,
         image_path=Path("/tmp/slide-a.svs"),
         mask_path=None,
+        annotation="tissue",
     )
     captured = {}
 
@@ -56,6 +71,131 @@ def test_model_embed_slide_uses_direct_api_and_returns_first_result(monkeypatch)
     assert captured["slides"][0]["sample_id"] == "slide-a"
 
 
+def test_embed_slides_returns_nested_dict_keyed_by_sample_and_label(monkeypatch):
+    model = Model.from_preset("virchow2")
+    slide_a = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
+
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *a, **k: [slide_a])
+
+    result = model.embed_slides(["/tmp/slide-a.svs"], preprocessing=DEFAULT_PREPROCESSING)
+
+    assert result == {"slide-a": {"tissue": slide_a}}
+
+
+def test_embed_slide_returns_single_bag_for_one_bag_run(monkeypatch):
+    model = Model.from_preset("virchow2")
+    slide_a = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
+
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *a, **k: [slide_a])
+
+    result = model.embed_slide("/tmp/slide-a.svs", preprocessing=DEFAULT_PREPROCESSING)
+
+    assert result is slide_a
+
+
+def test_embed_slide_selects_single_class_by_string(monkeypatch):
+    model = Model.from_preset("virchow2")
+    tumor = _make_embedded_slide(sample_id="slide-a", annotation="tumor")
+    stroma = _make_embedded_slide(sample_id="slide-a", annotation="stroma")
+
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *a, **k: [tumor, stroma])
+
+    result = model.embed_slide(
+        "/tmp/slide-a.svs", annotation="stroma", preprocessing=DEFAULT_PREPROCESSING
+    )
+
+    assert result is stroma
+
+
+def test_embed_slide_selects_list_of_classes_in_requested_order(monkeypatch):
+    model = Model.from_preset("virchow2")
+    tumor = _make_embedded_slide(sample_id="slide-a", annotation="tumor")
+    stroma = _make_embedded_slide(sample_id="slide-a", annotation="stroma")
+
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *a, **k: [tumor, stroma])
+
+    result = model.embed_slide(
+        "/tmp/slide-a.svs",
+        annotation=["stroma", "tumor"],
+        preprocessing=DEFAULT_PREPROCESSING,
+    )
+
+    assert result == [stroma, tumor]
+
+
+def test_embed_slide_unknown_class_names_available(monkeypatch):
+    model = Model.from_preset("virchow2")
+    tumor = _make_embedded_slide(sample_id="slide-a", annotation="tumor")
+    stroma = _make_embedded_slide(sample_id="slide-a", annotation="stroma")
+
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *a, **k: [tumor, stroma])
+
+    with pytest.raises(ValueError, match="stroma"):
+        model.embed_slide(
+            "/tmp/slide-a.svs", annotation="lymphocytes", preprocessing=DEFAULT_PREPROCESSING
+        )
+
+
+def test_embed_slide_raises_when_run_fans_out_into_multiple_bags(monkeypatch):
+    model = Model.from_preset("virchow2")
+    tumor = _make_embedded_slide(sample_id="slide-a", annotation="tumor")
+    stroma = _make_embedded_slide(sample_id="slide-a", annotation="stroma")
+
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *a, **k: [tumor, stroma])
+
+    with pytest.raises(ValueError, match="embed_slides"):
+        model.embed_slide("/tmp/slide-a.svs", preprocessing=DEFAULT_PREPROCESSING)
+
+
+def test_embed_slides_groups_multiple_samples_and_classes(monkeypatch):
+    model = Model.from_preset("virchow2")
+    a_tumor = _make_embedded_slide(sample_id="slide-a", annotation="tumor")
+    a_stroma = _make_embedded_slide(sample_id="slide-a", annotation="stroma")
+    b_tumor = _make_embedded_slide(sample_id="slide-b", annotation="tumor")
+
+    monkeypatch.setattr(
+        "slide2vec.inference.embed_slides", lambda *a, **k: [a_tumor, a_stroma, b_tumor]
+    )
+
+    result = model.embed_slides(
+        ["/tmp/slide-a.svs", "/tmp/slide-b.svs"], preprocessing=DEFAULT_PREPROCESSING
+    )
+
+    assert result == {
+        "slide-a": {"tumor": a_tumor, "stroma": a_stroma},
+        "slide-b": {"tumor": b_tumor},
+    }
+
+
+def test_embed_slides_restricts_inner_keys_to_named_annotations(monkeypatch):
+    model = Model.from_preset("virchow2")
+    tumor = _make_embedded_slide(sample_id="slide-a", annotation="tumor")
+    stroma = _make_embedded_slide(sample_id="slide-a", annotation="stroma")
+
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *a, **k: [tumor, stroma])
+
+    result = model.embed_slides(
+        ["/tmp/slide-a.svs"], annotations=["tumor"], preprocessing=DEFAULT_PREPROCESSING
+    )
+
+    assert result == {"slide-a": {"tumor": tumor}}
+
+
+def test_embed_slides_never_produces_none_keys(monkeypatch):
+    model = Model.from_preset("virchow2")
+    labelled = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
+    unlabelled = _make_embedded_slide(sample_id="slide-a", annotation=None)
+
+    monkeypatch.setattr(
+        "slide2vec.inference.embed_slides", lambda *a, **k: [labelled, unlabelled]
+    )
+
+    result = model.embed_slides(["/tmp/slide-a.svs"], preprocessing=DEFAULT_PREPROCESSING)
+
+    assert result == {"slide-a": {"tissue": labelled}}
+    assert None not in result["slide-a"]
+
+
 def test_model_embed_slide_allows_multi_gpu_execution(monkeypatch):
     model = Model.from_preset("virchow2")
     expected = EmbeddedSlide(
@@ -67,6 +207,7 @@ def test_model_embed_slide_allows_multi_gpu_execution(monkeypatch):
         tile_size_lv0=224,
         image_path=Path("/tmp/slide-a.svs"),
         mask_path=None,
+        annotation="tissue",
     )
     monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *args, **kwargs: [expected])
 
@@ -81,28 +222,9 @@ def test_model_embed_slide_allows_multi_gpu_execution(monkeypatch):
 
 def test_model_embed_slides_delegates_to_inference_and_returns_its_results(monkeypatch):
     model = Model.from_preset("virchow2")
-    expected = [
-        EmbeddedSlide(
-            sample_id="slide-a",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=None,
-            x=np.array([0], dtype=np.int64),
-            y=np.array([0], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-a.svs"),
-            mask_path=None,
-        ),
-        EmbeddedSlide(
-            sample_id="slide-b",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=None,
-            x=np.array([1], dtype=np.int64),
-            y=np.array([1], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-b.svs"),
-            mask_path=None,
-        ),
-    ]
+    slide_a = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
+    slide_b = _make_embedded_slide(sample_id="slide-b", annotation="tissue")
+    expected = [slide_a, slide_b]
     captured = {}
 
     def fake_embed_slides(model_arg, slides, **kwargs):
@@ -118,7 +240,10 @@ def test_model_embed_slides_delegates_to_inference_and_returns_its_results(monke
         preprocessing=DEFAULT_PREPROCESSING,
     )
 
-    assert result == expected
+    assert result == {
+        "slide-a": {"tissue": slide_a},
+        "slide-b": {"tissue": slide_b},
+    }
     assert captured["model"] is model
     assert captured["slides"] == ["/tmp/slide-a.svs", "/tmp/slide-b.svs"]
     assert isinstance(captured["kwargs"]["preprocessing"], PreprocessingConfig)
@@ -126,28 +251,9 @@ def test_model_embed_slides_delegates_to_inference_and_returns_its_results(monke
 
 def test_model_embed_slides_passes_multi_gpu_execution_through_to_inference(monkeypatch):
     model = Model.from_preset("virchow2")
-    expected = [
-        EmbeddedSlide(
-            sample_id="slide-a",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=None,
-            x=np.array([0], dtype=np.int64),
-            y=np.array([0], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-a.svs"),
-            mask_path=None,
-        ),
-        EmbeddedSlide(
-            sample_id="slide-b",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=None,
-            x=np.array([1], dtype=np.int64),
-            y=np.array([1], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-b.svs"),
-            mask_path=None,
-        ),
-    ]
+    slide_a = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
+    slide_b = _make_embedded_slide(sample_id="slide-b", annotation="tissue")
+    expected = [slide_a, slide_b]
     captured = {}
 
     def fake_embed_slides(model_arg, slides, **kwargs):
@@ -164,7 +270,10 @@ def test_model_embed_slides_passes_multi_gpu_execution_through_to_inference(monk
         execution=ExecutionOptions(num_gpus=2),
     )
 
-    assert result == expected
+    assert result == {
+        "slide-a": {"tissue": slide_a},
+        "slide-b": {"tissue": slide_b},
+    }
     assert captured["model"] is model
     assert captured["slides"] == ["/tmp/slide-a.svs", "/tmp/slide-b.svs"]
     assert captured["kwargs"]["execution"].num_gpus == 2
@@ -176,24 +285,13 @@ def test_model_embed_slides_auto_installs_progress_reporter(monkeypatch):
     model = Model.from_preset("virchow2")
     reporter = SimpleNamespace(close=lambda: None, emit=lambda event: None)
     captured = {}
-    expected = [
-        EmbeddedSlide(
-            sample_id="slide-a",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=None,
-            x=np.array([0], dtype=np.int64),
-            y=np.array([0], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-a.svs"),
-            mask_path=None,
-        )
-    ]
+    slide_a = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
 
     monkeypatch.setattr(progress, "create_api_progress_reporter", lambda **kwargs: reporter)
 
     def fake_embed_slides(model_arg, slides, **kwargs):
         captured["reporter"] = progress.get_progress_reporter()
-        return expected
+        return [slide_a]
 
     monkeypatch.setattr("slide2vec.inference.embed_slides", fake_embed_slides)
 
@@ -202,7 +300,7 @@ def test_model_embed_slides_auto_installs_progress_reporter(monkeypatch):
         preprocessing=DEFAULT_PREPROCESSING,
     )
 
-    assert result == expected
+    assert result == {"slide-a": {"tissue": slide_a}}
     assert captured["reporter"] is reporter
     assert isinstance(progress.get_progress_reporter(), progress.NullProgressReporter)
 
@@ -214,24 +312,13 @@ def test_model_embed_slides_preserves_existing_progress_reporter(monkeypatch):
     outer_reporter = SimpleNamespace(close=lambda: None, emit=lambda event: None)
     replacement_reporter = SimpleNamespace(close=lambda: None, emit=lambda event: None)
     captured = {}
-    expected = [
-        EmbeddedSlide(
-            sample_id="slide-a",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=None,
-            x=np.array([0], dtype=np.int64),
-            y=np.array([0], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-a.svs"),
-            mask_path=None,
-        )
-    ]
+    slide_a = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
 
     monkeypatch.setattr(progress, "create_api_progress_reporter", lambda **kwargs: replacement_reporter)
 
     def fake_embed_slides(model_arg, slides, **kwargs):
         captured["reporter"] = progress.get_progress_reporter()
-        return expected
+        return [slide_a]
 
     monkeypatch.setattr("slide2vec.inference.embed_slides", fake_embed_slides)
 
@@ -241,7 +328,7 @@ def test_model_embed_slides_preserves_existing_progress_reporter(monkeypatch):
             preprocessing=DEFAULT_PREPROCESSING,
         )
 
-    assert result == expected
+    assert result == {"slide-a": {"tissue": slide_a}}
     assert captured["reporter"] is outer_reporter
 
 
@@ -256,6 +343,7 @@ def test_model_embed_slide_infers_preprocessing_from_single_spacing_model(monkey
         tile_size_lv0=224,
         image_path=Path("/tmp/slide-a.svs"),
         mask_path=None,
+        annotation="tissue",
     )
     captured = {}
 
@@ -292,6 +380,7 @@ def test_model_embed_slide_infers_missing_values_from_explicit_backend_only_prep
         tile_size_lv0=224,
         image_path=Path("/tmp/slide-a.svs"),
         mask_path=None,
+        annotation="tissue",
     )
     captured = {}
 
@@ -365,20 +454,10 @@ def test_model_embed_slides_warns_when_non_recommended_settings_are_allowed(
     caplog: pytest.LogCaptureFixture,
 ):
     model = Model.from_preset("virchow2", allow_non_recommended_settings=True)
-    expected = [
-        EmbeddedSlide(
-            sample_id="slide-a",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=None,
-            x=np.array([0], dtype=np.int64),
-            y=np.array([0], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-a.svs"),
-            mask_path=None,
-        ),
-    ]
+    slide_a = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
+    expected = {"slide-a": {"tissue": slide_a}}
 
-    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *args, **kwargs: expected)
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *args, **kwargs: [slide_a])
 
     with caplog.at_level("WARNING", logger="slide2vec"):
         result = model.embed_slides(
@@ -407,20 +486,10 @@ def test_model_embed_slides_warns_when_non_recommended_precision_is_allowed(
     caplog: pytest.LogCaptureFixture,
 ):
     model = Model.from_preset("virchow2", allow_non_recommended_settings=True)
-    expected = [
-        EmbeddedSlide(
-            sample_id="slide-a",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=None,
-            x=np.array([0], dtype=np.int64),
-            y=np.array([0], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-a.svs"),
-            mask_path=None,
-        ),
-    ]
+    slide_a = _make_embedded_slide(sample_id="slide-a", annotation="tissue")
+    expected = {"slide-a": {"tissue": slide_a}}
 
-    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *args, **kwargs: expected)
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *args, **kwargs: [slide_a])
 
     with caplog.at_level("WARNING", logger="slide2vec"):
         result = model.embed_slides(
@@ -435,20 +504,19 @@ def test_model_embed_slides_warns_when_non_recommended_precision_is_allowed(
 
 def test_model_embed_slides_allows_cpu_execution_with_fp32_precision(monkeypatch):
     model = Model.from_preset("prism", device="cpu")
-    expected = [
-        EmbeddedSlide(
-            sample_id="slide-a",
-            tile_embeddings=np.zeros((1, 2), dtype=np.float32),
-            slide_embedding=np.zeros((2,), dtype=np.float32),
-            x=np.array([0], dtype=np.int64),
-            y=np.array([0], dtype=np.int64),
-            tile_size_lv0=224,
-            image_path=Path("/tmp/slide-a.svs"),
-            mask_path=None,
-        ),
-    ]
+    slide_a = EmbeddedSlide(
+        sample_id="slide-a",
+        tile_embeddings=np.zeros((1, 2), dtype=np.float32),
+        slide_embedding=np.zeros((2,), dtype=np.float32),
+        x=np.array([0], dtype=np.int64),
+        y=np.array([0], dtype=np.int64),
+        tile_size_lv0=224,
+        image_path=Path("/tmp/slide-a.svs"),
+        mask_path=None,
+        annotation="tissue",
+    )
 
-    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *args, **kwargs: expected)
+    monkeypatch.setattr("slide2vec.inference.embed_slides", lambda *args, **kwargs: [slide_a])
 
     result = model.embed_slides(
         [{"sample_id": "slide-a", "image_path": "/tmp/slide-a.svs"}],
@@ -456,7 +524,7 @@ def test_model_embed_slides_allows_cpu_execution_with_fp32_precision(monkeypatch
         execution=ExecutionOptions(precision="fp32"),
     )
 
-    assert result == expected
+    assert result == {"slide-a": {"tissue": slide_a}}
 
 
 def test_model_embed_tiles_requires_output_dir_at_api_boundary():


### PR DESCRIPTION
## Summary

Gives the public API annotation-aware ergonomics so a caller can select and index per-class bags directly.

- `embed_slide(slide, annotation=...)` gains a class selector with numpy-style shape-in/shape-out:
  - a single class string returns one `EmbeddedSlide`;
  - a list of class strings returns a list of `EmbeddedSlide` in the requested order;
  - omitting it returns the single bag for a one-bag run, and otherwise raises a clear error naming the available bags and directing to `embed_slides`;
  - requesting an unknown class raises an error naming what is available.
- `embed_slides(slides, annotations=...)` now returns a nested mapping `{sample_id: {label: EmbeddedSlide}}`, keyed by the informative annotation label (never `None`). Passing `annotations=[...]` restricts the inner keys to the named classes; omitting it returns every bag.
- `embed_slide` delegates to `embed_slides` and selects from the nested dict.

### Breaking change (release note)

`Model.embed_slides` return type changes from a flat `list[EmbeddedSlide]` to a nested `dict[str, dict[str, EmbeddedSlide]]`. Multi-result callers must migrate from `for es in model.embed_slides(...)` to iterating the nested mapping (e.g. `for sample_id, bags in result.items(): for label, es in bags.items(): ...`). `embed_slide` continues to return a single `EmbeddedSlide` (or a `list` when a list of classes is requested).

### Housekeeping

Replaces the undefined `:ref:\`annotation-aware-sampling\`` in the `EmbeddedSlide.annotation` docstring (introduced in #173) with plain prose so the docs build stays green.

## Internal callers updated for the breaking change

- `Model.embed_slide` — previously `return self.embed_slides([slide], ...)[0]`; now delegates to `embed_slides` and selects from the nested dict via the new selector. (Patient path is unaffected: `inference.embed_patients` is a standalone function and does not consume `Model.embed_slides`.)

## Tests

Full suite: 359 passed, 15 skipped.

Closes #174