### PR TITLE
docs: fix stale tissue_threshold kwarg in README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pipeline = Pipeline(
     preprocessing=PreprocessingConfig(
         requested_spacing_um=0.5,
         requested_tile_size_px=224,
-        tissue_threshold=0.1,
+        masks={"min_coverage": {"tissue": 0.1}},
     ),
     execution=ExecutionOptions(output_dir="outputs/demo"),
 )


### PR DESCRIPTION
The README quickstart passed `tissue_threshold=0.1` to `PreprocessingConfig(...)`, but that field no longer exists — `min_coverage.tissue` is the single source of truth. The snippet raises `TypeError: PreprocessingConfig.__init__() got an unexpected keyword argument 'tissue_threshold'` for anyone copy-pasting it.

Switch to the canonical `masks={"min_coverage": {"tissue": 0.1}}` form, matching the `.rst` docs (`api.rst`, `getting-started.rst`, `preprocessing.rst`), which are already on `min_coverage`.

Docs-only change; no runtime impact.