### PR TITLE
ci: bake heavy deps into image to cut docker-test time

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -89,8 +89,20 @@ jobs:
         if: ${{ steps.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
         run: |
           set -euo pipefail
+          # Dependencies (torch, xformers, transformers, hs2p, pytest, ...) are
+          # baked into the image, so install only the mounted source with
+          # --no-deps. The timing notices below split install vs. test wall-clock
+          # so we can see where this step's time actually goes.
           docker run --rm \
             -e HF_TOKEN="$HF_TOKEN" \
             -v "$GITHUB_WORKSPACE:/opt/app" \
             slide2vec-ci:${{ github.sha }} \
-            bash -lc "python -m pip install --no-cache-dir '/opt/app[prism,asap]' pytest pytest-cov && python -m pytest -q tests"
+            bash -lc '
+              set -euo pipefail
+              t0=$SECONDS
+              python -m pip install --no-cache-dir --no-deps -e /opt/app
+              echo "::notice::pip install (source only) took $((SECONDS - t0))s"
+              t1=$SECONDS
+              python -m pytest -q --durations=15 tests
+              echo "::notice::pytest took $((SECONDS - t1))s"
+            '

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -76,3 +76,20 @@ RUN python -m pip install --upgrade pip setuptools pip-tools \
 
 USER user
 WORKDIR /opt/app
+
+# Bake the heavy third-party dependencies (torch, xformers, transformers, hs2p,
+# ...) into the image at build time so the GHA layer cache absorbs them once,
+# instead of re-installing them on every PR run (the old runtime `pip install
+# '.[prism,asap]'` step dominated CI wall-clock). We resolve them from a stub
+# package built off the *real* pyproject.toml, so the dependency set is identical
+# to what the source would pull; the stub package itself is then uninstalled,
+# leaving only its resolved dependencies. This layer's cache key is the
+# pyproject.toml hash, so it only re-runs when the dependency set changes.
+# (`asap` is not a slide2vec extra — ASAP is the apt package installed above — so
+# only the `prism` extra is needed here.)
+COPY --chown=user:user pyproject.toml README.md /opt/deps/
+RUN mkdir -p /opt/deps/slide2vec \
+    && touch /opt/deps/slide2vec/__init__.py \
+    && python -m pip install --user --no-cache-dir '/opt/deps[prism]' pytest pytest-cov \
+    && python -m pip uninstall -y slide2vec \
+    && rm -rf /home/user/.cache/pip


### PR DESCRIPTION
## Problem

`docker-test` takes ~30 min per run. Profiling a full run (`28116888546`) showed the time split:

| Step | Time |
|---|---|
| Build image (GHA-cached) | 135s |
| **Run test suite in container** | **1823s (~30 min)** |

The build is *not* the bottleneck (the "~30-min build" comment in the workflow was stale). All the time is in the test step, which did:

```
pip install --no-cache-dir '.[prism,asap]' pytest pytest-cov && pytest -q tests
```

The install — `torch`, `xformers==0.0.31`, `transformers`, and `hs2p[asap,cucim,openslide,sam2,vips]` — was re-run from scratch (`--no-cache-dir`) on **every** push. The test suite itself is CPU-cheap: `Model.from_preset(...)` loads weights lazily and the regression tests monkeypatch inference, while the dense/attention suites run fully offline (`pretrained=False`). So the dependency install was essentially the entire cost.

## Change

- **`Dockerfile.ci`**: pre-install the heavy third-party deps at build time, resolved from a stub package built off the real `pyproject.toml` (so the dependency set is byte-for-byte what the source resolves), then uninstall the stub — leaving only its resolved deps. The layer's cache key is the `pyproject.toml` hash, so it only re-installs when the dependency set actually changes. The GHA layer cache (`mode=max`) then absorbs it across runs.
- **`pr-test.yaml`**: the runtime step now installs only the mounted source with `--no-deps`, and emits `::notice::` timing for the install vs. the pytest phases so the split is visible going forward.

## Expected impact

Once the dependency layer is cached on `main`, the per-run install collapses from ~minutes to ~seconds, and `docker-test` should drop from ~30 min to roughly the cached-build (~2 min) + suite runtime.

⚠️ **This PR's own run is a cache miss** (new layer) and will still be slow — it's building the heavy layer for the first time. The speedup lands on subsequent PRs.

## Note on the "share heavy model loads" idea

An earlier hypothesis was that the suite redundantly loaded large models (Virchow2/PRISM) across many tests. On inspection that does **not** hold: `from_preset` is lazy and those tests monkeypatch `slide2vec.inference.embed_slides`, so no backend is ever loaded; the dense/attention suites use `pretrained=False`; and the only real-weight load in the whole suite is a single `Phikon()` test that skips when weights are unavailable. So there was nothing to dedupe — the dependency install was the real target.