### PR TITLE
ci: skip docker-test build on docs-only PRs

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # needed for Buildx GHA cache
+      pull-requests: read  # paths-filter reads the PR's changed files
 
     # don't run on forked PRs (no secrets) or release-* bump PRs (version-only change)
     if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !startsWith(github.head_ref, 'release-') }}
@@ -20,16 +21,36 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:
+      # docker-test is a REQUIRED, strict status check on main. A docs-only PR must
+      # not pay the ~30-min image build, but we cannot skip the *job* (a skipped
+      # required check never reports and would block the merge). So the job always
+      # runs and reports green; the expensive steps below are short-circuited when a
+      # PR changes only documentation. `code` is true iff some non-docs file changed.
+      - name: Detect non-docs changes
+        id: changes
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.rst'
+
       - name: Check out repository
+        if: ${{ steps.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
         uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Set up Docker Buildx
+        if: ${{ steps.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
         uses: docker/setup-buildx-action@v3
 
       - name: Free disk space on runner
+        if: ${{ steps.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
         run: |
           set -euxo pipefail
           df -h
@@ -42,6 +63,7 @@ jobs:
           df -h
 
       - name: Build image
+        if: ${{ steps.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -59,6 +81,7 @@ jobs:
           test -n "${HF_TOKEN:-}" || { echo "HF_TOKEN is required but not set"; exit 1; }
 
       - name: Run test suite in container
+        if: ${{ steps.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
         run: |
           set -euo pipefail
           docker run --rm \
@@ -66,4 +89,3 @@ jobs:
             -v "$GITHUB_WORKSPACE:/opt/app" \
             slide2vec-ci:${{ github.sha }} \
             bash -lc "python -m pip install --no-cache-dir '/opt/app[prism,asap]' pytest pytest-cov && python -m pytest -q tests"
-


### PR DESCRIPTION
Docs-only PRs (e.g. the docs slice of the annotation-aware API work) should not wait ~30 min on the docker image build + in-container test run.

`docker-test` is a **required, strict** status check, so a blunt `paths-ignore` would make the required context never report and silently **block** every docs-only PR. Instead this keeps the job running (so it always reports green) and short-circuits the expensive steps when a PR changes only `docs/**`, `*.md`, or `*.rst`, using `dorny/paths-filter` to detect non-docs changes.

- Non-docs changes and `workflow_dispatch` still run the full build + test suite.
- Docs-only PRs report `docker-test` green in seconds.

This PR itself changes a workflow file (non-docs), so it runs the full suite as a sanity check.