### PR TITLE
Stream whole-region dense extraction via iter_regions_dense generator

### DIFF
--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -5,7 +5,10 @@ The dense counterpart of the pooled coordinate path (``compute_tile_embeddings_f
 each sampled ROI is read **spacing-aware** from the slide, run through the encoder's
 normalization-only dense transform (``get_dense_transform`` — NOT the pooled transform,
 which crops), padded up to the encoder's patch multiple, and encoded via
-``encode_tiles_dense`` into a ``(d, grid_h, grid_w)`` token grid.
+``encode_tiles_dense`` into a ``(d, grid_h, grid_w)`` token grid. ``iter_regions_dense``
+**streams** these grids — yielding one per coordinate, in coordinate order, holding at most
+one ``batch_size`` chunk resident — so host memory is bounded by ``batch_size`` rather than
+by a slide's ROI count.
 
 This is the extraction half of soma's slide-manifest segmentation path: slide2vec reads
 regions + encodes (it already owns the region reader and the dense encode); soma sources
@@ -26,7 +29,7 @@ encoder's comfortable field are out of scope for the first increment.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Sequence
+from typing import Callable, Iterator, Sequence
 
 import numpy as np
 import torch
@@ -136,7 +139,7 @@ def _resolve_encode_fn(
     )
 
 
-def encode_regions_dense(
+def iter_regions_dense(
     *,
     model,
     device: torch.device | str,
@@ -153,14 +156,23 @@ def encode_regions_dense(
     batch_size: int = 1,
     precision: str = "fp32",
     dense_transform: Callable | None = None,
-) -> np.ndarray:
-    """Encode slide regions at ``coordinates`` into dense grids; return ``(N, d, gh, gw)``.
+) -> Iterator[np.ndarray]:
+    """Stream slide regions at ``coordinates`` into dense grids, one per coordinate.
+
+    Yields one ``(d, grid_h, grid_w)`` ``float32`` grid per coordinate, in coordinate
+    order. Regions are read and encoded one ``batch_size`` chunk at a time, so resident
+    host memory is bounded by ``batch_size`` rather than by a slide's ROI count (the loop
+    holds at most one batch of grids resident — no per-slide accumulation).
 
     Injectable core: takes a constructed dense-capable ``model`` (with
     ``encode_tiles_dense`` / ``encode_tiles_attention`` / ``patch_size`` /
     ``get_dense_transform``) and a ``wsi`` exposing
     ``read_region_at_spacing(location, requested_spacing_um, size, *, tolerance,
     interpolation)``, so it runs offline in tests with random weights + a fake reader.
+
+    Arguments are validated and geometry is resolved **eagerly** (before any region is
+    read): an invalid ``pad_mode`` or ``feature_kind`` raises at the call site, not on the
+    first ``next()``. Iteration itself is lazy — reads advance one batch at a time.
 
     Args:
         coordinates: ``(x, y)`` top-left locations in **level-0** pixel space (the hs2p
@@ -169,9 +181,11 @@ def encode_regions_dense(
         target_size: supervision tile size (int or ``(h, w)``); the region is read at this
             size at ``requested_spacing_um`` and the token grid registers to it.
 
-    Returns a ``float32`` array of dense grids in coordinate order. ``feature_kind``
-    selects ``encode_tiles_dense`` (patch grid) vs ``encode_tiles_attention`` (CLS-attention
-    grid); both produce a ``(C, gh, gw)`` grid and share this path.
+    Yields ``float32`` grids in coordinate order; empty ``coordinates`` yields nothing.
+    ``feature_kind`` selects ``encode_tiles_dense`` (patch grid) vs
+    ``encode_tiles_attention`` (CLS-attention grid); both produce a ``(C, gh, gw)`` grid and
+    share this path. Each yielded grid is a standalone contiguous copy, so it does not pin
+    the rest of its batch's memory alive.
     """
     if pad_mode not in _PAD_MODES:
         raise ValueError(f"unsupported pad_mode {pad_mode!r}; expected one of {sorted(_PAD_MODES)}")
@@ -185,11 +199,8 @@ def encode_regions_dense(
         attention_include_registers=attention_include_registers,
     )
     target_h, target_w = geometry.target_size
-
     coords = [(int(x), int(y)) for x, y in coordinates]
-    grid_h, grid_w = geometry.grid_shape
-    if not coords:
-        return np.empty((0, 0, grid_h, grid_w), dtype=np.float32)
+    step = max(1, int(batch_size))
 
     def _read_padded(location: tuple[int, int]) -> torch.Tensor:
         region = wsi.read_region_at_spacing(
@@ -215,15 +226,21 @@ def encode_regions_dense(
             tensor, geometry, pad_mode=pad_mode, image_pad_value=image_pad_value
         )
 
-    grids: list[np.ndarray] = []
-    with torch.inference_mode(), slide_encode_autocast_ctx(device, precision):
-        for start in range(0, len(coords), max(1, int(batch_size))):
-            chunk = coords[start : start + max(1, int(batch_size))]
-            batch = torch.stack([_read_padded(loc) for loc in chunk]).to(device, non_blocking=True)
-            out = encode_fn(batch)
-            if out.ndim != 4:
-                raise ValueError(
-                    f"{feature_kind} encode returned a {out.ndim}-D tensor; expected (B, d, gh, gw)."
+    def _stream() -> Iterator[np.ndarray]:
+        with torch.inference_mode(), slide_encode_autocast_ctx(device, precision):
+            for start in range(0, len(coords), step):
+                chunk = coords[start : start + step]
+                batch = torch.stack([_read_padded(loc) for loc in chunk]).to(
+                    device, non_blocking=True
                 )
-            grids.append(out.detach().float().cpu().numpy())
-    return np.concatenate(grids, axis=0)
+                out = encode_fn(batch)
+                if out.ndim != 4:
+                    raise ValueError(
+                        f"{feature_kind} encode returned a {out.ndim}-D tensor; expected (B, d, gh, gw)."
+                    )
+                batch_np = out.detach().float().cpu().numpy()
+                for i in range(batch_np.shape[0]):
+                    # Standalone contiguous copy: a per-row view would pin the whole batch.
+                    yield np.ascontiguousarray(batch_np[i])
+
+    return _stream()

--- a/tests/test_dense_regions.py
+++ b/tests/test_dense_regions.py
@@ -1,9 +1,11 @@
-"""Tests for dense grid extraction over slide regions: ``encode_regions_dense``.
+"""Tests for dense grid extraction over slide regions: ``iter_regions_dense``.
 
 Fully offline (``pretrained=False`` random weights) + an injected fake reader, so no
-weights, no real WSI. Checks (1) grid shapes over a batch of coordinates and (2) that the
-orchestration is a faithful wrapper — its per-region grid is byte-identical to a direct
-``encode_tiles_dense(transform → pad)`` of the same region.
+weights, no real WSI. ``iter_regions_dense`` is a streaming generator: it yields one
+``(d, grid_h, grid_w)`` grid per coordinate in coordinate order, holding at most one batch
+resident. Checks (1) grid shapes over a batch of coordinates, (2) that each yielded grid is
+byte-identical to a direct ``transform → pad → encode`` of the same region (both feature
+kinds), (3) streaming/laziness via a call-counting reader, and (4) eager validation.
 """
 
 from __future__ import annotations
@@ -17,7 +19,7 @@ timm = pytest.importorskip("timm")
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
 from slide2vec.runtime.dense_regions import (  # noqa: E402
     compute_dense_geometry,
-    encode_regions_dense,
+    iter_regions_dense,
     pad_image_to_encoded,
 )
 
@@ -43,75 +45,142 @@ class _FakeWSI:
         return rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
 
 
-def test_encode_regions_dense_shapes_over_coordinates():
+def test_iter_regions_dense_yields_grid_per_coordinate_in_order():
     enc = _encoder()
     target_size = 64  # patch 16 -> grid 4x4, no padding
     wsi = _FakeWSI(target_h=target_size, target_w=target_size)
     coords = [(0, 0), (64, 0), (0, 64)]
 
-    grids = encode_regions_dense(
-        model=enc,
-        device="cpu",
-        wsi=wsi,
-        coordinates=coords,
-        requested_spacing_um=0.5,
-        target_size=target_size,
-        batch_size=2,
+    grids = list(
+        iter_regions_dense(
+            model=enc,
+            device="cpu",
+            wsi=wsi,
+            coordinates=coords,
+            requested_spacing_um=0.5,
+            target_size=target_size,
+            batch_size=2,
+        )
     )
 
-    assert grids.shape == (3, enc.encode_dim, 4, 4)
-    assert grids.dtype == np.float32
+    # One standalone (d, gh, gw) grid per coordinate, in coordinate order.
+    assert len(grids) == 3
+    for grid in grids:
+        assert grid.shape == (enc.encode_dim, 4, 4)
+        assert grid.dtype == np.float32
+        assert grid.flags["C_CONTIGUOUS"]
+        assert grid.base is None  # standalone copy, not a view pinning a batch
     # Reads went through read_region_at_spacing at (target_w, target_h), area interp, level-0 coords.
     assert [c[0] for c in wsi.calls] == [(0, 0), (64, 0), (0, 64)]
     assert all(c[2] == (target_size, target_size) and c[4] == "area" for c in wsi.calls)
 
 
-def test_encode_regions_dense_pads_non_multiple_target():
+def test_iter_regions_dense_pads_non_multiple_target():
     enc = _encoder()
     target_size = 60  # padded up to 64 -> grid 4x4
     wsi = _FakeWSI(target_h=target_size, target_w=target_size)
-    grids = encode_regions_dense(
+    grids = list(iter_regions_dense(
         model=enc, device="cpu", wsi=wsi, coordinates=[(0, 0)],
         requested_spacing_um=0.5, target_size=target_size,
-    )
-    assert grids.shape == (1, enc.encode_dim, 4, 4)
+    ))
+    assert len(grids) == 1
+    assert grids[0].shape == (enc.encode_dim, 4, 4)
 
 
-def test_encode_regions_dense_matches_direct_encode():
-    """The primitive is a faithful wrapper: parity vs a hand-rolled transform+pad+encode."""
-    enc = _encoder()
-    target_size = 64
-    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
-    coords = [(0, 0), (128, 256)]
-
-    grids = encode_regions_dense(
-        model=enc, device="cpu", wsi=wsi, coordinates=coords,
-        requested_spacing_um=0.5, target_size=target_size,
-    )
-
-    # Re-read the same regions (deterministic) and encode them directly.
+def _reference_grid(enc, loc, *, target_size, feature_kind):
+    """Hand-rolled transform → pad → encode of one region, for parity checks."""
     from PIL import Image
 
     geometry = compute_dense_geometry(target_size=target_size, patch_size=enc.patch_size)
     transform = enc.get_dense_transform()
     ref_wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    region = ref_wsi.read_region_at_spacing(
+        loc, 0.5, (target_size, target_size), tolerance=0.05, interpolation="area"
+    )
+    tensor = torch.as_tensor(transform(Image.fromarray(region))).as_subclass(torch.Tensor)
+    padded = pad_image_to_encoded(tensor, geometry, pad_mode="reflect", image_pad_value=None)
     with torch.inference_mode():
-        for i, loc in enumerate(coords):
-            region = ref_wsi.read_region_at_spacing(
-                loc, 0.5, (target_size, target_size), tolerance=0.05, interpolation="area"
-            )
-            tensor = torch.as_tensor(transform(Image.fromarray(region))).as_subclass(torch.Tensor)
-            padded = pad_image_to_encoded(tensor, geometry, pad_mode="reflect", image_pad_value=None)
-            ref = enc.encode_tiles_dense(padded.unsqueeze(0)).detach().float().cpu().numpy()[0]
-            np.testing.assert_allclose(grids[i], ref, rtol=0, atol=1e-6)
+        if feature_kind == "patch_features":
+            out = enc.encode_tiles_dense(padded.unsqueeze(0))
+        else:
+            out = enc.encode_tiles_attention(padded.unsqueeze(0))
+    return out.detach().float().cpu().numpy()[0]
 
 
-def test_encode_regions_dense_empty_coordinates():
+@pytest.mark.parametrize("feature_kind", ["patch_features", "cls_attention"])
+def test_iter_regions_dense_matches_direct_encode(feature_kind):
+    """Each yielded grid is byte-identical to a hand-rolled transform+pad+encode."""
+    enc = _encoder()
+    target_size = 64
+    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    coords = [(0, 0), (128, 256)]
+
+    grids = list(iter_regions_dense(
+        model=enc, device="cpu", wsi=wsi, coordinates=coords,
+        requested_spacing_um=0.5, target_size=target_size,
+        feature_kind=feature_kind,
+    ))
+
+    assert len(grids) == len(coords)
+    for grid, loc in zip(grids, coords):
+        ref = _reference_grid(enc, loc, target_size=target_size, feature_kind=feature_kind)
+        assert grid.shape == ref.shape
+        np.testing.assert_array_equal(grid, ref)
+
+
+def test_iter_regions_dense_empty_coordinates_yields_nothing():
     enc = _encoder()
     wsi = _FakeWSI(target_h=64, target_w=64)
-    grids = encode_regions_dense(
+    grids = list(iter_regions_dense(
         model=enc, device="cpu", wsi=wsi, coordinates=[],
         requested_spacing_um=0.5, target_size=64,
+    ))
+    assert grids == []
+    assert wsi.calls == []
+
+
+def test_iter_regions_dense_streams_one_batch_at_a_time():
+    """Reads advance one batch at a time; first grids land before all coords are read."""
+    enc = _encoder()
+    target_size = 64
+    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    coords = [(0, 0), (64, 0), (0, 64), (64, 64), (128, 0)]  # 5 coords, batches of [2, 2, 1]
+
+    gen = iter_regions_dense(
+        model=enc, device="cpu", wsi=wsi, coordinates=coords,
+        requested_spacing_um=0.5, target_size=target_size, batch_size=2,
     )
-    assert grids.shape == (0, 0, 4, 4)
+
+    assert wsi.calls == []  # iteration is lazy: building the generator reads nothing
+
+    first = next(gen)
+    assert first.shape == (enc.encode_dim, 4, 4)
+    # First grid is yielded after only the first batch (2 of 5) has been read.
+    assert len(wsi.calls) == 2
+    next(gen)
+    assert len(wsi.calls) == 2  # second grid comes from the already-read first batch
+    next(gen)
+    assert len(wsi.calls) == 4  # third grid forces the next batch to be read
+
+    rest = list(gen)
+    assert len(rest) == 2
+    assert len(wsi.calls) == len(coords)  # total reads never exceed the coordinate count
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{"pad_mode": "bogus"}, {"feature_kind": "bogus"}], ids=["pad_mode", "feature_kind"]
+)
+def test_iter_regions_dense_validates_eagerly_before_any_read(kwargs):
+    """Invalid pad mode / feature kind raise at the call site, before any region is read."""
+    enc = _encoder()
+    target_size = 64
+    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+
+    with pytest.raises(ValueError):
+        # The raise must come from the call itself, not from iterating the result — a
+        # single ``def … yield`` would wrongly defer validation to the first ``next()``.
+        iter_regions_dense(
+            model=enc, device="cpu", wsi=wsi, coordinates=[(0, 0)],
+            requested_spacing_um=0.5, target_size=target_size, **kwargs,
+        )
     assert wsi.calls == []


### PR DESCRIPTION
## What

Convert the whole-region dense-regions primitive from "accumulate every ROI grid in a Python list, then return one concatenated array" into a **streaming generator**, `iter_regions_dense`, that yields one `(d, grid_h, grid_w)` float32 grid per coordinate, in coordinate order.

This is a **hard rename** of `encode_regions_dense` — no back-compat alias is kept. The per-slide grid list and the trailing `np.concatenate` are gone, so resident host memory is bounded by `batch_size` rather than by a slide's ROI count (this is the leak that OOM-kills large slides).

This is the first of the three PRD slices and covers ONLY the whole-region path — no `window_size` parameter yet (that arrives in a later slice).

## Details

- **Eager validation, lazy iteration**: arguments are validated and geometry/encode-fn are resolved up front in the outer function, which then `return`s an inner generator closure. An invalid `pad_mode` / `feature_kind` raises at the call site, before any region is read; iteration advances one batch at a time.
- **Standalone grids**: each yielded grid is `np.ascontiguousarray(batch_np[i])`, a contiguous copy, so a per-row view does not pin the whole batch's memory alive.
- **Byte-identical** whole-region output (same spacing-aware reads, dense transform, padding to the patch multiple, encode) for both `patch_features` and `cls_attention`.
- Empty coordinates yield nothing (the sentinel empty-array return is dropped).

## Tests

`tests/test_dense_regions.py` updated to the generator contract (consume via `list(...)`); added:
- streaming/laziness test with a call-counting fake reader (reads advance one batch at a time; first grids land before all coordinates are read),
- eager-validation test (invalid pad mode / feature kind raise at call time, before any read),
- parametrized whole-region parity over both feature kinds, asserting byte-identity (`assert_array_equal`).

Full offline suite: `python -m pytest tests -m "not heavy"` → 363 passed, 1 deselected.

Closes #193