### PR TITLE
ci: seed Buildx GHA cache on main to fix cold PR builds

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -1,6 +1,14 @@
 name: Test suite
 
 on:
+  # Seed the Buildx GHA cache on the default branch. GitHub Actions cache is
+  # branch-scoped: a run can only restore caches created on its own ref or on the
+  # default branch. Without a push-to-main build, every PR writes its cache to its
+  # own PR scope (invisible to all other PRs) and the shared default-branch cache
+  # is never populated, so each PR rebuilds the entire image from scratch (~15 min).
+  # Building on push to main populates the cache every PR can then restore from.
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -80,13 +88,17 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Guard required secret (if needed)
-        if: ${{ github.event_name != 'pull_request' }}  # or drop the condition if PRs from same repo need it
+        if: ${{ github.event_name == 'workflow_dispatch' }}  # only the manual full-suite run needs the token up front
         run: |
           set -euo pipefail
           test -n "${HF_TOKEN:-}" || { echo "HF_TOKEN is required but not set"; exit 1; }
 
+      # Push-to-main runs are cache-seeding only: they build and export the image
+      # layers so PRs can restore them, but skip the ~16-min PRISM consistency test
+      # (the merged PR already ran it). Tests run on PRs that touch code and on
+      # manual dispatch.
       - name: Run test suite in container
-        if: ${{ steps.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
+        if: ${{ (github.event_name == 'pull_request' && steps.changes.outputs.code == 'true') || github.event_name == 'workflow_dispatch' }}
         run: |
           set -euo pipefail
           # Dependencies (torch, xformers, transformers, hs2p, pytest, ...) are


### PR DESCRIPTION
## Problem

`docker-test` takes ~33 min on every PR, split almost evenly between **build (~15.5 min)** and **test (~16 min)**. We already added GHA Buildx caching (`cache-from/to: type=gha,mode=max`), but it isn't helping: the latest run shows the build importing a cache manifest yet restoring **zero layers** — the whole image rebuilds from the first `RUN` (apt-get) onward.

```
#7 importing cache manifest from gha ... DONE 0.2s
#10 [apt-get install]  DONE 45.2s     ← rebuilt
#11 [libjpeg-turbo]    DONE 32.1s     ← rebuilt
#19 [dep-baking pip]   DONE 416.9s    ← rebuilt
grep -c CACHED = 0
```

## Root cause

Not the editable install (that runs at *runtime* in `docker run`, not during the build — and layer #10 rebuilds *before* `pyproject.toml` is even COPYed in, so the cache was fully cold).

The real cause is **GitHub Actions cache scoping**: a run can only restore caches created on **its own ref or the default branch**. This workflow only triggered on `pull_request` / `workflow_dispatch` — it **never ran on push to `main`**, so the shared default-branch cache was never seeded. Each PR wrote its cache to its own PR scope, invisible to every other PR, so every PR built cold.

## Fix

Build on **push to `main`** to populate the shared cache that all PRs restore from. Main-push runs are **cache-seeding only**: they build and export the image layers but skip the ~16-min PRISM consistency test (the merged PR already ran it). The guard-secret step is narrowed to `workflow_dispatch` (the only path that needs the token up front). PR and manual-dispatch behaviour is otherwise unchanged.

A nice side effect: the post-merge main build also re-warms the dep-baking layer right after a release bumps `pyproject.toml`, so the next PR doesn't pay for it.

## Expected effect

Once `main` is seeded (the first post-merge build of this PR), PR builds become near-instant cache restores, dropping `docker-test` from ~33 min to roughly the ~16-min PRISM test alone.

## Behaviour matrix

| event | build | test |
|---|---|---|
| push → main | ✅ seed cache | ⏭️ skipped |
| PR (code) | ✅ (cache hit) | ✅ full suite |
| PR (docs-only) | ⏭️ | ⏭️ (job still green) |
| workflow_dispatch | ✅ | ✅ full suite |
| release-* PR | job skipped (unchanged) | — |