### PR TITLE
Expose output dtype (fp16/fp32) control in the pooled feature path

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -96,7 +96,7 @@ By default, ``slide2vec`` uses all available GPUs, a batch size of 32, and infer
 model's registered ``precision`` field.
 
 Pass :class:`~slide2vec.ExecutionOptions` to control GPU count, batch size,
-and precision:
+compute precision, and the on-disk feature dtype:
 
 .. code-block:: python
 
@@ -106,9 +106,16 @@ and precision:
    execution = ExecutionOptions(
        num_gpus=2,
        batch_size=32,
-       precision="fp16",   # "fp16", "bf16", "fp32", or None (auto)
+       precision="fp16",      # forward-pass dtype: "fp16", "bf16", "fp32", or None (auto)
+       output_dtype=None,     # saved feature dtype: "fp16", "fp32", or None (follow precision)
    )
    embedded = model.embed_slide("/path/to/slide.svs", execution=execution)
+
+``output_dtype`` controls the dtype the tile, slide, hierarchical, and patient features are
+written in. Left as ``None`` (the default), it follows ``precision`` — an ``fp16`` run stores
+``fp16`` features, while ``bf16``/``fp32`` store ``fp32`` — so you can force a compact ``fp16``
+cache or a lossless ``fp32`` one independently of the compute precision. The equivalent config
+key is ``speed.output_dtype``.
 
 See :doc:`api` for the full field reference.
 

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -110,6 +110,9 @@ Embedding Meta Files
 
 Each ``.pt`` embedding file has a companion ``.meta.json`` with provenance
 and shape information. The exact fields depend on the artifact type.
+``feature_dtype`` records the dtype the features were written in (``"fp16"`` or
+``"fp32"``), as resolved from ``ExecutionOptions.output_dtype`` / ``speed.output_dtype``
+(see :ref:`execution-options`).
 
 **tile_embeddings**
 
@@ -124,6 +127,7 @@ and shape information. The exact fields depend on the artifact type.
       "encoder_level": "tile",
       "encoder_name": "prost40m",
       "feature_dim": 384,
+      "feature_dtype": "fp16",
       "format": "pt",
       "image_path": "/data/slide-1.tif",
       "mask_path": "/data/mask-1.tif",

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -21,7 +21,11 @@ from slide2vec.encoders.registry import (
     resolve_preprocessing_defaults,
 )
 from slide2vec.encoders.validation import validate_encoder_config
-from slide2vec.runtime.model_settings import canonicalize_model_name, normalize_precision_name
+from slide2vec.runtime.model_settings import (
+    canonicalize_model_name,
+    normalize_output_dtype,
+    normalize_precision_name,
+)
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.types import LoadedModel
 from slide2vec.utils.utils import cpu_worker_limit, slurm_cpu_limit
@@ -226,6 +230,10 @@ class ExecutionOptions:
     #: Forward-pass dtype — ``"fp16"``, ``"bf16"``, ``"fp32"``,
     #: or ``None`` (auto-determined from the model preset).
     precision: str | None = None
+    #: On-disk feature dtype — ``"fp16"``, ``"fp32"``, or ``None`` to follow
+    #: :attr:`precision` (fp16 → fp16, else fp32). Applies to tile, slide, hierarchical,
+    #: and patient artifacts; ``"bf16"`` is rejected (numpy has no bfloat16).
+    output_dtype: str | None = None
     #: DataLoader prefetch queue depth per worker (default ``4``).
     prefetch_factor: int = 4
     #: Persist tile embeddings to disk when running a slide-level model.
@@ -253,6 +261,7 @@ class ExecutionOptions:
             ),
             num_gpus=1 if run_on_cpu else (int(configured_num_gpus) if configured_num_gpus is not None else None),
             precision="fp32" if run_on_cpu else requested_precision,
+            output_dtype=getattr(cfg.speed, "output_dtype", None),
             prefetch_factor=prefetch_factor,
             save_tile_embeddings=bool(cfg.model.save_tile_embeddings),
             save_slide_embeddings=bool(cfg.model.save_slide_embeddings),
@@ -263,6 +272,7 @@ class ExecutionOptions:
         resolved_num_gpus = _default_num_gpus() if self.num_gpus is None else self.num_gpus
         object.__setattr__(self, "num_gpus", resolved_num_gpus)
         object.__setattr__(self, "precision", normalize_precision_name(self.precision))
+        object.__setattr__(self, "output_dtype", normalize_output_dtype(self.output_dtype))
         if resolved_num_gpus < 1:
             raise ValueError("ExecutionOptions.num_gpus must be at least 1")
         if self.prefetch_factor < 1:

--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -7,6 +7,8 @@ import numpy as np
 import torch
 from hs2p.fileops import is_flattened_annotation
 
+from slide2vec.runtime.model_settings import output_torch_dtype
+
 
 @dataclass(frozen=True, kw_only=True)
 class TileEmbeddingArtifact:
@@ -74,7 +76,6 @@ def _validate_output_format(output_format: str) -> str:
     return normalized
 
 
-_OUTPUT_TORCH_DTYPE = {"fp16": torch.float16, "fp32": torch.float32}
 _OUTPUT_NUMPY_DTYPE = {"fp16": np.float16, "fp32": np.float32}
 
 
@@ -89,10 +90,9 @@ def cast_feature_dtype(data: Any, precision: str) -> Any:
     """
     if data is None:
         return data
-    if precision not in _OUTPUT_TORCH_DTYPE:
-        raise ValueError(f"Unsupported output precision {precision!r}; expected 'fp16' or 'fp32'.")
+    torch_dtype = output_torch_dtype(precision)  # validates precision (shared string→dtype map)
     if torch.is_tensor(data):
-        return data.to(_OUTPUT_TORCH_DTYPE[precision])
+        return data.to(torch_dtype)
     return np.asarray(data).astype(_OUTPUT_NUMPY_DTYPE[precision], copy=False)
 
 

--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -74,6 +74,28 @@ def _validate_output_format(output_format: str) -> str:
     return normalized
 
 
+_OUTPUT_TORCH_DTYPE = {"fp16": torch.float16, "fp32": torch.float32}
+_OUTPUT_NUMPY_DTYPE = {"fp16": np.float16, "fp32": np.float32}
+
+
+def cast_feature_dtype(data: Any, precision: str) -> Any:
+    """Cast features to the on-disk ``precision`` (``"fp16"`` / ``"fp32"``), keeping their kind.
+
+    Torch tensors are cast via ``.to`` and arrays via ``astype``; ``None`` (no features)
+    passes through. This is what makes the pooled tile/slide/hierarchical/patient artifacts
+    land in a deterministic dtype, mirroring the dense path's ``output_dtype``. The precision
+    is resolved upstream by :func:`slide2vec.runtime.model_settings.resolve_output_precision`,
+    so only ``"fp16"`` / ``"fp32"`` reach here.
+    """
+    if data is None:
+        return data
+    if precision not in _OUTPUT_TORCH_DTYPE:
+        raise ValueError(f"Unsupported output precision {precision!r}; expected 'fp16' or 'fp32'.")
+    if torch.is_tensor(data):
+        return data.to(_OUTPUT_TORCH_DTYPE[precision])
+    return np.asarray(data).astype(_OUTPUT_NUMPY_DTYPE[precision], copy=False)
+
+
 def _ensure_array(data: Any) -> np.ndarray:
     if isinstance(data, np.ndarray):
         return data

--- a/slide2vec/configs/default.yaml
+++ b/slide2vec/configs/default.yaml
@@ -88,6 +88,7 @@ tiling:
 
 speed:
   precision: # model inference precision ["fp32", "fp16", "bf16"]; if not set, determined automatically based on model recommendations
+  output_dtype: # on-disk feature dtype ["fp16", "fp32"]; if not set, follows speed.precision (fp16 -> fp16, otherwise fp32)
   num_dataloader_workers: # number of DataLoader worker processes per GPU rank for reading tiles during embedding; defaults to auto (job CPU budget split across GPUs, except cuCIM on-the-fly uses per-GPU budget // speed.num_cucim_workers)
   num_gpus: # number of GPUs to use for feature extraction; defaults to all available GPUs
   num_preprocessing_workers: # number of workers for hs2p tiling (WSI reading, JPEG encoding, tar writing); defaults to the runtime CPU budget capped at 64

--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -39,9 +39,11 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 
-from slide2vec.runtime.batching import autocast_dtype
 from slide2vec.runtime.dense_sliding import encode_dense_sliding
+from slide2vec.runtime.model_settings import resolve_output_precision
 from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
+
+_OUTPUT_TORCH_DTYPE = {"fp16": torch.float16, "fp32": torch.float32}
 
 
 def _resolve_output_dtype(output_dtype: "torch.dtype | None", precision: str) -> "torch.dtype":
@@ -54,8 +56,8 @@ def _resolve_output_dtype(output_dtype: "torch.dtype | None", precision: str) ->
     materialized via ``.numpy()`` and bfloat16 cannot cross that boundary.
     """
     if output_dtype is None:
-        compute = autocast_dtype(torch, precision)  # float16 | bfloat16 | None(fp32)
-        return torch.float16 if compute == torch.float16 else torch.float32
+        # Shared rule with the pooled write path: fp16 compute -> fp16, else fp32.
+        return _OUTPUT_TORCH_DTYPE[resolve_output_precision(None, precision)]
     if output_dtype == torch.bfloat16:
         raise ValueError(
             "output_dtype=torch.bfloat16 cannot be materialized as a numpy grid; "

--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -40,10 +40,8 @@ import torch.nn.functional as F
 from PIL import Image
 
 from slide2vec.runtime.dense_sliding import encode_dense_sliding
-from slide2vec.runtime.model_settings import resolve_output_precision
+from slide2vec.runtime.model_settings import output_torch_dtype, resolve_output_precision
 from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
-
-_OUTPUT_TORCH_DTYPE = {"fp16": torch.float16, "fp32": torch.float32}
 
 
 def _resolve_output_dtype(output_dtype: "torch.dtype | None", precision: str) -> "torch.dtype":
@@ -57,7 +55,7 @@ def _resolve_output_dtype(output_dtype: "torch.dtype | None", precision: str) ->
     """
     if output_dtype is None:
         # Shared rule with the pooled write path: fp16 compute -> fp16, else fp32.
-        return _OUTPUT_TORCH_DTYPE[resolve_output_precision(None, precision)]
+        return output_torch_dtype(resolve_output_precision(None, precision))
     if output_dtype == torch.bfloat16:
         raise ValueError(
             "output_dtype=torch.bfloat16 cannot be materialized as a numpy grid; "

--- a/slide2vec/runtime/embedding.py
+++ b/slide2vec/runtime/embedding.py
@@ -10,11 +10,13 @@ from slide2vec.artifacts import (
     HierarchicalEmbeddingArtifact,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
+    cast_feature_dtype,
     write_hierarchical_embeddings,
     write_slide_embeddings,
     write_tile_embeddings,
 )
 from slide2vec.runtime.hierarchical import resolve_hierarchical_geometry
+from slide2vec.runtime.model_settings import resolve_output_precision
 
 
 def tiling_result_annotation(tiling_result) -> str | None:
@@ -114,12 +116,14 @@ def write_tile_embedding_artifact(
 ) -> TileEmbeddingArtifact:
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required to persist tile embeddings")
+    precision = resolve_output_precision(execution.output_dtype, execution.precision)
+    features = cast_feature_dtype(features, precision)
     return write_tile_embeddings(
         sample_id,
         features,
         output_dir=execution.output_dir,
         output_format=execution.output_format,
-        metadata=metadata,
+        metadata={**metadata, "feature_dtype": precision},
         tile_index=np.arange(_num_rows(features), dtype=np.int64),
         annotation=annotation,
     )
@@ -142,13 +146,14 @@ def write_slide_embedding_artifact(
 ) -> SlideEmbeddingArtifact:
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required to persist slide embeddings")
+    precision = resolve_output_precision(execution.output_dtype, execution.precision)
     return write_slide_embeddings(
         sample_id,
-        embedding,
+        cast_feature_dtype(embedding, precision),
         output_dir=execution.output_dir,
         output_format=execution.output_format,
-        metadata=metadata,
-        latents=latents,
+        metadata={**metadata, "feature_dtype": precision},
+        latents=cast_feature_dtype(latents, precision),
         annotation=annotation,
     )
 
@@ -163,11 +168,12 @@ def write_hierarchical_embedding_artifact(
 ) -> HierarchicalEmbeddingArtifact:
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required to persist hierarchical embeddings")
+    precision = resolve_output_precision(execution.output_dtype, execution.precision)
     return write_hierarchical_embeddings(
         sample_id,
-        features,
+        cast_feature_dtype(features, precision),
         output_dir=execution.output_dir,
         output_format=execution.output_format,
-        metadata=metadata,
+        metadata={**metadata, "feature_dtype": precision},
         annotation=annotation,
     )

--- a/slide2vec/runtime/model_settings.py
+++ b/slide2vec/runtime/model_settings.py
@@ -74,6 +74,23 @@ def resolve_output_precision(output_dtype: Any, compute_precision: Any) -> str:
     return "fp16" if normalize_precision_name(compute_precision) == "fp16" else "fp32"
 
 
+def output_torch_dtype(precision: str):
+    """The torch dtype an on-disk feature artifact materializes in for ``precision``.
+
+    ``precision`` is a value returned by :func:`resolve_output_precision` (``"fp16"`` or
+    ``"fp32"``); anything else is a programming error. This is the single string→dtype
+    mapping shared by the pooled write path (:func:`slide2vec.artifacts.cast_feature_dtype`)
+    and the dense ``iter_regions_dense`` path, so both agree on the materialized dtype.
+    torch is imported lazily to keep this module importable without it.
+    """
+    import torch
+
+    mapping = {"fp16": torch.float16, "fp32": torch.float32}
+    if precision not in mapping:
+        raise ValueError(f"Unsupported output precision {precision!r}; expected 'fp16' or 'fp32'.")
+    return mapping[precision]
+
+
 def canonicalize_model_name(name: str) -> str:
     normalized = name.strip().lower()
     return MODEL_NAME_ALIASES.get(normalized, normalized)

--- a/slide2vec/runtime/model_settings.py
+++ b/slide2vec/runtime/model_settings.py
@@ -42,6 +42,38 @@ def normalize_precision_name(value: Any) -> str | None:
     return PRECISION_ALIASES[normalized]
 
 
+def normalize_output_dtype(value: Any) -> str | None:
+    """Normalize a requested on-disk feature dtype to ``"fp16"`` / ``"fp32"`` (or ``None``).
+
+    ``None`` means *follow the compute precision* (see :func:`resolve_output_precision`).
+    ``bf16`` is rejected: tile/slide/hierarchical/patient artifacts serialize through numpy,
+    which has no bfloat16 — the same boundary the dense path guards.
+    """
+    normalized = normalize_precision_name(value)
+    if normalized == "bf16":
+        raise ValueError(
+            "Unsupported output dtype 'bf16'. Feature artifacts serialize through numpy "
+            "(no bfloat16); choose 'fp16' or 'fp32', or leave unset to follow precision."
+        )
+    return normalized
+
+
+def resolve_output_precision(output_dtype: Any, compute_precision: Any) -> str:
+    """Resolve the concrete on-disk feature precision (``"fp16"`` or ``"fp32"``).
+
+    ``output_dtype is None`` follows ``compute_precision``: an fp16 forward keeps fp16
+    features, while bf16 / fp32 (and an unset or unknown compute precision) widen to fp32 —
+    fp32 is bf16's lossless container and the only float dtype a numpy artifact can hold.
+    A non-null ``output_dtype`` is honored verbatim (after :func:`normalize_output_dtype`).
+    This is the single source of truth shared by the pooled write path and the dense
+    ``iter_regions_dense`` path.
+    """
+    normalized = normalize_output_dtype(output_dtype)
+    if normalized is not None:
+        return normalized
+    return "fp16" if normalize_precision_name(compute_precision) == "fp16" else "fp32"
+
+
 def canonicalize_model_name(name: str) -> str:
     normalized = name.strip().lower()
     return MODEL_NAME_ALIASES.get(normalized, normalized)

--- a/slide2vec/runtime/patient_pipeline.py
+++ b/slide2vec/runtime/patient_pipeline.py
@@ -11,6 +11,7 @@ from slide2vec.artifacts import (
     PatientEmbeddingArtifact,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
+    cast_feature_dtype,
     write_patient_embeddings,
 )
 from slide2vec.progress import emit_progress
@@ -22,6 +23,7 @@ from slide2vec.runtime.embedding import (
 )
 from slide2vec.runtime.embedding_pipeline import compute_tile_embeddings_for_slide
 from slide2vec.runtime.hierarchical import num_embedding_items
+from slide2vec.runtime.model_settings import resolve_output_precision
 from slide2vec.runtime.slide_encode import encode_slide_from_tiles
 from slide2vec.runtime.tiling import resolve_slide_backend
 
@@ -117,12 +119,17 @@ def run_patient_pipeline(
         stacked = torch.stack(slide_embs, dim=0).to(loaded.device)
         with torch.inference_mode():
             patient_emb = loaded.model.encode_patient(stacked).detach().cpu()
+        precision = resolve_output_precision(execution.output_dtype, execution.precision)
         artifact = write_patient_embeddings(
             patient_id,
-            patient_emb,
+            cast_feature_dtype(patient_emb, precision),
             output_dir=output_dir,
             output_format=execution.output_format,
-            metadata={"encoder_name": model.name, "encoder_level": model.level},
+            metadata={
+                "encoder_name": model.name,
+                "encoder_level": model.level,
+                "feature_dtype": precision,
+            },
             num_slides=patient_slide_counts[patient_id],
         )
         patient_artifacts.append(artifact)

--- a/slide2vec/runtime/serialization.py
+++ b/slide2vec/runtime/serialization.py
@@ -52,6 +52,7 @@ def serialize_execution(
         "num_preprocessing_workers": execution.num_preprocessing_workers,
         "num_gpus": execution.num_gpus,
         "precision": execution.precision,
+        "output_dtype": execution.output_dtype,
         "prefetch_factor": execution.prefetch_factor,
         "save_tile_embeddings": execution.save_tile_embeddings,
         "save_slide_embeddings": execution.save_slide_embeddings,
@@ -104,6 +105,7 @@ def deserialize_execution(payload: dict[str, Any]) -> ExecutionOptions:
     num_preprocessing_workers = payload.get("num_preprocessing_workers")
     num_gpus = payload.get("num_gpus", 1)
     precision = payload.get("precision", "fp32")
+    output_dtype = payload.get("output_dtype")
     prefetch_factor = payload.get("prefetch_factor", 4)
     save_tile_embeddings = bool(payload.get("save_tile_embeddings", False))
     save_slide_embeddings = bool(payload.get("save_slide_embeddings", False))
@@ -118,6 +120,7 @@ def deserialize_execution(payload: dict[str, Any]) -> ExecutionOptions:
         ),
         num_gpus=int(num_gpus),
         precision=precision,
+        output_dtype=output_dtype,
         prefetch_factor=int(prefetch_factor),
         save_tile_embeddings=save_tile_embeddings,
         save_slide_embeddings=save_slide_embeddings,

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -290,6 +290,170 @@ def test_hierarchical_npz_artifacts_round_trip(tmp_path: Path):
     assert metadata["requested_region_size_px"] == 672
 
 
+# --- output dtype control (pooled feature path) -------------------------------------
+
+
+def test_resolve_output_precision_follows_compute_precision_by_default():
+    from slide2vec.runtime.model_settings import resolve_output_precision
+
+    # output_dtype=None tracks compute precision; bf16/fp32/unknown widen to fp32.
+    assert resolve_output_precision(None, "fp16") == "fp16"
+    assert resolve_output_precision(None, "bf16") == "fp32"
+    assert resolve_output_precision(None, "fp32") == "fp32"
+    assert resolve_output_precision(None, None) == "fp32"
+    # An explicit request overrides the compute precision either way.
+    assert resolve_output_precision("fp32", "fp16") == "fp32"
+    assert resolve_output_precision("float16", "fp32") == "fp16"
+
+
+def test_normalize_output_dtype_rejects_bf16_and_normalizes_aliases():
+    from slide2vec.runtime.model_settings import normalize_output_dtype
+
+    assert normalize_output_dtype(None) is None
+    assert normalize_output_dtype("float16") == "fp16"
+    assert normalize_output_dtype("fp32") == "fp32"
+    with pytest.raises(ValueError, match="bf16"):
+        normalize_output_dtype("bf16")
+
+
+def test_execution_options_normalizes_output_dtype():
+    assert ExecutionOptions().output_dtype is None
+    assert ExecutionOptions(output_dtype="float16").output_dtype == "fp16"
+    with pytest.raises(ValueError, match="bf16"):
+        ExecutionOptions(output_dtype="bf16")
+
+
+def test_execution_options_from_config_maps_output_dtype(tmp_path: Path):
+    cfg = SimpleNamespace(
+        output_dir=str(tmp_path),
+        model=SimpleNamespace(
+            batch_size=4,
+            save_tile_embeddings=False,
+            save_slide_embeddings=False,
+            save_latents=False,
+        ),
+        speed=SimpleNamespace(
+            precision="fp16",
+            output_dtype="fp32",
+            num_dataloader_workers=2,
+            num_preprocessing_workers=8,
+            num_gpus=1,
+            prefetch_factor_embedding=4,
+        ),
+    )
+
+    execution = ExecutionOptions.from_config(cfg)
+
+    assert execution.precision == "fp16"
+    assert execution.output_dtype == "fp32"
+
+
+def test_execution_options_from_config_defaults_output_dtype_to_none_when_absent(tmp_path: Path):
+    # Configs predating speed.output_dtype must still parse (attribute absent entirely).
+    cfg = SimpleNamespace(
+        output_dir=str(tmp_path),
+        model=SimpleNamespace(
+            batch_size=4,
+            save_tile_embeddings=False,
+            save_slide_embeddings=False,
+            save_latents=False,
+        ),
+        speed=SimpleNamespace(
+            precision="fp16",
+            num_dataloader_workers=2,
+            num_preprocessing_workers=8,
+            num_gpus=1,
+            prefetch_factor_embedding=4,
+        ),
+    )
+
+    assert ExecutionOptions.from_config(cfg).output_dtype is None
+
+
+@pytest.mark.parametrize(
+    "precision, output_dtype, expected",
+    [
+        ("fp16", None, "float16"),  # default follows compute precision
+        ("bf16", None, "float32"),  # bf16 compute widens to fp32 on disk
+        ("fp32", None, "float32"),
+        (None, None, "float32"),
+        ("fp16", "fp32", "float32"),  # explicit override wins over precision
+        ("fp32", "fp16", "float16"),
+    ],
+)
+def test_tile_artifact_output_dtype(tmp_path: Path, precision, output_dtype, expected):
+    torch = pytest.importorskip("torch")
+    from slide2vec.runtime.embedding import write_tile_embedding_artifact
+
+    execution = ExecutionOptions(
+        output_dir=tmp_path, output_format="pt", precision=precision, output_dtype=output_dtype
+    )
+    features = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    artifact = write_tile_embedding_artifact(
+        "sample-d", features, execution=execution, metadata={"k": "v"}
+    )
+
+    loaded = load_array(artifact.path)
+    metadata = load_metadata(artifact.metadata_path)
+    assert str(loaded.dtype) == f"torch.{expected}"
+    assert metadata["feature_dtype"] == ("fp16" if expected == "float16" else "fp32")
+
+
+def test_slide_and_hierarchical_artifact_output_dtype(tmp_path: Path):
+    torch = pytest.importorskip("torch")
+    from slide2vec.runtime.embedding import (
+        write_hierarchical_embedding_artifact,
+        write_slide_embedding_artifact,
+    )
+
+    execution = ExecutionOptions(
+        output_dir=tmp_path, output_format="pt", precision="fp32", output_dtype="fp16"
+    )
+    embedding = torch.ones(8, dtype=torch.float32)
+    latents = torch.ones(2, 8, dtype=torch.float32)
+    slide_artifact = write_slide_embedding_artifact(
+        "sample-e", embedding, execution=execution, metadata={"image_path": "x"}, latents=latents
+    )
+    assert str(load_array(slide_artifact.path).dtype) == "torch.float16"
+    assert slide_artifact.latent_path is not None
+    assert str(load_array(slide_artifact.latent_path).dtype) == "torch.float16"
+
+    hierarchical_artifact = write_hierarchical_embedding_artifact(
+        "sample-f",
+        torch.ones(2, 3, 4, dtype=torch.float32),
+        execution=execution,
+        metadata={"tiles_per_region": 3},
+    )
+    assert str(load_array(hierarchical_artifact.path).dtype) == "torch.float16"
+    assert load_metadata(hierarchical_artifact.metadata_path)["feature_dtype"] == "fp16"
+
+
+def test_npz_tile_artifact_honours_output_dtype(tmp_path: Path):
+    torch = pytest.importorskip("torch")
+    from slide2vec.runtime.embedding import write_tile_embedding_artifact
+
+    execution = ExecutionOptions(
+        output_dir=tmp_path, output_format="npz", precision="fp32", output_dtype="fp16"
+    )
+    features = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    artifact = write_tile_embedding_artifact("sample-g", features, execution=execution, metadata={})
+
+    assert load_array(artifact.path).dtype == np.float16
+
+
+def test_execution_options_output_dtype_round_trips_through_serialization():
+    from slide2vec.runtime.serialization import deserialize_execution, serialize_execution
+
+    execution = ExecutionOptions(precision="fp16", output_dtype="fp32")
+    payload = serialize_execution(execution)
+    assert payload["output_dtype"] == "fp32"
+    assert deserialize_execution(payload).output_dtype == "fp32"
+
+    # Legacy payloads without the key deserialize to None (follow precision).
+    legacy = {k: v for k, v in payload.items() if k != "output_dtype"}
+    assert deserialize_execution(legacy).output_dtype is None
+
+
 def test_resolve_direct_api_preprocessing_derives_requested_region_size_from_multiple():
     import slide2vec.api as api
 


### PR DESCRIPTION
## Summary

Brings the **pooled feature path** to parity with the dense path on output-dtype control.

`iter_regions_dense(output_dtype=...)` already lets callers pick the on-disk feature dtype (defaulting from the compute precision). The pooled path (tile / slide / hierarchical / patient) had no equivalent — it only exposed the compute-precision autocast knob and saved whatever dtype the model emitted, with **no cast at write time**. Because `torch.autocast` does not guarantee the final tensor dtype, `precision="fp16"` did not reliably produce fp16 features on disk.

## What changed

- **New knob:** `ExecutionOptions.output_dtype` (`"fp16"` / `"fp32"` / `None`) and the matching `speed.output_dtype` config key.
  - `None` (default) follows `precision`: fp16 → fp16, bf16/fp32 → fp32 — identical to the dense default.
  - An explicit value overrides the compute precision either way.
  - `bf16` is rejected (feature artifacts serialize through numpy, which has no bfloat16) — same boundary the dense path guards.
- **Single source of truth:** the resolution rule now lives in `model_settings.resolve_output_precision`, shared by both paths. Dense's `_resolve_output_dtype` delegates to it (behavior unchanged).
- **Deterministic cast at the write chokepoint:** the three artifact writers in `runtime/embedding.py` (tile/slide/hierarchical, incl. slide latents) and the patient writer cast features via `artifacts.cast_feature_dtype` before serialization. The resolved dtype is recorded as `feature_dtype` in the artifact `.meta.json`.
- **Distributed parity:** `output_dtype` round-trips through the execution-request serialization; legacy payloads without the key deserialize to `None` (follow precision).
- **Docs:** `getting-started` (ExecutionOptions example + note) and `output-layout` (`feature_dtype` metadata field).

## Testing

- New tests in `tests/test_regression_core.py`: resolver semantics, `ExecutionOptions`/`from_config` normalization (incl. bf16 rejection and configs predating the key), per-path on-disk dtype across `pt`/`npz` (default-follows-precision + explicit override), and serialization round-trip.
- Full `test_regression_core`, `test_dense_regions`, `test_regression_inference`, `test_output_consistency`, `test_runtime_batching`, `test_architecture_runtime_split`, `test_dense_extraction`, `test_attention_extraction` pass locally.

Closes #205
