### PR TITLE
Unify whole-region and sliding-window dense extraction in iter_regions_dense

### DIFF
--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -21,9 +21,12 @@ the finest pyramid level ``<=`` the requested µm/px is read and downscaled to t
 the same spacing. The ``wsi`` is injected (any object exposing ``read_region_at_spacing``),
 so the loop is unit-testable offline with a fake reader + a random-weight encoder.
 
-Whole-tile only (one padded forward per region). Sliding-window dense extraction over
-coordinates (``window_size`` < input) is a deferred follow-up — large ROIs that exceed the
-encoder's comfortable field are out of scope for the first increment.
+Both dense modes run through one primitive (:func:`~slide2vec.runtime.dense_sliding.encode_dense_sliding`):
+``window_size=None`` is a single whole-tile forward (byte-identical to the legacy
+whole-region encode), and a ``window_size`` smaller than the encoded tile slides the
+encoder's native field over the padded tile and blends the per-window token grids with a
+separable raised-cosine map — letting a native-field encoder (e.g. 224-px Virchow2/phikon)
+serve a larger ROI without interpolating its position embeddings.
 """
 
 from __future__ import annotations
@@ -36,6 +39,7 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 
+from slide2vec.runtime.dense_sliding import encode_dense_sliding
 from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
 
 _PAD_MODES = {"reflect", "constant", "zero", "replicate"}
@@ -150,6 +154,8 @@ def iter_regions_dense(
     tolerance: float = 0.05,
     pad_mode: str = "reflect",
     image_pad_value: float | None = None,
+    window_size: int | None = None,
+    overlap: float = 0.0,
     feature_kind: str = "patch_features",
     attention_blocks: tuple[int, ...] = (-1,),
     attention_include_registers: bool = False,
@@ -180,6 +186,14 @@ def iter_regions_dense(
         requested_spacing_um: µm/px to read each region at.
         target_size: supervision tile size (int or ``(h, w)``); the region is read at this
             size at ``requested_spacing_um`` and the token grid registers to it.
+        window_size: encoder field-of-view chunk fed through the backbone per forward.
+            ``None`` (default) is one whole-tile forward, byte-identical to the
+            whole-region encode; a value smaller than the encoded tile slides the encoder
+            over patch-aligned windows and blends the token grids (raised-cosine map). The
+            output grid is always the whole geometry's ``(grid_h, grid_w)`` either way —
+            sliding is internal to extraction.
+        overlap: fractional window overlap in ``[0, 1)`` for the sliding path (ignored when
+            ``window_size is None``); the stride is ``window * (1 - overlap)``.
 
     Yields ``float32`` grids in coordinate order; empty ``coordinates`` yields nothing.
     ``feature_kind`` selects ``encode_tiles_dense`` (patch grid) vs
@@ -233,14 +247,26 @@ def iter_regions_dense(
                 batch = torch.stack([_read_padded(loc) for loc in chunk]).to(
                     device, non_blocking=True
                 )
-                out = encode_fn(batch)
+                # Every batch goes through the one windowed primitive: window_size=None
+                # short-circuits to a single whole-tile forward (byte-identical to the
+                # whole-region encode), so there is no separate whole-region branch.
+                out = encode_dense_sliding(
+                    model,
+                    batch,
+                    geometry=geometry,
+                    window_size=window_size,
+                    overlap=overlap,
+                    encode_fn=encode_fn,
+                )
                 if out.ndim != 4:
                     raise ValueError(
                         f"{feature_kind} encode returned a {out.ndim}-D tensor; expected (B, d, gh, gw)."
                     )
                 batch_np = out.detach().float().cpu().numpy()
                 for i in range(batch_np.shape[0]):
-                    # Standalone contiguous copy: a per-row view would pin the whole batch.
-                    yield np.ascontiguousarray(batch_np[i])
+                    # Standalone C-contiguous copy: a per-row view would pin the whole
+                    # batch alive (the blended sliding output is contiguous, so a view of
+                    # it would not copy). ``.copy()`` always copies, in C order.
+                    yield batch_np[i].copy()
 
     return _stream()

--- a/slide2vec/runtime/dense_sliding.py
+++ b/slide2vec/runtime/dense_sliding.py
@@ -1,0 +1,185 @@
+"""Sliding-window dense encoding — ``window_size`` + ``overlap`` as a free knob.
+
+The ``whole`` path feeds the full padded tile through the encoder in one forward,
+interpolating the positional embeddings to the larger grid. That is one end of a
+single mechanism; the other end is running the encoder over smaller **windows** and
+stitching the per-window token grids. Three sizes that are usually conflated —
+
+* **native size** (e.g. 224) — sets the pos-embed table; not a hard input limit
+  (``dynamic_img_size`` lets a ViT process a larger field at the correct mpp);
+* **window size** ``W`` — how big a chunk goes through the ViT in one forward;
+* **input size** — the padded ``encoded_size`` we want dense features for.
+
+``whole`` is ``W >= input`` (one window, zero stitching); native sliding is ``W = 224``;
+the useful middle is ``W = 512`` slid over a larger input. So this is **one**
+parametrized path, not a separate mode: :func:`encode_dense_sliding` takes
+``window_size`` (``None`` ⇒ ``whole``) and ``overlap``, and the ``whole`` case falls out
+as the degenerate single window — which we short-circuit to the exact same
+``encode_tiles_dense(batch)`` call, so it stays **byte-identical** to the whole-region
+path (the parity anchor).
+
+Stitching happens in **token space** (the grid the decoder/head consume), so the output
+is always ``(B, d, grid_h, grid_w)`` for ``geometry.grid_shape`` regardless of
+``window_size`` — sliding is purely internal to extraction. Windows and strides are kept
+patch-aligned, so each window maps cleanly onto a block of tokens; overlapping windows
+are blended with a separable raised-cosine importance map (the standard frozen-backbone
+dense-inference recipe, cf. MONAI ``sliding_window_inference``) to remove the
+block-boundary seams naive non-overlapping tiling would introduce.
+
+Ported from soma's ``soma/dense/sliding.py`` (the window/blend math is encoder
+featurization that belongs in slide2vec); adapted to slide2vec's own
+:class:`~slide2vec.runtime.dense_regions.DenseGridGeometry`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Callable
+
+import torch
+
+if TYPE_CHECKING:
+    from slide2vec.runtime.dense_regions import DenseGridGeometry
+
+__all__ = [
+    "cover_origins",
+    "encode_dense_sliding",
+    "resolve_window_geometry",
+]
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _round_to(value: float, multiple: int) -> int:
+    return max(multiple, int(round(value / multiple)) * multiple)
+
+
+def cover_origins(extent: int, size: int, stride: int) -> list[int]:
+    """Start offsets of ``size``-wide windows that fully cover ``[0, extent)``.
+
+    Walks ``[0, extent - size]`` in ``stride`` steps and, if the last step leaves a gap,
+    appends one final start flush to the far edge (``extent - size``) so coverage is
+    complete with no partial tail. ``extent``/``size``/``stride`` are patch multiples,
+    so every start is too — the edge-flush ``extent - size`` is a difference of patch
+    multiples.
+    """
+    if size >= extent:
+        return [0]
+    starts = list(range(0, extent - size + 1, stride))
+    if starts[-1] + size < extent:
+        starts.append(extent - size)  # shift the last window flush to the edge
+    return starts
+
+
+def _window_starts(extent: int, win: int, stride: int) -> list[int]:
+    """Patch-aligned encoder-window starts — the token-space use of :func:`cover_origins`."""
+    return cover_origins(extent, win, stride)
+
+
+def resolve_window_geometry(
+    geometry: DenseGridGeometry, *, window_size: int | None, overlap: float
+) -> tuple[tuple[int, int], tuple[int, int], list[int], list[int]]:
+    """Resolve per-dim window size, stride, and start offsets (all patch-aligned).
+
+    ``window_size`` is rounded up to the patch multiple and clamped to the encoded
+    extent; because ``round_up`` is monotonic, ``window_size >= target_size`` always
+    clamps to the full extent ⇒ a single window ⇒ the ``whole`` path. ``stride`` is
+    ``window * (1 - overlap)`` rounded to the patch multiple and clamped to
+    ``[patch, window]``.
+    """
+    enc_h, enc_w = geometry.encoded_size
+    ph, pw = geometry.patch_size
+    if window_size is None:
+        return (enc_h, enc_w), (enc_h, enc_w), [0], [0]
+
+    win_h = min(_round_up(int(window_size), ph), enc_h)
+    win_w = min(_round_up(int(window_size), pw), enc_w)
+    keep = 1.0 - float(overlap)
+    stride_h = min(win_h, _round_to(win_h * keep, ph))
+    stride_w = min(win_w, _round_to(win_w * keep, pw))
+    starts_h = _window_starts(enc_h, win_h, stride_h)
+    starts_w = _window_starts(enc_w, win_w, stride_w)
+    return (win_h, win_w), (stride_h, stride_w), starts_h, starts_w
+
+
+def _hann_1d(n: int, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    """Strictly-positive raised-cosine weights of length ``n`` (uniform if ``n == 1``).
+
+    ``0.5 - 0.5*cos(2*pi*(i+1)/(n+1))`` is > 0 for every ``i in [0, n)`` (no zeros at
+    the edges), so the accumulated weight map never hits zero where a window covers.
+    """
+    if n <= 1:
+        return torch.ones(n, device=device, dtype=dtype)
+    i = torch.arange(1, n + 1, device=device, dtype=dtype)
+    return 0.5 - 0.5 * torch.cos(2.0 * math.pi * i / (n + 1))
+
+
+def encode_dense_sliding(
+    encoder,
+    batch: torch.Tensor,
+    *,
+    geometry: DenseGridGeometry,
+    window_size: int | None,
+    overlap: float = 0.0,
+    encode_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+) -> torch.Tensor:
+    """Encode a padded ``(B, C, enc_h, enc_w)`` batch into ``(B, d, grid_h, grid_w)``.
+
+    ``window_size is None`` (or any window that covers the whole encoded input) is the
+    degenerate single-window case: it short-circuits to one full-tile forward,
+    byte-identical to the whole-region path. Otherwise the encoder runs over
+    patch-aligned overlapping windows and the per-window token grids are blended with a
+    separable raised-cosine importance map. The stitch math runs in fp32 (sub-grids are
+    upcast before accumulation) so blended regions don't accumulate autocast-dtype error.
+
+    ``encode_fn`` is the per-window encode callable ``(B, C, wh, ww) -> (B, d, th, tw)``;
+    it defaults to ``encoder.encode_tiles_dense`` (the patch-feature grid). The attention
+    path passes ``encoder.encode_tiles_attention`` (partial-applied with its
+    block/register knobs) so a CLS-attention grid stitches through the identical
+    raised-cosine blending — the output is just ``(B, K, grid)`` instead of ``(B, d, grid)``.
+    """
+    if encode_fn is None:
+        encode_fn = encoder.encode_tiles_dense
+    (win_h, win_w), _, starts_h, starts_w = resolve_window_geometry(
+        geometry, window_size=window_size, overlap=overlap
+    )
+    if len(starts_h) == 1 and len(starts_w) == 1:
+        # Single window == the whole encoded tile: identical forward to the whole-region path.
+        return encode_fn(batch)
+
+    ph, pw = geometry.patch_size
+    grid_h, grid_w = geometry.grid_shape
+    wth, wtw = win_h // ph, win_w // pw
+    # Raised-cosine weights where windows overlap; uniform along any dim that is not
+    # actually tiled (a single window there) — avoids needless edge attenuation.
+    fdtype = torch.float32
+    wh = (
+        _hann_1d(wth, batch.device, fdtype)
+        if len(starts_h) > 1
+        else torch.ones(wth, device=batch.device, dtype=fdtype)
+    )
+    ww = (
+        _hann_1d(wtw, batch.device, fdtype)
+        if len(starts_w) > 1
+        else torch.ones(wtw, device=batch.device, dtype=fdtype)
+    )
+    weight = torch.outer(wh, ww)  # (wth, wtw)
+
+    acc: torch.Tensor | None = None
+    wsum = torch.zeros(1, 1, grid_h, grid_w, device=batch.device, dtype=fdtype)
+    for sh in starts_h:
+        th = sh // ph
+        for sw in starts_w:
+            tw = sw // pw
+            window = batch[:, :, sh : sh + win_h, sw : sw + win_w]
+            sub = encode_fn(window).to(fdtype)  # (B, d, wth, wtw)
+            if acc is None:
+                acc = torch.zeros(
+                    sub.shape[0], sub.shape[1], grid_h, grid_w, device=batch.device, dtype=fdtype
+                )
+            acc[:, :, th : th + wth, tw : tw + wtw] += sub * weight
+            wsum[:, :, th : th + wth, tw : tw + wtw] += weight
+    assert acc is not None  # at least one window always runs
+    return acc / wsum

--- a/tests/test_dense_regions.py
+++ b/tests/test_dense_regions.py
@@ -22,6 +22,7 @@ from slide2vec.runtime.dense_regions import (  # noqa: E402
     iter_regions_dense,
     pad_image_to_encoded,
 )
+from slide2vec.runtime.dense_sliding import encode_dense_sliding  # noqa: E402
 
 
 def _encoder(**kwargs) -> TimmTileEncoder:
@@ -45,7 +46,9 @@ class _FakeWSI:
         return rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
 
 
-def test_iter_regions_dense_yields_grid_per_coordinate_in_order():
+@pytest.mark.parametrize("feature_kind", ["patch_features", "cls_attention"])
+@pytest.mark.parametrize("window_size", [None, 32], ids=["whole", "window32"])
+def test_iter_regions_dense_yields_grid_per_coordinate_in_order(window_size, feature_kind):
     enc = _encoder()
     target_size = 64  # patch 16 -> grid 4x4, no padding
     wsi = _FakeWSI(target_h=target_size, target_w=target_size)
@@ -59,14 +62,18 @@ def test_iter_regions_dense_yields_grid_per_coordinate_in_order():
             coordinates=coords,
             requested_spacing_um=0.5,
             target_size=target_size,
+            window_size=window_size,
+            feature_kind=feature_kind,
             batch_size=2,
         )
     )
 
-    # One standalone (d, gh, gw) grid per coordinate, in coordinate order.
+    # One standalone (d, gh, gw) grid per coordinate, in coordinate order — for both the
+    # whole-tile and sliding-window paths and both feature kinds (sliding is internal to
+    # extraction, so the output grid is always the whole geometry's 4x4 token grid).
     assert len(grids) == 3
     for grid in grids:
-        assert grid.shape == (enc.encode_dim, 4, 4)
+        assert grid.shape[1:] == (4, 4)
         assert grid.dtype == np.float32
         assert grid.flags["C_CONTIGUOUS"]
         assert grid.base is None  # standalone copy, not a view pinning a batch
@@ -87,8 +94,13 @@ def test_iter_regions_dense_pads_non_multiple_target():
     assert grids[0].shape == (enc.encode_dim, 4, 4)
 
 
-def _reference_grid(enc, loc, *, target_size, feature_kind):
-    """Hand-rolled transform → pad → encode of one region, for parity checks."""
+def _reference_grid(enc, loc, *, target_size, feature_kind, window_size=None, overlap=0.0):
+    """Hand-rolled transform → pad → encode of one region, for parity checks.
+
+    ``window_size=None`` is the direct whole-tile forward (the byte-identity anchor for
+    the whole-region path); a ``window_size`` routes the padded tile through the same
+    windowed primitive ``iter_regions_dense`` uses, so the seam stays exactly identical.
+    """
     from PIL import Image
 
     geometry = compute_dense_geometry(target_size=target_size, patch_size=enc.patch_size)
@@ -99,17 +111,30 @@ def _reference_grid(enc, loc, *, target_size, feature_kind):
     )
     tensor = torch.as_tensor(transform(Image.fromarray(region))).as_subclass(torch.Tensor)
     padded = pad_image_to_encoded(tensor, geometry, pad_mode="reflect", image_pad_value=None)
+    batch = padded.unsqueeze(0)
+    if feature_kind == "patch_features":
+        encode_fn = enc.encode_tiles_dense
+    else:
+        encode_fn = enc.encode_tiles_attention
     with torch.inference_mode():
-        if feature_kind == "patch_features":
-            out = enc.encode_tiles_dense(padded.unsqueeze(0))
+        if window_size is None:
+            out = encode_fn(batch)
         else:
-            out = enc.encode_tiles_attention(padded.unsqueeze(0))
+            out = encode_dense_sliding(
+                enc, batch, geometry=geometry, window_size=window_size,
+                overlap=overlap, encode_fn=encode_fn,
+            )
     return out.detach().float().cpu().numpy()[0]
 
 
 @pytest.mark.parametrize("feature_kind", ["patch_features", "cls_attention"])
-def test_iter_regions_dense_matches_direct_encode(feature_kind):
-    """Each yielded grid is byte-identical to a hand-rolled transform+pad+encode."""
+@pytest.mark.parametrize("window_size", [None, 32], ids=["whole", "window32"])
+def test_iter_regions_dense_matches_direct_encode(window_size, feature_kind):
+    """Each yielded grid is byte-identical to a hand-rolled transform+pad+encode.
+
+    ``window_size=None`` pins the whole-region path against a direct encode; a smaller
+    ``window_size`` pins the streamed blended grid against the same windowed primitive.
+    """
     enc = _encoder()
     target_size = 64
     wsi = _FakeWSI(target_h=target_size, target_w=target_size)
@@ -118,12 +143,15 @@ def test_iter_regions_dense_matches_direct_encode(feature_kind):
     grids = list(iter_regions_dense(
         model=enc, device="cpu", wsi=wsi, coordinates=coords,
         requested_spacing_um=0.5, target_size=target_size,
-        feature_kind=feature_kind,
+        window_size=window_size, feature_kind=feature_kind,
     ))
 
     assert len(grids) == len(coords)
     for grid, loc in zip(grids, coords):
-        ref = _reference_grid(enc, loc, target_size=target_size, feature_kind=feature_kind)
+        ref = _reference_grid(
+            enc, loc, target_size=target_size, feature_kind=feature_kind,
+            window_size=window_size,
+        )
         assert grid.shape == ref.shape
         np.testing.assert_array_equal(grid, ref)
 
@@ -139,8 +167,14 @@ def test_iter_regions_dense_empty_coordinates_yields_nothing():
     assert wsi.calls == []
 
 
-def test_iter_regions_dense_streams_one_batch_at_a_time():
-    """Reads advance one batch at a time; first grids land before all coords are read."""
+@pytest.mark.parametrize("feature_kind", ["patch_features", "cls_attention"])
+@pytest.mark.parametrize("window_size", [None, 32], ids=["whole", "window32"])
+def test_iter_regions_dense_streams_one_batch_at_a_time(window_size, feature_kind):
+    """Reads advance one batch at a time; first grids land before all coords are read.
+
+    The streaming/laziness contract is independent of the dense mode, so it holds for
+    both the whole-tile and sliding-window paths and both feature kinds.
+    """
     enc = _encoder()
     target_size = 64
     wsi = _FakeWSI(target_h=target_size, target_w=target_size)
@@ -148,13 +182,14 @@ def test_iter_regions_dense_streams_one_batch_at_a_time():
 
     gen = iter_regions_dense(
         model=enc, device="cpu", wsi=wsi, coordinates=coords,
-        requested_spacing_um=0.5, target_size=target_size, batch_size=2,
+        requested_spacing_um=0.5, target_size=target_size,
+        window_size=window_size, feature_kind=feature_kind, batch_size=2,
     )
 
     assert wsi.calls == []  # iteration is lazy: building the generator reads nothing
 
     first = next(gen)
-    assert first.shape == (enc.encode_dim, 4, 4)
+    assert first.shape[1:] == (4, 4)
     # First grid is yielded after only the first batch (2 of 5) has been read.
     assert len(wsi.calls) == 2
     next(gen)

--- a/tests/test_dense_sliding.py
+++ b/tests/test_dense_sliding.py
@@ -1,0 +1,121 @@
+"""Tests for the window-as-knob dense sliding path (relocated from soma).
+
+``window_size=None`` is ``whole`` (one padded forward); a smaller ``window_size``
+(+ ``overlap``) slides the encoder over patch-aligned windows and blends the token
+grids. The anchor invariant: any window that covers the whole encoded input — most
+importantly ``window_size=None`` — is **byte-identical** to the legacy
+``encode_tiles_dense(batch)`` forward, so the ``whole`` path is untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("timm")
+
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime.dense_regions import compute_dense_geometry  # noqa: E402
+from slide2vec.runtime.dense_sliding import (  # noqa: E402
+    _window_starts,
+    encode_dense_sliding,
+    resolve_window_geometry,
+)
+
+PATCH = 16
+
+
+def _encoder() -> TimmTileEncoder:
+    return TimmTileEncoder(
+        "vit_tiny_patch16_224", pretrained=False, num_classes=0, dynamic_img_size=True
+    )
+
+
+# --- pure geometry (no encoder) ------------------------------------------------
+
+
+def test_window_starts_cover_and_patch_aligned():
+    starts = _window_starts(extent=64, win=32, stride=16)
+    assert starts == [0, 16, 32]
+    assert all(s % PATCH == 0 for s in starts)
+    assert starts[-1] + 32 == 64  # last window flush to the edge
+
+
+def test_window_starts_appends_edge_window_when_stride_misses():
+    # stride 24 from 0 -> [0, 24] then last (24+32=56 < 64) appends edge 32.
+    starts = _window_starts(extent=64, win=32, stride=24)
+    assert starts[0] == 0 and starts[-1] == 32 and starts[-1] + 32 == 64
+
+
+def test_resolve_window_geometry_whole_is_single_window():
+    geom = compute_dense_geometry(target_size=64, patch_size=PATCH)
+    (win, stride, sh, sw) = resolve_window_geometry(geom, window_size=None, overlap=0.0)
+    assert win == geom.encoded_size and stride == geom.encoded_size
+    assert sh == [0] and sw == [0]
+
+
+def test_resolve_window_geometry_large_window_clamps_to_whole():
+    geom = compute_dense_geometry(target_size=64, patch_size=PATCH)
+    # window >= target -> rounds/clamps to the full encoded extent -> one window.
+    _, _, sh, sw = resolve_window_geometry(geom, window_size=128, overlap=0.5)
+    assert sh == [0] and sw == [0]
+
+
+def test_resolve_window_geometry_rounds_window_up_to_patch():
+    geom = compute_dense_geometry(target_size=64, patch_size=PATCH)
+    (win, _, sh, _) = resolve_window_geometry(geom, window_size=30, overlap=0.0)
+    assert win == (32, 32)  # 30 -> round up to patch multiple
+    assert len(sh) == 2  # 32 over 64 at stride 32 -> two windows
+
+
+# --- parity: whole-covering windows == encode_tiles_dense ----------------------
+
+
+def test_sliding_window_none_is_byte_identical_to_encode_tiles_dense():
+    enc = _encoder()
+    geom = compute_dense_geometry(target_size=64, patch_size=enc.patch_size)
+    x = torch.randn(2, 3, *geom.encoded_size)
+    with torch.no_grad():
+        ref = enc.encode_tiles_dense(x)
+        got = encode_dense_sliding(enc, x, geometry=geom, window_size=None, overlap=0.0)
+    assert torch.equal(ref, got)
+
+
+def test_sliding_window_covering_whole_is_byte_identical():
+    enc = _encoder()
+    geom = compute_dense_geometry(target_size=64, patch_size=enc.patch_size)
+    x = torch.randn(1, 3, *geom.encoded_size)
+    with torch.no_grad():
+        ref = enc.encode_tiles_dense(x)
+        # window >= input -> degenerate single window, must short-circuit to ref.
+        got = encode_dense_sliding(enc, x, geometry=geom, window_size=256, overlap=0.5)
+    assert torch.equal(ref, got)
+
+
+# --- genuine sliding -----------------------------------------------------------
+
+
+def test_sliding_outputs_full_grid_shape():
+    enc = _encoder()
+    geom = compute_dense_geometry(target_size=64, patch_size=enc.patch_size)
+    x = torch.randn(2, 3, *geom.encoded_size)
+    with torch.no_grad():
+        grid = encode_dense_sliding(enc, x, geometry=geom, window_size=32, overlap=0.5)
+    # Sliding is internal to extraction: output grid == the whole geometry's grid.
+    assert grid.shape == (2, enc.encode_dim, *geom.grid_shape)
+    assert torch.isfinite(grid).all()
+
+
+def test_sliding_non_overlap_matches_block_encoding_on_interior():
+    """With overlap=0 each token is covered by exactly one window; the blended result
+    equals encoding that window's block (the weight cancels for single-coverage tokens)."""
+    enc = _encoder()
+    geom = compute_dense_geometry(target_size=64, patch_size=enc.patch_size)
+    x = torch.randn(1, 3, *geom.encoded_size)
+    ph = enc.patch_size[0] if isinstance(enc.patch_size, tuple) else enc.patch_size
+    with torch.no_grad():
+        grid = encode_dense_sliding(enc, x, geometry=geom, window_size=32, overlap=0.0)
+        # top-left 32x32 block encoded on its own -> its 2x2 token sub-grid.
+        block = enc.encode_tiles_dense(x[:, :, :32, :32]).float()
+    wt = 32 // ph
+    torch.testing.assert_close(grid[:, :, :wt, :wt], block, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## What

Moves soma's sliding-window dense-extraction math down into slide2vec and unifies whole-region and sliding-window extraction behind the single streaming primitive `iter_regions_dense`. This slice only **adds** to slide2vec; soma is untouched (it keeps its own copy until a later migration).

### Changes

- **New `slide2vec/runtime/dense_sliding.py`** — ports `encode_dense_sliding`, `resolve_window_geometry`, and their private helpers (`cover_origins`/`_window_starts`, `_round_up`/`_round_to`, `_hann_1d`) from `soma/dense/sliding.py`. Adapted to slide2vec's own `DenseGridGeometry` (referenced under `TYPE_CHECKING` to avoid a circular import). `describe_dense_mode` is intentionally **not** ported (stays a soma concern). The stitch math runs in fp32. `window_size=None` (or any whole-covering window) short-circuits to a single whole-tile forward, byte-identical to the legacy encode.
- **`iter_regions_dense` gains `window_size: int | None = None` and `overlap: float = 0.0`** and routes **every** batch through `encode_dense_sliding`, collapsing the separate whole-region `encode_fn(batch)` branch. Per-yield grids now use `.copy()` so the contiguous blended sliding output is a standalone copy rather than a view that would pin the whole batch.
- **Tests**: relocated stitch-math suite as `tests/test_dense_sliding.py`; extended the `iter_regions_dense` seam tests, now parametrized over `window_size` × `feature_kind`, keeping the streaming/laziness contract.

### Tests

- `tests/test_dense_sliding.py`: 9 passed
- `tests/test_dense_regions.py`: 16 passed (parametrized window_size × feature_kind)
- Full suite: 380 passed, 1 deselected (pre-existing `heavy` HF-weights test)

Closes #194