### PR TITLE
Split the natural-image DINOv2 control into its own model table

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -48,11 +48,6 @@ Tile-level encoders
      - 768
      - ``0.5``
      - Lu et al. (2024)
-   * - ``dinov2-vitb14``
-     - `DINOv2 ViT-B/14 <https://huggingface.co/timm/vit_base_patch14_dinov2.lvd142m>`_
-     - 768
-     - any (``0.5`` default)
-     - Oquab et al. (2024); natural-image (non-pathology) control, public weights; spacing-agnostic
    * - ``hibou-b``
      - `Hibou-B <https://huggingface.co/histai/hibou-b>`_
      - 768
@@ -133,6 +128,30 @@ Tile-level encoders
      - 4608
      - ``0.5``
      - GenBio AI (2024)
+
+Natural-image control
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A non-pathology tile encoder, kept separate from the pathology-focused table
+above. It holds the ViT architecture and self-supervised objective fixed while
+varying only the pretraining domain, so it acts as a control for measuring the
+effect of pathology pretraining. Being spacing-agnostic, it has no intrinsic
+micron spacing and accepts any requested spacing, tiling at ``0.5`` µm/px by
+default so it lands on the same tile geometry as the pathology encoders.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Preset
+     - Model
+     - Output dim
+     - Spacing (um)
+     - Notes
+   * - ``dinov2-vitb14``
+     - `DINOv2 ViT-B/14 <https://huggingface.co/timm/vit_base_patch14_dinov2.lvd142m>`_
+     - 768
+     - any (``0.5`` default)
+     - Oquab et al. (2024)
 
 Dense tile grids
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## What

Reorganizes the model-zoo docs so the natural-image `dinov2-vitb14` control lives in its own table instead of sitting inside the pathology tile-encoder table.

- Removes the `dinov2-vitb14` row from the main **Tile-level encoders** table.
- Adds a dedicated **Natural-image control** subsection (with its own single-row `list-table`) right below it, introduced by a short paragraph explaining the control role and spacing-agnostic behavior.
- Drops the redundant per-row note (`natural-image (non-pathology) control, public weights; spacing-agnostic`) now that the surrounding text carries that context; the row keeps just the plain citation.

## Why

`dinov2-vitb14` is a non-pathology control, so listing it inline with the pathology foundation models is misleading — it invites reading it as just another pathology encoder. A separate table makes its distinct purpose obvious at a glance.

## Scope

Docs-only (`docs/models.rst`). No code or behavior change; the dense/attention coverage lists still reference `dinov2-vitb14` (unchanged, since it remains dense- and attention-capable).