### PR TITLE
docs: document annotation-aware extraction for embed_slide and embed_slides

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -81,6 +81,10 @@ Pass :class:`~slide2vec.PreprocessingConfig` to override tiling defaults:
    )
    embedded = model.embed_slide("/path/to/slide.svs", preprocessing=preprocessing)
 
+To restrict feature extraction to specific annotated classes (e.g. embed only
+tumor-annotated tiles), customize the ``masks`` block — see
+:ref:`annotation-aware-sampling`.
+
 See :doc:`preprocessing` for advanced settings.
 
 .. _execution-options:

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -37,6 +37,38 @@ Directory Structure
    └── config.yaml
 
 
+Per-Annotation Namespacing
+--------------------------
+
+The layout above is the tissue-only (default) case. When
+:ref:`annotation-aware sampling <annotation-aware-sampling>` is
+enabled, each sampled class gets its own ``<class>/`` subdirectory under every
+embedding directory, and the tiling artifacts are namespaced the same way:
+
+.. code-block:: text
+
+   <output_dir>/
+   ├── tile_embeddings/
+   │   ├── tumor/<sample_id>.pt
+   │   └── stroma/<sample_id>.pt
+   ├── slide_embeddings/
+   │   ├── tumor/<sample_id>.pt
+   │   └── stroma/<sample_id>.pt
+   ├── tiles/
+   │   ├── tumor/<sample_id>.coordinates.npz
+   │   └── stroma/<sample_id>.coordinates.npz
+   └── preview/
+       ├── mask/<sample_id>.png            ← one multi-label mask preview per slide
+       └── tiling/
+           ├── tumor/<sample_id>.png
+           └── stroma/<sample_id>.png
+
+The ``tissue`` class (and the ``merged`` ``output_mode``) carry no class label
+and collapse to the flat root shown earlier — there is no ``tissue/``
+subdirectory. ``process_list.csv`` has one row per ``(sample_id, annotation)``
+pair, each recording that class's own ``feature_path``.
+
+
 Embedding Files
 ---------------
 

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -56,6 +56,180 @@ Or in a YAML config:
          sam2_device: "cuda"
 
 
+.. _annotation-aware-sampling:
+
+Annotation-Aware Sampling
+-------------------------
+
+By default ``slide2vec`` tiles tissue: the ``masks`` vocabulary is the binary
+``{background: 0, tissue: 1}``, and embeddings cover every tissue tile. You can
+instead restrict tiling **and** feature extraction to specific annotated classes
+(tumor-only, stroma-only, …) by customizing the ``masks`` block. Any divergence
+from the default vocabulary opts the run into annotation-aware sampling; the
+plain tissue path is otherwise byte-for-byte unchanged.
+
+In annotation mode the per-slide ``mask_path`` is read as a **multi-label
+raster**: each class occupies a distinct integer pixel value. The ``masks`` block
+maps that vocabulary and is deep-merged over the default, so you only state what
+you add:
+
+- ``pixel_mapping`` — ``{class_name: integer pixel value in the raster}``
+- ``min_coverage`` — ``{class_name: float | null}``; the minimum fraction of a
+  tile that must be covered by that class to keep it. ``null`` means *don't
+  sample that class*. The ``tissue`` entry is the single source of truth for the
+  tissue threshold.
+- ``colors`` — ``{class_name: [r, g, b] | null}`` used when rendering previews.
+- ``output_mode`` — ``per_annotation`` (one artifact set per sampled class) or
+  ``merged`` (one set per slide over the union of tiles passing any class).
+- ``independent_sampling`` (a top-level ``tiling`` flag, exposed on
+  :class:`~slide2vec.PreprocessingConfig`) — ``True`` samples each class against
+  its own mask; ``False`` samples once over the union, then post-filters per
+  class by coverage.
+
+**Tumor-only bag features.** Add a ``tumor`` class, set its ``min_coverage``, and
+disable tissue sampling with ``min_coverage.tissue: null``. Only ``tumor`` tiles
+are sampled, so the returned :class:`~slide2vec.EmbeddedSlide` carries the
+tumor-only bag directly:
+
+.. code-block:: python
+
+   from slide2vec import Model, PreprocessingConfig
+
+   model = Model.from_preset("virchow2")
+   preprocessing = PreprocessingConfig(
+       requested_spacing_um=0.5,
+       requested_tile_size_px=224,
+       masks={
+           "pixel_mapping": {"tumor": 2},        # tumor pixels == 2 in the raster
+           "min_coverage": {"tissue": None, "tumor": 0.5},
+           "colors": {"tumor": [255, 0, 0]},     # preview color (optional)
+       },
+   )
+
+   embedded = model.embed_slide(
+       "/path/to/slide.svs",
+       mask_path="/path/to/annotation_mask.tif",  # multi-label raster
+       preprocessing=preprocessing,
+   )
+
+   assert embedded.annotation == "tumor"  # every bag is stamped with its label
+   tumor_bag = embedded.tile_embeddings   # shape (N_tumor, D) — tumor tiles only
+
+Because this run produces exactly one bag, bare ``embed_slide(...)`` returns that
+single :class:`~slide2vec.EmbeddedSlide` directly. You can also name the class
+explicitly with the ``annotation`` selector — ``embed_slide(..., annotation="tumor")``
+returns the same single bag, and requesting a class the run did not produce
+raises a ``ValueError`` listing the available bags.
+
+The ``mask_path`` argument (or the ``mask_path`` column in a manifest) is
+**required** in annotation mode — it is the raster the class vocabulary indexes
+into.
+
+**Multiple classes per slide.** To extract several classes in one run, give each
+its own ``min_coverage`` and use a :class:`~slide2vec.Pipeline` so the per-class
+artifacts are persisted and namespaced on disk under a ``<class>/`` subdirectory
+(e.g. ``tile_embeddings/tumor/<sample_id>.pt`` and
+``tile_embeddings/stroma/<sample_id>.pt``):
+
+.. code-block:: python
+
+   from slide2vec import Model, Pipeline, PreprocessingConfig, ExecutionOptions
+
+   pipeline = Pipeline(
+       model=Model.from_preset("virchow2"),
+       preprocessing=PreprocessingConfig(
+           requested_spacing_um=0.5,
+           requested_tile_size_px=224,
+           masks={
+               "pixel_mapping": {"tumor": 2, "stroma": 3},
+               "min_coverage": {"tissue": None, "tumor": 0.5, "stroma": 0.5},
+           },
+       ),
+       execution=ExecutionOptions(output_dir="outputs/run"),
+   )
+
+   # The manifest's mask_path column points at each slide's multi-label raster.
+   result = pipeline.run(manifest_path="/path/to/slides.csv")
+
+This fans out per ``(sample_id, annotation)`` across tile, slide, and
+hierarchical embeddings — and across multiple GPUs — recording each class's own
+``feature_path`` in ``process_list.csv``. See :doc:`output-layout` for the
+namespaced directory structure.
+
+**The** ``merged`` **output mode.** With ``masks={"output_mode": "merged"}`` the
+run does not fan out per class: it samples the union of tiles passing any class
+and produces **one bag per slide**. That bag is labelled ``"merged"`` rather than
+a class name — its :attr:`~slide2vec.EmbeddedSlide.annotation` is ``"merged"``,
+the inner ``embed_slides`` key is ``"merged"``, and on disk it lands at the flat
+output root (``tile_embeddings/<sample_id>.pt``) with **no** ``<class>/``
+subdirectory, exactly like the default ``tissue`` case:
+
+.. code-block:: python
+
+   results = model.embed_slides(slides, ...)   # masks with output_mode "merged"
+   merged = results["slide-1"]["merged"]
+   assert merged.annotation == "merged"        # not "tumor"/"stroma"
+
+   # Single bag per slide, so embed_slide returns it directly:
+   merged = model.embed_slide(slide, ...)      # output_mode "merged"
+   assert merged.annotation == "merged"
+
+A named class (``"tumor"``) is keyed by its class name and namespaced under
+``<class>/`` on disk; the ``"merged"`` and ``"tissue"`` labels are keyed by that
+label and sit at the flat root.
+
+To work with several classes **in memory** instead of on disk, call
+``embed_slides`` (not ``embed_slide``). It returns a **nested mapping**,
+``{sample_id: {label: EmbeddedSlide}}`` — the outer key is the ``sample_id`` and
+the inner key is each bag's informative annotation label (a class name,
+``"tissue"``, or ``"merged"``; never ``None``). Every
+:class:`~slide2vec.EmbeddedSlide` is also stamped with its
+:attr:`~slide2vec.EmbeddedSlide.annotation`, so you can tell the bags apart by
+inner key *or* by attribute:
+
+.. code-block:: python
+
+   results = model.embed_slides(
+       [{"sample_id": "slide-1",
+         "image_path": "/path/to/slide.svs",
+         "mask_path": "/path/to/annotation_mask.tif"}],
+       preprocessing=preprocessing,   # masks with tumor + stroma, as above
+   )
+
+   # Index straight in by slide, then by class.
+   tumor_bag = results["slide-1"]["tumor"].tile_embeddings    # shape (N_tumor, D)
+   stroma_bag = results["slide-1"]["stroma"].tile_embeddings  # shape (N_stroma, D)
+
+   assert results["slide-1"]["tumor"].annotation == "tumor"
+   assert results["slide-1"]["stroma"].annotation == "stroma"
+
+Pass ``annotations=[...]`` to restrict the inner keys to the classes you care
+about; omit it to receive every bag the run produced:
+
+.. code-block:: python
+
+   results = model.embed_slides(slides, annotations=["tumor"])
+   results["slide-1"].keys()  # dict_keys(['tumor']) — stroma is dropped
+
+**Selecting bags with** ``embed_slide``. ``embed_slide`` returns one bag (or a
+list of bags) for a single slide via the same ``annotation`` selector:
+
+.. code-block:: python
+
+   # One class → one EmbeddedSlide.
+   tumor = model.embed_slide(slide, annotation="tumor")
+   assert tumor.annotation == "tumor"
+
+   # A list of classes → a list of EmbeddedSlide in the requested order.
+   tumor, stroma = model.embed_slide(slide, annotation=["tumor", "stroma"])
+   assert [b.annotation for b in (tumor, stroma)] == ["tumor", "stroma"]
+
+Bare ``embed_slide(slide)`` (no ``annotation``) returns the single bag when the
+run produced exactly one; if the run fanned the slide out into several bags it
+raises a ``ValueError`` naming the available bags and directing you to
+``embed_slides``, so per-class results are never silently dropped.
+
+
 Preview Images
 --------------
 


### PR DESCRIPTION
Closes #175

## What

Documents annotation-aware feature extraction end-to-end against the shipped API (#172–#174), with runnable examples covering single-class, multi-class, and merged cases across both `embed_slide` and `embed_slides`.

Applies the seeded draft and rewrites every in-memory API example to the final shipped shapes.

### Changes (docs-only)
- `docs/preprocessing.rst` — `.. _annotation-aware-sampling:` anchor plus rewritten examples:
  - Single-class `embed_slide(..., annotation="tumor")` and list `embed_slide(..., annotation=["tumor", "stroma"])` (in order); bare `embed_slide(slide)` one-bag / raise-on-fan-out behavior.
  - `embed_slides` returns the nested `{sample_id: {label: EmbeddedSlide}}` mapping; examples index `results["slide-1"]["tumor"]` / `["stroma"]` and show `annotations=["tumor"]` restricting inner keys.
  - Dedicated `merged` output-mode section: `.annotation == "merged"`, inner key `"merged"`, flat output root (no `<class>/` subdir), contrasted with a named class.
  - Every example reads `.annotation` so bags are distinguishable.
- `docs/getting-started.rst`, `docs/output-layout.rst` — cross-references to the anchor and per-annotation namespacing layout (from the draft).

## Acceptance criteria
- [x] Single-class `embed_slide(..., annotation=...)` and multi-class list example.
- [x] `embed_slides` example indexing `{sample_id: {label: EmbeddedSlide}}` by slide and class.
- [x] `merged` output mode covered (label + flat-root placement vs. named class).
- [x] All examples reflect the shipped API shapes and read each bag's `annotation` label.

## Docs build
`python -m sphinx -W -b html docs docs/_build/html` (the exact CI invocation) succeeds with **zero warnings**; the `annotation-aware-sampling` ref resolves with no `undefined label`.
