### PR TITLE
Single source of truth for tile-encoder prefix-token counts

### DIFF
--- a/slide2vec/encoders/models/hibou.py
+++ b/slide2vec/encoders/models/hibou.py
@@ -54,6 +54,13 @@ class _HibouBase(TileEncoder):
             v2.Normalize(mean=_HIBOU_MEAN, std=_HIBOU_STD),
         ])
 
+    @property
+    def _num_prefix_tokens(self) -> int:
+        # CLS + register tokens. Dinov2-with-registers carries the register tokens
+        # between the CLS and patch tokens, so both the dense and attention paths
+        # must strip them; deriving the count from config keeps the two in sync.
+        return 1 + int(getattr(self._model.config, "num_register_tokens", 0))
+
     def encode_tiles(self, batch: Tensor) -> Tensor:
         output = self._model(pixel_values=batch)
         return output.pooler_output
@@ -77,7 +84,7 @@ class _HibouBase(TileEncoder):
             output.last_hidden_state,
             grid_h=height // patch,
             grid_w=width // patch,
-            num_prefix_tokens=1 + int(getattr(self._model.config, "num_register_tokens", 0)),
+            num_prefix_tokens=self._num_prefix_tokens,
             encoder_name=type(self).__name__,
         )
 
@@ -111,7 +118,7 @@ class _HibouBase(TileEncoder):
             output = self._model(pixel_values=batch, output_attentions=True)
         return attentions_tuple_to_grids(
             output.attentions,
-            num_prefix_tokens=1 + int(getattr(self._model.config, "num_register_tokens", 0)),
+            num_prefix_tokens=self._num_prefix_tokens,
             blocks=blocks,
             include_registers=include_registers,
             grid_h=height // patch,

--- a/slide2vec/encoders/models/midnight.py
+++ b/slide2vec/encoders/models/midnight.py
@@ -36,6 +36,18 @@ class Midnight(TileEncoder):
         self._model = AutoModel.from_pretrained("kaiko-ai/midnight").eval()
         self._device = preferred_default_device()
         self._output_variant = resolve_requested_output_variant(output_variant)
+        # The pooled, dense, and attention paths all assume a single CLS prefix
+        # token (kaiko's reference recipe pools over output[:, 1:]). If a future
+        # checkpoint adds register tokens, that assumption silently folds them into
+        # the patch mean and mislabels the dense/attention grids — fail loudly here.
+        num_register_tokens = int(getattr(self._model.config, "num_register_tokens", 0))
+        if num_register_tokens:
+            raise ValueError(
+                "Midnight encoder assumes a single CLS prefix token, but the loaded "
+                f"checkpoint reports num_register_tokens={num_register_tokens}. Update "
+                "the pooled/dense/attention paths to strip the register tokens before "
+                "using this checkpoint."
+            )
 
     def get_transform(self) -> Callable:
         return v2.Compose([

--- a/slide2vec/encoders/models/virchow.py
+++ b/slide2vec/encoders/models/virchow.py
@@ -16,8 +16,6 @@ _VIRCHOW_OUTPUT_DIMS = {
 class _VirchowBase(TimmTileEncoder):
     """Base for Virchow models that concat CLS + mean-pooled patch tokens."""
 
-    _num_prefix_tokens: int = 1  # Override in subclass if needed
-
     def __init__(self, model_name: str, *, output_variant: str | None = None):
         self._output_variant = resolve_requested_output_variant(
             output_variant,
@@ -36,7 +34,7 @@ class _VirchowBase(TimmTileEncoder):
         cls_token = output[:, 0]
         if self._output_variant == "cls":
             return cls_token
-        patch_tokens = output[:, self._num_prefix_tokens:]
+        patch_tokens = output[:, self._model.num_prefix_tokens:]
         return torch.cat([cls_token, patch_tokens.mean(dim=1)], dim=-1)
 
     @property
@@ -57,8 +55,6 @@ class _VirchowBase(TimmTileEncoder):
     source="paige-ai/Virchow",
 )
 class Virchow(_VirchowBase):
-    _num_prefix_tokens = 1
-
     def __init__(self, *, output_variant: str | None = None):
         super().__init__("hf-hub:paige-ai/Virchow", output_variant=output_variant)
 
@@ -76,7 +72,5 @@ class Virchow(_VirchowBase):
     source="paige-ai/Virchow2",
 )
 class Virchow2(_VirchowBase):
-    _num_prefix_tokens = 5  # 1 CLS + 4 register tokens
-
     def __init__(self, *, output_variant: str | None = None):
         super().__init__("hf-hub:paige-ai/Virchow2", output_variant=output_variant)


### PR DESCRIPTION
## Summary

The count of leading non-patch tokens (CLS + register tokens) was tracked inconsistently across encoders' pooled vs. dense/attention paths. The values happen to agree today, but nothing kept them in sync — a recipe for silent divergence between extraction modes. This unifies each encoder on a single source.

## Changes

- **Virchow** — the pooled path (`encode_tiles`) sliced with a hardcoded class attribute (`_num_prefix_tokens`, overridden to `5` for Virchow2), while the dense (`encode_tiles_dense`) and attention paths read `self._model.num_prefix_tokens` off the timm trunk. They coincide today (1 CLS + 4 register tokens = 5), but only by luck. Dropped the class attribute and read the trunk in the pooled path too — matching the dense/attention paths and the existing `h-optimus` idiom. After this change `_num_prefix_tokens` exists nowhere in the encoders except the base trunk-reading helper.
- **Hibou** — the `1 + num_register_tokens` expression was copy-pasted into both the dense and attention paths. Extracted it into a single `_num_prefix_tokens` property so the two cannot drift.
- **Midnight** — the pooled, dense, and attention paths all hardcode a single CLS prefix token (matching kaiko's reference recipe, which pools over `output[:, 1:]`). Added a guard in `__init__` so a future checkpoint carrying register tokens fails loudly instead of silently folding them into the patch mean and mislabeling the dense/attention grids.

## Notes

Audited the remaining encoders (`conch`/`conchv15`, `phikon`, `musk`, `h-optimus`, and the single-prefix timm presets) — they already derive the count consistently (trunk-sourced, or a single literal used within one class), so no changes were needed there.

No behavioral change for any current checkpoint; this is a maintainability/robustness fix.