### PR TITLE
Document region-level streaming dense extraction

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -155,6 +155,69 @@ variable-size model setting:
        allow_non_recommended_settings=True,
    ).to("cuda")
 
+Region-level streaming
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The encoder-level API above operates on tiles you have already read and
+normalized. To extract dense grids over many slide regions at once, slide2vec
+provides a higher-level streaming primitive,
+``iter_regions_dense`` (from ``slide2vec.runtime.dense_regions``), that wraps
+spacing-aware region reads, padding, and encoding into a single generator:
+
+.. code-block:: python
+
+   from slide2vec.runtime.dense_regions import iter_regions_dense
+
+   for grid in iter_regions_dense(
+       model=model,
+       device=model.device,
+       wsi=wsi,
+       coordinates=[(0, 0), (4096, 0)],
+       requested_spacing_um=0.5,
+       target_size=2048,
+   ):
+       print(grid.shape)  # (d, grid_h, grid_w), float32
+
+For each ``(x, y)`` coordinate (a level-0 top-left location), the region is read
+**spacing-aware** at ``requested_spacing_um`` to ``target_size``, run through the
+encoder's normalization-only ``get_dense_transform``, padded on the bottom/right
+up to the encoder's patch multiple, and encoded into a ``(d, grid_h, grid_w)``
+token grid. The ``wsi`` argument is any object exposing
+``read_region_at_spacing(location, requested_spacing_um, size, *, tolerance,
+interpolation)``, so the loop runs offline in tests with a fake reader.
+
+Streaming contract:
+
+- Grids are yielded **one per coordinate, in coordinate order**; an empty
+  ``coordinates`` sequence yields nothing.
+- Regions are read and encoded one ``batch_size`` chunk at a time, so resident
+  host memory is bounded by ``batch_size`` rather than by the slide's coordinate
+  count — there is no per-slide accumulation.
+- Each yielded grid is a standalone C-contiguous ``float32`` copy, so consuming
+  one grid does not pin the rest of its batch's memory alive.
+- Arguments and geometry are validated **eagerly** at the call site (an invalid
+  ``pad_mode`` or ``feature_kind`` raises before any region is read); iteration
+  itself is lazy and advances one batch at a time.
+
+The ``window_size`` / ``overlap`` parameters select the encode strategy:
+
+- ``window_size=None`` (the default) runs a single whole-region forward —
+  byte-identical to encoding the full padded tile in one pass.
+- A ``window_size`` smaller than the encoded region slides the encoder's native
+  field over patch-aligned windows and blends the per-window token grids with a
+  separable raised-cosine map; ``overlap`` (in ``[0, 1)``) sets the fractional
+  window overlap and the stride is ``window * (1 - overlap)``. This lets a
+  native-field encoder serve a larger region without interpolating its position
+  embeddings. The output grid is always the whole region's ``(grid_h, grid_w)``
+  either way — sliding is internal to extraction.
+
+``feature_kind`` selects which dense map is streamed. ``"patch_features"`` (the
+default) uses ``encode_tiles_dense`` to produce the ``(d, grid_h, grid_w)``
+patch-token grid; ``"cls_attention"`` uses ``encode_tiles_attention`` to produce
+a ``(K, grid_h, grid_w)`` CLS-attention grid, with ``attention_blocks`` and
+``attention_include_registers`` forwarded to that call. Both feature kinds share
+the same read / pad / window path.
+
 Dense Attention Map Extraction
 ------------------------------
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -133,8 +133,12 @@ Notes:
   concatenates CLS and mean patch tokens, ``d`` can be smaller than the pooled
   output dimension ``D``.
 - ``get_dense_transform`` preserves geometry by applying normalization only.
-  Resize, crop, padding, and sliding-window policy are the caller's
-  responsibility.
+  At the **encoder level** (``get_dense_transform`` / ``encode_tiles_dense``),
+  resize, crop, padding, and sliding-window policy are therefore the caller's
+  responsibility. slide2vec also ships a **region-level** streaming primitive,
+  ``iter_regions_dense``, that layers spacing-aware region reads, padding to the
+  patch multiple, and optional sliding-window blending on top of this encoder
+  API — see the "Dense Tile Feature Extraction" section of :doc:`api`.
 - ``musk`` dense extraction currently requires its native 384 x 384 input size.
 - H-Optimus dense extraction at non-native input sizes requires
   ``dynamic_img_size=True`` and ``allow_non_recommended_settings=True`` when


### PR DESCRIPTION
## Summary

Docs-only slice documenting the region-level dense extraction primitive that landed in the two prior slices (#196, #198), and correcting a now-misleading note.

- **`docs/models.rst`** — the "Dense tile grids" Notes entry previously read as a flat "resize, crop, padding, and sliding-window policy are the caller's responsibility", which now contradicts the new capability. It now scopes the normalization-only caveat explicitly to the **encoder level** (`get_dense_transform` / `encode_tiles_dense`) and points out that slide2vec also ships a **region-level** streaming primitive, `iter_regions_dense`, which handles spacing-aware reads, padding to the patch multiple, and optional sliding-window blending — with a pointer to the API section.
- **`docs/api.rst`** — adds a "Region-level streaming" subsection under "Dense Tile Feature Extraction" documenting `iter_regions_dense` (`slide2vec.runtime.dense_regions`): what it does (reads ROIs at coordinates spacing-aware, pads, encodes, streams one `(d, grid_h, grid_w)` grid per coordinate), the streaming/generator contract (coordinate order, bounded by `batch_size`, standalone contiguous copies, eager validation), the `window_size` / `overlap` knobs (`None` = whole-region single forward; smaller window = sliding raised-cosine blend), and both feature kinds (`patch_features`, `cls_attention`). Prose + code-block style, matching the existing section. Signature verified against the source.
- **`docs/output-layout.rst`** — left unchanged (its statement is still accurate).

No code, tests, version bump, or release notes touched.

## Docs build

`python -m sphinx -W -b html docs docs/_build/html` succeeds (exit 0) — exactly the command CI runs.

Closes #195