### PR TITLE
Add a natural-image DINOv2 ViT-B/14 control tile encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The package writes explicit artifact directories:
 
 ### Supported Models
 
-`slide2vec` currently ships preset configs for 20 tile-level models and 3 slide-level models.  
+`slide2vec` currently ships preset configs for 22 tile-level models and 3 slide-level models.  
 For the full catalog and preset names, see [`docs/models.md`](docs/models.md).
 
 ## CLI

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -51,8 +51,8 @@ Tile-level encoders
    * - ``dinov2-vitb14``
      - `DINOv2 ViT-B/14 <https://huggingface.co/timm/vit_base_patch14_dinov2.lvd142m>`_
      - 768
-     - ``0.5``
-     - Oquab et al. (2024); natural-image (non-pathology) control, public weights
+     - any (``0.5`` default)
+     - Oquab et al. (2024); natural-image (non-pathology) control, public weights; spacing-agnostic
    * - ``hibou-b``
      - `Hibou-B <https://huggingface.co/histai/hibou-b>`_
      - 768

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -48,6 +48,11 @@ Tile-level encoders
      - 768
      - ``0.5``
      - Lu et al. (2024)
+   * - ``dinov2-vitb14``
+     - `DINOv2 ViT-B/14 <https://huggingface.co/timm/vit_base_patch14_dinov2.lvd142m>`_
+     - 768
+     - ``0.5``
+     - Oquab et al. (2024); natural-image (non-pathology) control, public weights
    * - ``hibou-b``
      - `Hibou-B <https://huggingface.co/histai/hibou-b>`_
      - 768
@@ -137,10 +142,10 @@ Dense tile feature extraction is available on tile encoders that implement
 instead of the pooled ``(B, D)`` tensor returned by ``encode_tiles``.
 
 The following built-in tile presets are covered by the dense encoder interface:
-``conch``, ``conchv15``, ``genbio-pathfm``, ``gigapath``, ``gpfm``, ``h0-mini``,
-``h-optimus-0``, ``h-optimus-1``, ``hibou-b``, ``hibou-l``, ``lunit``,
-``midnight``, ``mstar``, ``musk``, ``phikon``, ``phikonv2``, ``prost40m``,
-``uni``, ``uni2``, ``virchow``, and ``virchow2``.
+``conch``, ``conchv15``, ``dinov2-vitb14``, ``genbio-pathfm``, ``gigapath``,
+``gpfm``, ``h0-mini``, ``h-optimus-0``, ``h-optimus-1``, ``hibou-b``,
+``hibou-l``, ``lunit``, ``midnight``, ``mstar``, ``musk``, ``phikon``,
+``phikonv2``, ``prost40m``, ``uni``, ``uni2``, ``virchow``, and ``virchow2``.
 
 Notes:
 
@@ -171,9 +176,10 @@ prefix-token self-attention as a spatial grid ``(B, K, h, w)`` — see the
 contract and knobs.
 
 The following built-in tile presets are covered: ``conch``, ``conchv15``,
-``gigapath``, ``gpfm``, ``h0-mini``, ``h-optimus-0``, ``h-optimus-1``,
-``hibou-b``, ``hibou-l``, ``lunit``, ``midnight``, ``mstar``, ``phikon``,
-``phikonv2``, ``prost40m``, ``uni``, ``uni2``, ``virchow``, and ``virchow2``.
+``dinov2-vitb14``, ``gigapath``, ``gpfm``, ``h0-mini``, ``h-optimus-0``,
+``h-optimus-1``, ``hibou-b``, ``hibou-l``, ``lunit``, ``midnight``, ``mstar``,
+``phikon``, ``phikonv2``, ``prost40m``, ``uni``, ``uni2``, ``virchow``, and
+``virchow2``.
 
 Notes:
 

--- a/slide2vec/encoders/models/__init__.py
+++ b/slide2vec/encoders/models/__init__.py
@@ -5,6 +5,7 @@ Importing this package registers all encoders in the encoder_registry.
 
 from . import (
     conch,
+    dinov2,
     genbio,
     gigapath,
     gpfm,
@@ -25,6 +26,7 @@ from . import (
 
 __all__ = [
     "conch",
+    "dinov2",
     "genbio",
     "gigapath",
     "gpfm",

--- a/slide2vec/encoders/models/dinov2.py
+++ b/slide2vec/encoders/models/dinov2.py
@@ -21,11 +21,15 @@ run at the 224px detection tile geometry via positional-embedding interpolation,
 a no-op at the native size (verified in the shared dense-extraction suite).
 
 Spacing note: a natural-image model has **no** intrinsic micron-per-pixel
-spacing. ``supported_spacing_um=0.5`` is a *convention*, not a physical property:
-0.5 µm/px is the default task-spacing the pathology tile encoders declare, so
-selecting this encoder by name lands on identical tile geometry and it drops in
-as a matched control. To sweep other task-spacings, pass
-``allow_non_recommended_settings=True`` (the encoder is spacing-agnostic).
+spacing, so it declares ``supported_spacing_um=None`` — it is *spacing-agnostic*
+and :func:`validate_encoder_config` never rejects a requested spacing for it
+(unlike the pathology encoders, which are validated at a specific spacing). It
+still needs *a* spacing to tile a slide, so ``default_spacing_um=0.5`` sets the
+tiling default: 0.5 µm/px is the task-spacing the pathology tile encoders
+declare, so selecting this encoder by name lands on identical tile geometry and
+it drops in as a matched control. Because it is agnostic, sweeping other
+task-spacings (e.g. 0.25) needs no ``allow_non_recommended_settings`` escape
+hatch — any requested spacing is accepted as-is.
 """
 
 from slide2vec.encoders.base import TimmTileEncoder
@@ -38,7 +42,8 @@ from slide2vec.encoders.registry import register_encoder
     default_output_variant="default",
     input_size=224,
     patch_size=14,
-    supported_spacing_um=0.5,  # convention: match the pathology encoders' default task-spacing
+    supported_spacing_um=None,  # spacing-agnostic: no intrinsic µm/px, so no validation constraint
+    default_spacing_um=0.5,  # tiling default: match the pathology encoders' task-spacing
     precision="fp16",
     source="timm/vit_base_patch14_dinov2.lvd142m",
 )

--- a/slide2vec/encoders/models/dinov2.py
+++ b/slide2vec/encoders/models/dinov2.py
@@ -1,0 +1,51 @@
+"""Natural-image DINOv2 ViT-B/14 control encoder.
+
+``dinov2-vitb14`` is a **non-pathology** ViT: the original DINOv2 ViT-B/14
+(Oquab et al., 2024) self-supervised on LVD-142M *natural* images, shipped by
+``timm`` as ``vit_base_patch14_dinov2.lvd142m`` (weights hosted on Hugging Face
+under ``timm/vit_base_patch14_dinov2.lvd142m`` — public, no gated access).
+
+It exists as a **control**: nearly every pathology tile encoder here (UNI,
+Virchow, GigaPath, H-optimus, Midnight, …) is a DINOv2-family ViT, so pairing
+them with a DINOv2 ViT trained on natural images holds the architecture and the
+self-supervised objective fixed and varies only the *pretraining domain*. That
+isolates the question "does pathology-pretraining actually pay off?" for a
+downstream task (e.g. cell detection).
+
+Structurally it is a plain :class:`TimmTileEncoder` (mirroring ``lunit`` /
+``prost40m`` / ``uni``): the dense (``encode_tiles_dense``) and attention
+(``encode_tiles_attention``) paths are inherited unchanged from the timm ViT
+base, so the control is dense-extraction- and attention-capable exactly like the
+pathology encoders. ``dynamic_img_size=True`` lets the (natively 518px) backbone
+run at the 224px detection tile geometry via positional-embedding interpolation,
+a no-op at the native size (verified in the shared dense-extraction suite).
+
+Spacing note: a natural-image model has **no** intrinsic micron-per-pixel
+spacing. ``supported_spacing_um=0.5`` is a *convention*, not a physical property:
+0.5 µm/px is the default task-spacing the pathology tile encoders declare, so
+selecting this encoder by name lands on identical tile geometry and it drops in
+as a matched control. To sweep other task-spacings, pass
+``allow_non_recommended_settings=True`` (the encoder is spacing-agnostic).
+"""
+
+from slide2vec.encoders.base import TimmTileEncoder
+from slide2vec.encoders.registry import register_encoder
+
+
+@register_encoder(
+    "dinov2-vitb14",
+    output_variants={"default": {"encode_dim": 768}},
+    default_output_variant="default",
+    input_size=224,
+    patch_size=14,
+    supported_spacing_um=0.5,  # convention: match the pathology encoders' default task-spacing
+    precision="fp16",
+    source="timm/vit_base_patch14_dinov2.lvd142m",
+)
+class DINOv2ViTB14(TimmTileEncoder):
+    def __init__(self, *, output_variant: str | None = None):
+        super().__init__(
+            "vit_base_patch14_dinov2.lvd142m",
+            output_variant=output_variant,
+            dynamic_img_size=True,  # enable dense extraction; no-op at native size
+        )

--- a/slide2vec/encoders/registry.py
+++ b/slide2vec/encoders/registry.py
@@ -41,7 +41,8 @@ def register_encoder(
     level: str = "tile",
     tile_encoder: str | None = None,
     tile_encoder_output_variant: str | None = None,
-    supported_spacing_um: float | list[float],
+    supported_spacing_um: float | list[float] | None,
+    default_spacing_um: float | None = None,
     precision: str = "fp16",
     source: str = "",
 ):
@@ -61,7 +62,22 @@ def register_encoder(
         level: Encoder output level ("tile" or "slide").
         tile_encoder: Registered tile encoder dependency for slide-level models.
         tile_encoder_output_variant: Fixed tile-encoder output variant for slide models.
-        supported_spacing_um: Supported spacing(s) in µm/px.
+        supported_spacing_um: The spacing(s) in µm/px the model was trained/validated
+            for; :func:`validate_encoder_config` rejects requests outside this set
+            unless ``allow_non_recommended_settings=True``. ``None`` marks a
+            *spacing-agnostic* encoder (e.g. a natural-image control): the spacing
+            check is skipped entirely because no spacing is more "correct" than
+            another. Agnostic encoders MUST pair this with an explicit
+            ``default_spacing_um`` so name-only selection still resolves a tiling
+            spacing.
+        default_spacing_um: The single spacing in µm/px used to tile a slide when the
+            caller selects this encoder by name without passing an explicit
+            ``requested_spacing_um``. Optional: when omitted it is derived from
+            ``supported_spacing_um`` if that is a single value. Encoders that
+            support a *list* of spacings, or are spacing-agnostic
+            (``supported_spacing_um=None``), have no derivable default and must
+            declare one here to be selectable with zero config (otherwise
+            :func:`resolve_preprocessing_defaults` requires an explicit spacing).
         precision: Recommended inference precision ("fp16" or "fp32").
         source: Model source identifier (e.g. HuggingFace hub path).
     """
@@ -78,6 +94,7 @@ def register_encoder(
         "tile_encoder": tile_encoder,
         "tile_encoder_output_variant": tile_encoder_output_variant,
         "supported_spacing_um": supported_spacing_um,
+        "default_spacing_um": default_spacing_um,
         "precision": precision,
         "source": source,
     }
@@ -133,14 +150,13 @@ def resolve_preprocessing_requirements(
 
     if level == "tile":
         input_size = require_encoder_metadata_field(encoder_name, info, "input_size")
-        spacing_um = require_encoder_metadata_field(
-            encoder_name,
-            info,
-            "supported_spacing_um",
-        )
+        # supported_spacing_um is the *validated* constraint set and may be None
+        # (spacing-agnostic). Kept lazy: do NOT resolve a default here — callers
+        # that only need the constraint (e.g. tile-size validation) must not trip
+        # over a list/agnostic encoder having no single default.
         return {
             "tile_size_px": input_size,
-            "spacing_um": spacing_um,
+            "spacing_um": info.get("supported_spacing_um"),
             "source_encoder": encoder_name,
         }
 
@@ -153,35 +169,67 @@ def resolve_preprocessing_requirements(
     raise AssertionError("unreachable")
 
 
+def _resolve_default_spacing(encoder_name: str, info: dict[str, Any]) -> float:
+    """Resolve the single spacing (µm/px) an encoder is tiled at by default.
+
+    Prefers an explicit ``default_spacing_um``. Otherwise derives it from
+    ``supported_spacing_um`` when that is a single value. Encoders that support a
+    *list* of spacings, or are spacing-agnostic (``supported_spacing_um=None``),
+    with no explicit default have no unambiguous tiling spacing and raise — the
+    caller must pass ``preprocessing.requested_spacing_um`` (or the encoder must
+    declare ``default_spacing_um``).
+    """
+    explicit = info.get("default_spacing_um")
+    if explicit is not None:
+        return float(explicit)
+
+    supported = info.get("supported_spacing_um")
+    if isinstance(supported, list):
+        unique_spacings: list[float] = []
+        for spacing in supported:
+            spacing_value = float(spacing)
+            if not any(abs(spacing_value - existing) <= 1e-8 for existing in unique_spacings):
+                unique_spacings.append(spacing_value)
+        if len(unique_spacings) == 1:
+            return unique_spacings[0]
+        supported_text = ", ".join(f"{s:g}" for s in unique_spacings)
+        raise ValueError(
+            f"Encoder '{encoder_name}' supports multiple spacings [{supported_text}]; "
+            "cannot infer a default requested_spacing_um. Declare default_spacing_um "
+            "in its registration or pass preprocessing.requested_spacing_um explicitly."
+        )
+    if isinstance(supported, (int, float)) and not isinstance(supported, bool):
+        return float(supported)
+
+    raise ValueError(
+        f"Encoder '{encoder_name}' is spacing-agnostic (supported_spacing_um=None) but "
+        "declares no default_spacing_um; declare default_spacing_um in its registration "
+        "or pass preprocessing.requested_spacing_um explicitly."
+    )
+
+
 def resolve_preprocessing_defaults(
     encoder_name: str,
     metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Resolve a single unambiguous preprocessing default for an encoder.
 
-    This is stricter than :func:`resolve_preprocessing_requirements`: it only
-    succeeds when the encoder advertises exactly one supported spacing.
+    This is stricter than :func:`resolve_preprocessing_requirements`: it resolves
+    exactly one tiling spacing (see :func:`_resolve_default_spacing`) and raises
+    when the encoder advertises several supported spacings without an explicit
+    ``default_spacing_um``.
     """
     reqs = resolve_preprocessing_requirements(encoder_name, metadata)
-    spacing_um = reqs["spacing_um"]
-    if isinstance(spacing_um, list):
-        unique_spacings = []
-        for spacing in spacing_um:
-            spacing_value = float(spacing)
-            if not any(abs(spacing_value - existing) <= 1e-8 for existing in unique_spacings):
-                unique_spacings.append(spacing_value)
-        if len(unique_spacings) != 1:
-            supported_text = ", ".join(f"{s:g}" for s in unique_spacings)
-            raise ValueError(
-                f"Encoder '{encoder_name}' supports multiple spacings [{supported_text}]; "
-                "cannot infer a default requested_spacing_um. "
-                "Pass preprocessing.requested_spacing_um explicitly."
-            )
-        spacing_um = unique_spacings[0]
+    source_encoder = reqs["source_encoder"]
+    # Resolve the default off the *tile* encoder's metadata: slide/patient
+    # encoders inherit both tile size and spacing from their tile encoder, so
+    # source_encoder already points at the model that carries the spacing fields.
+    source_info = encoder_registry.info(source_encoder)
+    spacing_um = _resolve_default_spacing(source_encoder, source_info)
     return {
         "tile_size_px": int(reqs["tile_size_px"]),
         "spacing_um": float(spacing_um),
-        "source_encoder": reqs["source_encoder"],
+        "source_encoder": source_encoder,
     }
 
 

--- a/slide2vec/runtime/model_settings.py
+++ b/slide2vec/runtime/model_settings.py
@@ -30,6 +30,9 @@ MODEL_NAME_ALIASES = {
     "prov-gigapath-slide": "gigapath-slide",
     "kaiko-midnight": "midnight",
     "mstar-slide": "mstar",
+    "dinov2": "dinov2-vitb14",
+    "dinov2-base": "dinov2-vitb14",
+    "dinov2-vitb": "dinov2-vitb14",
 }
 
 

--- a/tests/test_dinov2_natimage.py
+++ b/tests/test_dinov2_natimage.py
@@ -1,0 +1,91 @@
+"""Tests for the natural-image DINOv2 control encoder (``dinov2-vitb14``).
+
+``dinov2-vitb14`` is a non-pathology ViT: the original DINOv2 ViT-B/14
+self-supervised on LVD-142M (natural images), registered as a tile encoder so it
+can act as a "does pathology-pretraining pay off?" control in soma's detection
+benchmark. It must behave exactly like the pathology timm ViT tile encoders it
+mirrors (registration + dense + attention), so these tests reuse the same offline
+(``pretrained=False``) oracle checks as the shared encoder suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+
+from slide2vec.encoders import encoder_registry  # noqa: E402
+
+
+def test_dinov2_natimage_metadata_contract():
+    info = encoder_registry.info("dinov2-vitb14")
+    assert info["level"] == "tile"
+    assert info["input_size"] == 224
+    assert info["patch_size"] == 14
+    # Natural-image encoders have no intrinsic micron spacing; 0.5 is the
+    # convention that matches the pathology tile encoders' default task-spacing,
+    # so the control runs at identical tile geometry when selected by name.
+    assert info["supported_spacing_um"] == pytest.approx(0.5)
+    assert info["precision"] == "fp16"
+    assert info["source"] == "timm/vit_base_patch14_dinov2.lvd142m"
+    assert info["output_variants"]["default"]["encode_dim"] == 768
+    assert info["default_output_variant"] == "default"
+
+
+def test_dinov2_alias_resolves_to_canonical():
+    from slide2vec.runtime.model_settings import canonicalize_model_name
+
+    assert canonicalize_model_name("dinov2") == "dinov2-vitb14"
+    assert canonicalize_model_name("dinov2-base") == "dinov2-vitb14"
+
+
+def test_dinov2_natimage_dense_matches_timm_oracle_at_detection_geometry():
+    """Dense grid at a 224 tile == timm's own reshape-aware patch grid.
+
+    Runs offline with random weights (``pretrained=False``): the natural-image
+    DINOv2 is a plain timm ViT, so the inherited dense path must be bit-identical
+    to timm's ``get_intermediate_layers`` oracle, pinning spatial registration
+    (not just tensor shape) at the detection tile geometry (224 / 14 = 16).
+    """
+    from slide2vec.encoders.models.dinov2 import DINOv2ViTB14
+
+    enc = DINOv2ViTB14.__new__(DINOv2ViTB14)
+    enc._model = timm.create_model(
+        "vit_base_patch14_dinov2.lvd142m",
+        pretrained=False,
+        num_classes=0,
+        dynamic_img_size=True,
+    ).eval()
+    enc._device = torch.device("cpu")
+    enc._output_variant = "default"
+
+    x = torch.randn(2, 3, 224, 224)
+    with torch.no_grad():
+        mine = enc.encode_tiles_dense(x)
+        oracle = enc._model.get_intermediate_layers(
+            x, n=1, reshape=True, return_prefix_tokens=False, norm=True
+        )[0]
+    assert mine.shape == (2, 768, 16, 16)
+    torch.testing.assert_close(mine, oracle, rtol=0, atol=1e-6)
+
+
+def test_dinov2_natimage_attention_shape_cls_only():
+    """CLS-only per-head attention grid at the detection geometry (single prefix)."""
+    from slide2vec.encoders.models.dinov2 import DINOv2ViTB14
+
+    enc = DINOv2ViTB14.__new__(DINOv2ViTB14)
+    enc._model = timm.create_model(
+        "vit_base_patch14_dinov2.lvd142m",
+        pretrained=False,
+        num_classes=0,
+        dynamic_img_size=True,
+    ).eval()
+    enc._device = torch.device("cpu")
+    enc._output_variant = "default"
+
+    nh = enc._model.blocks[-1].attn.num_heads
+    x = torch.randn(1, 3, 224, 224)
+    with torch.no_grad():
+        out = enc.encode_tiles_attention(x)  # blocks=(-1,), CLS only
+    assert out.shape == (1, nh, 16, 16)

--- a/tests/test_dinov2_natimage.py
+++ b/tests/test_dinov2_natimage.py
@@ -23,14 +23,39 @@ def test_dinov2_natimage_metadata_contract():
     assert info["level"] == "tile"
     assert info["input_size"] == 224
     assert info["patch_size"] == 14
-    # Natural-image encoders have no intrinsic micron spacing; 0.5 is the
-    # convention that matches the pathology tile encoders' default task-spacing,
-    # so the control runs at identical tile geometry when selected by name.
-    assert info["supported_spacing_um"] == pytest.approx(0.5)
+    # Natural-image encoders have no intrinsic micron spacing, so they declare
+    # supported_spacing_um=None (spacing-agnostic: no validation constraint) and
+    # a separate default_spacing_um that matches the pathology encoders' task
+    # spacing, so the control runs at identical tile geometry when selected by name.
+    assert info["supported_spacing_um"] is None
+    assert info["default_spacing_um"] == pytest.approx(0.5)
     assert info["precision"] == "fp16"
     assert info["source"] == "timm/vit_base_patch14_dinov2.lvd142m"
     assert info["output_variants"]["default"]["encode_dim"] == 768
     assert info["default_output_variant"] == "default"
+
+
+def test_dinov2_natimage_resolves_tiling_default_from_default_spacing():
+    """Spacing-agnostic encoder still resolves a zero-config tiling spacing.
+
+    ``supported_spacing_um=None`` alone has no derivable default; the explicit
+    ``default_spacing_um`` is what lets name-only selection tile at 0.5 µm/px.
+    """
+    from slide2vec.encoders.registry import resolve_preprocessing_defaults
+
+    defaults = resolve_preprocessing_defaults("dinov2-vitb14")
+    assert defaults["tile_size_px"] == 224
+    assert defaults["spacing_um"] == pytest.approx(0.5)
+
+
+def test_dinov2_natimage_is_spacing_agnostic_in_validation():
+    """No requested spacing is ever "non-recommended" for the agnostic control."""
+    from slide2vec.encoders.validation import validate_encoder_config
+
+    # A spacing far from the 0.5 tiling default must NOT raise, even without the
+    # allow_non_recommended escape hatch: the model has no spacing to violate.
+    validate_encoder_config("dinov2-vitb14", requested_spacing_um=0.25)
+    validate_encoder_config("dinov2-vitb14", requested_spacing_um=2.0)
 
 
 def test_dinov2_alias_resolves_to_canonical():

--- a/tests/test_encoder_registry.py
+++ b/tests/test_encoder_registry.py
@@ -12,6 +12,7 @@ EXPECTED_TILE_ENCODERS = {
     "virchow2",
     "conch",
     "conchv15",
+    "dinov2-vitb14",
     "genbio-pathfm",
     "gigapath",
     "gpfm",

--- a/tests/test_patch_size_metadata.py
+++ b/tests/test_patch_size_metadata.py
@@ -37,6 +37,7 @@ DENSE_PATCH_SIZES: dict[str, tuple[int, int]] = {
     "prost40m": (16, 16),
     "conch": (16, 16),
     "conchv15": (16, 16),
+    "dinov2-vitb14": (14, 14),
     "phikon": (16, 16),
     "phikonv2": (16, 16),
     "midnight": (14, 14),

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -189,6 +189,7 @@ def test_list_models_can_filter_by_level():
     assert list_models("tile") == [
         "conch",
         "conchv15",
+        "dinov2-vitb14",
         "genbio-pathfm",
         "gigapath",
         "gpfm",


### PR DESCRIPTION
## What

Registers **`dinov2-vitb14`**: the original DINOv2 ViT-B/14 self-supervised on **LVD-142M natural images** (Oquab et al., 2024), shipped by `timm` as `vit_base_patch14_dinov2.lvd142m`. Weights are hosted publicly on Hugging Face under `timm/vit_base_patch14_dinov2.lvd142m` — **no gated access, no HF token**.

Implements clemsgrs/soma#232.

## Why

soma's detection benchmark (Paper 1) needs a **non-pathology** ViT control to answer *"does pathology-pretraining actually pay off for detection?"* (and Paper 2 the "catches up late" curve). Almost every pathology tile encoder here (UNI, Virchow, GigaPath, H-optimus, Midnight, …) is a DINOv2-family ViT, so pairing them with a DINOv2 ViT trained on natural images holds **architecture and the SSL objective fixed** and varies only the **pretraining domain** — exactly the control the benchmark wants.

## How

Structurally a plain `TimmTileEncoder`, mirroring `lunit` / `prost40m` / `uni`: the dense (`encode_tiles_dense`) and attention (`encode_tiles_attention`) paths are **inherited unchanged** from the timm ViT base, so the control is dense-extraction- and attention-capable exactly like the pathology encoders. `dynamic_img_size=True` lets the natively-518px backbone run at the 224px detection tile geometry via positional-embedding interpolation (a no-op at native size, verified in the shared dense-extraction suite).

## Metadata

| field | value | note |
|---|---|---|
| `level` | `tile` | |
| `output dim` | 768 | ViT-B, single `default` variant |
| `input_size` | 224 | matches every pathology tile encoder → same tile geometry |
| `patch_size` | 14 | 224 / 14 = 16 → 16×16 dense grid |
| `precision` | fp16 | |
| `supported_spacing_um` | **`None`** | spacing-agnostic — no validation constraint (see below) |
| `default_spacing_um` | **0.5** | tiling default when selected by name |
| `source` | `timm/vit_base_patch14_dinov2.lvd142m` | public |

### Spacing model — split constraint from default

A natural-image model has **no intrinsic micron-per-pixel spacing**, so advertising `0.5` as a *supported/recommended* spacing (the way the pathology encoders do) would be a lie: it would make `validate_encoder_config` reject any other spacing as "non-recommended" when in fact no spacing is more correct than another. This PR splits the previously overloaded `supported_spacing_um` into its two real roles:

- **`supported_spacing_um`** — the *validation constraint*: the spacing(s) a model was trained/validated for. Off-list requests raise unless `allow_non_recommended_settings=True`. Set to **`None`** here to mark the encoder **spacing-agnostic** — the spacing check is skipped entirely.
- **`default_spacing_um`** — the single spacing a slide is tiled at when the encoder is selected by name with no explicit `requested_spacing_um`. Set to **0.5** here so the control lands on the pathology encoders' tile geometry and drops in with zero config.

Consequences:
- Selecting `dinov2-vitb14` by name still tiles at 0.5 µm/px → matched geometry, zero config (acceptance criterion satisfied).
- Sweeping other task-spacings (e.g. the 0.25 used in the OCELOT campaign) now needs **no escape hatch** — any requested spacing is accepted as-is, because the model has no spacing to violate.

`default_spacing_um` is optional and *derived* from `supported_spacing_um` when that is a single value, so the ~13 single-spacing pathology encoders need **no edits**. The multi-spacing guardrail is preserved: `virchow2` / `musk` / `midnight` (a list of spacings) still require an explicit `requested_spacing_um` unless they opt in with their own `default_spacing_um`. Default resolution is kept lazy so tile-size validation never trips over a list/agnostic encoder.

### Other judgment calls
- **Plain DINOv2 (no registers).** Picked `vit_base_patch14_dinov2` over the `reg4` variant for the cleanest "vanilla ViT" control: a single CLS prefix token, which is the simplest dense/attention layout (like `uni`/`midnight`/`phikon`). The reg4 variant is a trivial swap if you'd prefer to match the register-carrying pathology models (UNI2, H-optimus, Virchow2).
- **ViT-B/14** as the size: the mid-size that most directly parallels the ViT-L/g pathology backbones while staying cheap.
- Aliases `dinov2` / `dinov2-base` / `dinov2-vitb` → `dinov2-vitb14`.

## Tests

New `tests/test_dinov2_natimage.py` mirrors the existing encoder suite:
- registration/metadata contract (`supported_spacing_um is None`, `default_spacing_um == 0.5`) + alias resolution,
- **spacing model**: name-only selection resolves the 0.5 tiling default, and `validate_encoder_config` accepts any requested spacing (0.25 / 2.0) with no escape hatch,
- **dense grid parity vs timm's `get_intermediate_layers` oracle** at the 224px detection geometry (offline, `pretrained=False`) — pins spatial registration, not just shape,
- CLS-only per-head attention shape.

The registry split (`supported_spacing_um` accepts `None`; new `default_spacing_um`) lives in `slide2vec/encoders/registry.py`; the existing multi-spacing guard tests (`virchow2`/`musk`/`midnight` in `test_regression_core` / `test_regression_models`) are unchanged and still pass. Also updated the shared exact-membership lists (`test_encoder_registry`, `test_patch_size_metadata`, `test_regression_core`), docs (`docs/models.rst`), and the README count.

**Full suite (`-o addopts=""`): 483 passed, 4 skipped** (the 4 skips are the weight-dependent heavy tests, which run on the nightly heavy workflow). Separately verified end-to-end with the **real** downloaded weights on CPU: `dense (1, 768, 16, 16)` · `attn (1, 12, 16, 16)` · `pooled (1, 768)` at 224px.

> Coverage note: this repo's `--cov` addopts hit a sqlite lock on my (network) filesystem, so I ran pytest with `-o addopts=""`. Heavy weight-parity test (`test_static_patch_size_matches_runtime`) is excluded from the PR suite by design and runs on the nightly heavy workflow.
