### PR TITLE
Let iter_regions_dense emit grids in the compute precision (output_dtype)

### DIFF
--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -39,8 +39,30 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 
+from slide2vec.runtime.batching import autocast_dtype
 from slide2vec.runtime.dense_sliding import encode_dense_sliding
 from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
+
+
+def _resolve_output_dtype(output_dtype: "torch.dtype | None", precision: str) -> "torch.dtype":
+    """Resolve the dtype emitted grids are materialized in.
+
+    Defaults (``output_dtype is None``) to the model's compute precision — fp16 runs
+    yield fp16 grids — so the engine no longer force-upcasts everything to float32.
+    numpy has no bfloat16, so a bf16 compute precision widens to float32 (its lossless
+    container) and an *explicit* ``torch.bfloat16`` request is rejected: the grid is
+    materialized via ``.numpy()`` and bfloat16 cannot cross that boundary.
+    """
+    if output_dtype is None:
+        compute = autocast_dtype(torch, precision)  # float16 | bfloat16 | None(fp32)
+        return torch.float16 if compute == torch.float16 else torch.float32
+    if output_dtype == torch.bfloat16:
+        raise ValueError(
+            "output_dtype=torch.bfloat16 cannot be materialized as a numpy grid; "
+            "request torch.float16 or torch.float32"
+        )
+    return output_dtype
+
 
 _PAD_MODES = {"reflect", "constant", "zero", "replicate"}
 
@@ -161,14 +183,16 @@ def iter_regions_dense(
     attention_include_registers: bool = False,
     batch_size: int = 1,
     precision: str = "fp32",
+    output_dtype: "torch.dtype | None" = None,
     dense_transform: Callable | None = None,
 ) -> Iterator[np.ndarray]:
     """Stream slide regions at ``coordinates`` into dense grids, one per coordinate.
 
-    Yields one ``(d, grid_h, grid_w)`` ``float32`` grid per coordinate, in coordinate
-    order. Regions are read and encoded one ``batch_size`` chunk at a time, so resident
-    host memory is bounded by ``batch_size`` rather than by a slide's ROI count (the loop
-    holds at most one batch of grids resident — no per-slide accumulation).
+    Yields one ``(d, grid_h, grid_w)`` grid per coordinate, in coordinate order, in the
+    model's compute ``precision`` by default (fp16 runs yield fp16 grids; see
+    ``output_dtype``). Regions are read and encoded one ``batch_size`` chunk at a time, so
+    resident host memory is bounded by ``batch_size`` rather than by a slide's ROI count
+    (the loop holds at most one batch of grids resident — no per-slide accumulation).
 
     Injectable core: takes a constructed dense-capable ``model`` (with
     ``encode_tiles_dense`` / ``encode_tiles_attention`` / ``patch_size`` /
@@ -194,8 +218,12 @@ def iter_regions_dense(
             sliding is internal to extraction.
         overlap: fractional window overlap in ``[0, 1)`` for the sliding path (ignored when
             ``window_size is None``); the stride is ``window * (1 - overlap)``.
+        output_dtype: torch dtype the grids are materialized in. ``None`` (default) follows
+            the compute ``precision`` — fp16 → fp16, fp32 → fp32, bf16 → fp32 (numpy has no
+            bfloat16). Pass e.g. ``torch.float32`` to force a lossless cache regardless of
+            precision; an explicit ``torch.bfloat16`` is rejected (cannot cross ``.numpy()``).
 
-    Yields ``float32`` grids in coordinate order; empty ``coordinates`` yields nothing.
+    Yields grids in coordinate order in ``output_dtype``; empty ``coordinates`` yields nothing.
     ``feature_kind`` selects ``encode_tiles_dense`` (patch grid) vs
     ``encode_tiles_attention`` (CLS-attention grid); both produce a ``(C, gh, gw)`` grid and
     share this path. Each yielded grid is a standalone contiguous copy, so it does not pin
@@ -203,6 +231,7 @@ def iter_regions_dense(
     """
     if pad_mode not in _PAD_MODES:
         raise ValueError(f"unsupported pad_mode {pad_mode!r}; expected one of {sorted(_PAD_MODES)}")
+    resolved_output_dtype = _resolve_output_dtype(output_dtype, precision)
     geometry = compute_dense_geometry(target_size=target_size, patch_size=model.patch_size)
     if dense_transform is None:
         dense_transform = model.get_dense_transform()
@@ -262,7 +291,7 @@ def iter_regions_dense(
                     raise ValueError(
                         f"{feature_kind} encode returned a {out.ndim}-D tensor; expected (B, d, gh, gw)."
                     )
-                batch_np = out.detach().float().cpu().numpy()
+                batch_np = out.detach().to(resolved_output_dtype).cpu().numpy()
                 for i in range(batch_np.shape[0]):
                     # Standalone C-contiguous copy: a per-row view would pin the whole
                     # batch alive (the blended sliding output is contiguous, so a view of

--- a/tests/test_dense_regions.py
+++ b/tests/test_dense_regions.py
@@ -18,6 +18,7 @@ timm = pytest.importorskip("timm")
 
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
 from slide2vec.runtime.dense_regions import (  # noqa: E402
+    _resolve_output_dtype,
     compute_dense_geometry,
     iter_regions_dense,
     pad_image_to_encoded,
@@ -217,5 +218,47 @@ def test_iter_regions_dense_validates_eagerly_before_any_read(kwargs):
         iter_regions_dense(
             model=enc, device="cpu", wsi=wsi, coordinates=[(0, 0)],
             requested_spacing_um=0.5, target_size=target_size, **kwargs,
+        )
+    assert wsi.calls == []
+
+
+@pytest.mark.parametrize(
+    "precision,expected",
+    [("fp16", torch.float16), ("fp32", torch.float32), ("bf16", torch.float32)],
+    ids=["fp16->fp16", "fp32->fp32", "bf16->fp32(numpy-safe)"],
+)
+def test_resolve_output_dtype_defaults_follow_precision(precision, expected):
+    # output_dtype=None tracks the compute precision; bf16 widens to fp32 (numpy has no
+    # bfloat16). An explicit dtype overrides; an explicit bfloat16 is rejected.
+    assert _resolve_output_dtype(None, precision) is expected
+    assert _resolve_output_dtype(torch.float32, precision) is torch.float32
+    assert _resolve_output_dtype(torch.float16, precision) is torch.float16
+    with pytest.raises(ValueError):
+        _resolve_output_dtype(torch.bfloat16, precision)
+
+
+@pytest.mark.parametrize("dtype,np_dtype", [(torch.float16, np.float16), (torch.float32, np.float32)])
+def test_iter_regions_dense_honours_output_dtype(dtype, np_dtype):
+    """An explicit output_dtype materializes the grids in that dtype, deterministically."""
+    enc = _encoder()
+    target_size = 64
+    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    grids = list(iter_regions_dense(
+        model=enc, device="cpu", wsi=wsi, coordinates=[(0, 0)],
+        requested_spacing_um=0.5, target_size=target_size, output_dtype=dtype,
+    ))
+    assert len(grids) == 1
+    assert grids[0].dtype == np_dtype
+
+
+def test_iter_regions_dense_rejects_bfloat16_output_eagerly():
+    """output_dtype=bfloat16 (uncrossable by .numpy()) raises at the call site, no read."""
+    enc = _encoder()
+    target_size = 64
+    wsi = _FakeWSI(target_h=target_size, target_w=target_size)
+    with pytest.raises(ValueError):
+        iter_regions_dense(
+            model=enc, device="cpu", wsi=wsi, coordinates=[(0, 0)],
+            requested_spacing_um=0.5, target_size=target_size, output_dtype=torch.bfloat16,
         )
     assert wsi.calls == []


### PR DESCRIPTION
## Problem

`iter_regions_dense` unconditionally upcast every grid to float32 on output:

```python
batch_np = out.detach().float().cpu().numpy()   # always fp32
```

So an fp16 run (e.g. Virchow2) still produced **float32** grids — doubling the bytes a downstream caller has to cache and stream, for information the model never computed at fp32. Whether to keep full precision is the caller's call, not something the extraction engine should force.

## Change

Add an explicit `output_dtype` param to `iter_regions_dense`:

- **Default (`None`)** follows the compute `precision`: `fp16 → fp16`, `fp32 → fp32`. The engine emits what the model actually computed.
- **Explicit** dtype overrides — pass `torch.float32` to force a lossless cache regardless of precision.
- **bf16:** numpy has no bfloat16, so a `bf16` compute precision **widens to fp32** (its lossless container), and an *explicit* `torch.bfloat16` request is **rejected at the call site** (the grid is materialized via `.numpy()`, which bfloat16 can't cross).
- Resolution is **eager**, matching the existing `pad_mode` / `feature_kind` validation contract (raises on call, not on first `next()`).

The caller still owns the caching/storage-dtype decision; this just stops the engine from throwing away precision the caller may want to keep.

## Tests

`tests/test_dense_regions.py`: unit-cover the resolver (defaults follow precision; bf16→fp32; explicit override; explicit bfloat16 rejected), plus end-to-end that an explicit `output_dtype` materializes grids in that dtype and that `bfloat16` raises before any region is read. Existing `float32` default-precision assertion still holds. **22 passed.**

## Note

No version bump here — leaving the release cut to you (as with 5.1.0 / #200). soma will adopt this in a follow-up: store grids in fp16 to halve the dense cache + per-epoch I/O.