### PR TITLE
Align with hs2p 4.2.0: drop TilingConfig.tissue_threshold reads (#182)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.1.2",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.2.0",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -88,7 +88,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.1.2",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.2.0",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/slide2vec/runtime/tiling.py
+++ b/slide2vec/runtime/tiling.py
@@ -46,9 +46,10 @@ def build_hs2p_configs(
         if is_hierarchical_preprocessing(preprocessing)
         else preprocessing.requested_tile_size_px
     )
-    # Reuse hs2p's tiling-config resolver so the derived tissue_threshold comes from
-    # masks.min_coverage.tissue (the single source of truth) and independent_sampling
-    # is threaded consistently. The resolver reads attributes, so wrap the masks dict.
+    # Reuse hs2p's tiling-config resolver so the resolved min_coverage map comes from
+    # masks.min_coverage (the single source of truth; min_coverage["tissue"] is the tissue
+    # threshold) and independent_sampling is threaded consistently. The resolver reads
+    # attributes, so wrap the masks dict.
     tiling_adapter = SimpleNamespace(
         tiling=SimpleNamespace(
             masks=SimpleNamespace(**dict(preprocessing.masks)),

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -700,7 +700,7 @@ def test_masks_min_coverage_tissue_drives_derived_tiling_threshold():
 
     tiling_cfg = build_hs2p_configs(preprocessing)[0]
 
-    assert tiling_cfg.tissue_threshold == pytest.approx(0.37)
+    assert tiling_cfg.min_coverage["tissue"] == pytest.approx(0.37)
     assert tiling_cfg.independent_sampling is False
 
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -2498,7 +2498,7 @@ def test_build_hs2p_configs_constructs_preview_config():
     ) = runtime_tiling.build_hs2p_configs(preprocessing)
 
     assert tiling_cfg.backend == "asap"
-    assert tiling_cfg.tissue_threshold == pytest.approx(0.1)  # derived from masks.min_coverage.tissue
+    assert tiling_cfg.min_coverage["tissue"] == pytest.approx(0.1)  # resolved from masks.min_coverage.tissue
     assert segmentation_cfg.downsample == 64
     assert segmentation_cfg.method == "hsv"
     assert filtering_cfg.ref_tile_size == 224


### PR DESCRIPTION
Closes #182.

hs2p 4.2.0 (clemsgrs/hs2p#158) collapses the derived `TilingConfig.tissue_threshold` scalar into the resolved `min_coverage` map — the single source of truth, where `min_coverage["tissue"]` is the tissue threshold.

slide2vec's **runtime is unaffected**: it never constructs a `TilingConfig`, already drops the standalone scalar (`min_coverage.tissue` is the source of truth), and `build_hs2p_configs` (`runtime/tiling.py`) delegates derivation to hs2p's `resolve_tiling_config`. No shipping code reads `.tissue_threshold` off the result — only the test suite and one stale comment did.

## Changes

- **`pyproject.toml`** — bump pin `hs2p[...]>=4.1.2` → `>=4.2.0` (both dependency blocks)
- **`tests/test_regression_core.py`** — assert `tiling_cfg.min_coverage["tissue"]` (≈ 0.37) instead of the removed `tiling_cfg.tissue_threshold`
- **`tests/test_regression_inference.py`** — same migration (≈ 0.1); comment reworded "derived" → "resolved"
- **`slide2vec/runtime/tiling.py`** — reword the resolver comment for the field-removed world (`min_coverage["tissue"]` is the threshold)

## Verification

Upgraded the local env to hs2p 4.2.0 and ran the full suite: **359 passed, 15 skipped**.

## Release ordering

Per #182, release **after** hs2p 4.2.0 (done) and **before** soma (clemsgrs/soma#97).