### PR TITLE
ci: make docs-skip actually short-circuit (predicate-quantifier: every)

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -31,6 +31,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: dorny/paths-filter@v3
         with:
+          # `every`: a changed file counts toward `code` only if it matches ALL
+          # patterns — i.e. it is under '**' AND not docs/, *.md, or *.rst. With the
+          # default `some` quantifier the leading '**' alone matches every file
+          # (docs included), so `code` would always be true and never skip.
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'


### PR DESCRIPTION
Follow-up to the docs-skip change. That version was a **no-op**: `dorny/paths-filter` defaults to `predicate-quantifier: some`, so a docs file matches the leading `**` pattern and sets `code=true` — the full ~30-min build ran on docs-only PRs anyway (verified on the #175 docs PR).

Setting `predicate-quantifier: 'every'` means a changed file counts toward `code` only if it matches **all** patterns (under `**` and not `docs/**`/`*.md`/`*.rst`), i.e. `code` is true iff some non-docs file changed. Docs-only PRs now report `docker-test` green in seconds; non-docs changes and `workflow_dispatch` still run the full suite.

This PR changes a workflow file (non-docs), so it correctly runs the full build.