### PR TITLE
Add 0.25 mpp (40x) to Virchow2 supported spacings

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -86,7 +86,7 @@ Tile-level encoders
    * - ``virchow2``
      - `Virchow2 <https://huggingface.co/paige-ai/Virchow2>`_
      - 1280 / 2560
-     - ``0.5``, ``1.0``, ``2.0``
+     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
      - Zimmermann et al. (2024)
    * - ``uni2``
      - `UNI2 <https://huggingface.co/MahmoodLab/UNI2-h>`_

--- a/slide2vec/encoders/models/virchow.py
+++ b/slide2vec/encoders/models/virchow.py
@@ -71,7 +71,7 @@ class Virchow(_VirchowBase):
     },
     default_output_variant="cls_patch_mean",
     input_size=224,
-    supported_spacing_um=[0.5, 1.0, 2.0],
+    supported_spacing_um=[0.25, 0.5, 1.0, 2.0],
     precision="fp16",
     source="paige-ai/Virchow2",
 )


### PR DESCRIPTION
## Summary

The [Virchow2 model card](https://huggingface.co/paige-ai/Virchow2) states it was pretrained on tiles sampled at **2.0, 1.0, 0.5 and 0.25** microns per pixel (5x/10x/20x/40x). Both the encoder registry and the docs model zoo listed only `0.5, 1.0, 2.0`, dropping the 0.25 mpp / 40x resolution.

## Changes

- `slide2vec/encoders/models/virchow.py` — `supported_spacing_um=[0.25, 0.5, 1.0, 2.0]` (source of truth)
- `docs/models.rst` — tile-encoder zoo row updated to match

Virchow (v1) is left at `0.5`, matching its own card which only documents 20x/0.5 mpp pretraining.