### PR TITLE
Distributed multi-GPU dense feature extraction over slide ROIs

### DIFF
--- a/slide2vec/__init__.py
+++ b/slide2vec/__init__.py
@@ -1,4 +1,5 @@
 from slide2vec.api import (
+    DenseOptions,
     EmbeddedPatient,
     EmbeddedSlide,
     ExecutionOptions,
@@ -6,9 +7,15 @@ from slide2vec.api import (
     Pipeline,
     PreprocessingConfig,
     RunResult,
+    SlideRegions,
     list_models,
 )
-from slide2vec.artifacts import HierarchicalEmbeddingArtifact, SlideEmbeddingArtifact, TileEmbeddingArtifact
+from slide2vec.artifacts import (
+    DenseRegionArtifact,
+    HierarchicalEmbeddingArtifact,
+    SlideEmbeddingArtifact,
+    TileEmbeddingArtifact,
+)
 
 
 __version__ = "5.3.0"
@@ -18,6 +25,8 @@ __all__ = [
     "list_models",
     "Pipeline",
     "PreprocessingConfig",
+    "DenseOptions",
+    "SlideRegions",
     "ExecutionOptions",
     "RunResult",
     "EmbeddedPatient",
@@ -25,5 +34,6 @@ __all__ = [
     "SlideEmbeddingArtifact",
     "HierarchicalEmbeddingArtifact",
     "TileEmbeddingArtifact",
+    "DenseRegionArtifact",
     "__version__",
 ]

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -11,6 +11,7 @@ import torch
 from hs2p import SlideSpec
 
 from slide2vec.artifacts import (
+    DenseRegionArtifact,
     HierarchicalEmbeddingArtifact,
     PatientEmbeddingArtifact,
     SlideEmbeddingArtifact,
@@ -313,6 +314,63 @@ class ExecutionOptions:
 
 
 @dataclass(frozen=True, kw_only=True)
+class DenseOptions:
+    """Dense ``(d, gh, gw)`` grid extraction settings (issue #217).
+
+    The dense counterpart of the pooled :class:`PreprocessingConfig`: it names the
+    extraction geometry (spacing → level, supervision ``target_size``, padding) and the
+    dense encode knobs (whole-tile vs sliding-window, patch grid vs CLS-attention). Unlike
+    the pooled path there is no tiling — the caller supplies ROI coordinates directly (see
+    :class:`SlideRegions`) — so a ``DenseOptions`` carries only what slide2vec needs to read
+    and encode each ROI. ``ExecutionOptions`` is reused unchanged for output/precision/GPUs.
+    """
+
+    #: Target spacing in µm/px the ROI is read at (resolved to a pyramid level per slide).
+    spacing_um: float
+    #: Supervision tile side length in pixels at *spacing_um* (the dense grid registers to it).
+    target_size: int
+    #: Relative spacing tolerance for pyramid level selection.
+    tolerance: float = 0.05
+    #: Slide reading backend. ``"auto"`` resolves per slide (cucim → openslide → vips).
+    backend: str = "auto"
+    #: Padding mode used to pad the tile up to the encoder's patch multiple.
+    #: One of ``"reflect"`` / ``"replicate"`` / ``"constant"`` / ``"zero"``.
+    pad_mode: str = "reflect"
+    #: Constant fill value for ``pad_mode in {"constant", "zero"}`` (ignored otherwise).
+    image_pad_value: float | None = None
+    #: Encoder field-of-view chunk fed through the backbone per forward. ``None`` (default)
+    #: is one whole-tile forward; a smaller value slides the encoder and blends token grids.
+    window_size: int | None = None
+    #: Fractional window overlap in ``[0, 1)`` for the sliding path (ignored when
+    #: ``window_size is None``).
+    overlap: float = 0.0
+    #: ``"patch_features"`` (the patch-token grid) or ``"cls_attention"`` (CLS/register
+    #: self-attention grid).
+    feature_kind: str = "patch_features"
+    #: Transformer blocks whose CLS attention is read (``cls_attention`` only).
+    attention_blocks: tuple[int, ...] = (-1,)
+    #: Include register-token query rows as extra attention channels (``cls_attention`` only).
+    attention_include_registers: bool = False
+
+
+@dataclass(frozen=True, kw_only=True)
+class SlideRegions:
+    """One slide's ROIs for dense extraction: ``(sample_id, image_path, coordinates, annotation)``.
+
+    The dense input unit soma's slide-manifest path hands to
+    :meth:`Model.embed_regions_dense`. ``coordinates`` is an ``(N, 2)`` array of level-0
+    top-left ``(x, y)`` pixel coordinates; each ROI is read + encoded into one persisted
+    ``(d, gh, gw)`` grid named ``<x>_<y>.pt``. ``annotation`` namespaces the output under a
+    per-class subdirectory (reusing the pooled convention); ``None`` is the flat layout.
+    """
+
+    sample_id: str
+    image_path: PathLike
+    coordinates: Any
+    annotation: str | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
 class RunResult:
     """Return value of :meth:`Pipeline.run`."""
 
@@ -587,6 +645,30 @@ class Model:
                 preprocessing=resolved_preprocessing,
                 execution=resolved,
             )
+
+    def embed_regions_dense(
+        self,
+        regions: "Sequence[SlideRegions]",
+        *,
+        dense: "DenseOptions",
+        execution: ExecutionOptions | None = None,
+    ) -> list[DenseRegionArtifact]:
+        """Extract + persist a dense ``(d, gh, gw)`` grid per caller-supplied ROI.
+
+        The dense counterpart of the pooled coordinate path: each ``SlideRegions`` names a
+        slide + a set of level-0 ROI coordinates, and every ROI is read, encoded through the
+        dense transform, and written to ``dense_embeddings/[<class>/]<sample_id>/<x>_<y>.pt``
+        plus a geometry sidecar. The run splits its ROIs across all visible GPUs
+        (``execution.num_gpus``); ``num_gpus=1`` encodes fully in-process. Resume is
+        automatic — ROIs whose sidecar already exists are skipped. Returns one
+        :class:`~slide2vec.artifacts.DenseRegionArtifact` per input ROI.
+        """
+        from slide2vec.runtime.dense_stage import embed_regions_dense
+
+        resolved = _coerce_execution_options(execution, model=self)
+        _require_output_dir_for_persistence(resolved, method_name="Model.embed_regions_dense(...)")
+        with _auto_progress_reporting(output_dir=resolved.output_dir):
+            return embed_regions_dense(self, regions, dense=dense, execution=resolved)
 
     def _load_backend(self) -> LoadedModel:
         if self._backend is None:

--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -62,6 +63,30 @@ class HierarchicalEmbeddingArtifact:
     feature_dim: int
     num_regions: int
     tiles_per_region: int
+    annotation: str | None = None
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return load_metadata(self.metadata_path)
+
+
+@dataclass(frozen=True, kw_only=True)
+class DenseRegionArtifact:
+    """One persisted dense ROI grid: the ``(d, gh, gw)`` payload + its geometry sidecar.
+
+    Dense emits one *directory* per slide (``dense_embeddings/[<class>/]<sample_id>/``) and
+    one ``<x>_<y>.pt`` / ``<x>_<y>.meta.json`` pair per ROI — the counterpart of the pooled
+    one-file-per-slide artifacts. Named from what slide2vec knows (slide + level-0 top-left
+    coordinate); soma maps its ROI ``sample_id`` back onto ``(x, y)``.
+    """
+
+    sample_id: str
+    x: int
+    y: int
+    path: Path
+    metadata_path: Path
+    feature_dim: int
+    grid_shape: tuple[int, int]
     annotation: str | None = None
 
     @property
@@ -160,6 +185,70 @@ def hierarchical_embeddings_subdir(annotation: str | None) -> str:
     if is_flattened_annotation(annotation):
         return "hierarchical_embeddings"
     return f"hierarchical_embeddings/{annotation}"
+
+
+def dense_embeddings_subdir(annotation: str | None) -> str:
+    """Namespace the ``dense_embeddings`` output dir per annotation class.
+
+    Reuses hs2p's flatten rule (the single source of truth, shared with
+    :func:`tile_embeddings_subdir` and the other pooled subdir helpers): ``None`` and the
+    sentinel ``"tissue"`` collapse to the flat ``dense_embeddings`` root; any real class
+    label gets its own ``dense_embeddings/<class>`` subdirectory.
+    """
+    if is_flattened_annotation(annotation):
+        return "dense_embeddings"
+    return f"dense_embeddings/{annotation}"
+
+
+def region_dense_paths(
+    output_dir: str | Path, *, sample_id: str, annotation: str | None, x: int, y: int
+) -> tuple[Path, Path]:
+    """``(payload_path, sidecar_path)`` for one ROI: ``.../<sample_id>/<x>_<y>.{pt,meta.json}``.
+
+    Geometry-independent (named only from slide + level-0 ``(x, y)`` + class), so the resume
+    check can test sidecar existence before any slide is opened.
+    """
+    slide_dir = (Path(output_dir) / dense_embeddings_subdir(annotation) / str(sample_id)).resolve()
+    stem = f"{int(x)}_{int(y)}"
+    return slide_dir / f"{stem}.pt", slide_dir / f"{stem}.meta.json"
+
+
+def write_dense_region(
+    grid,
+    *,
+    output_dir: str | Path,
+    sample_id: str,
+    annotation: str | None,
+    x: int,
+    y: int,
+    metadata: dict[str, Any],
+) -> DenseRegionArtifact:
+    """Persist one ``(d, gh, gw)`` grid + its geometry sidecar, atomically and sidecar-last.
+
+    Write order (D6): payload to a temp file in the destination directory → ``os.replace``
+    into ``<x>_<y>.pt`` (atomic on the same filesystem) → then the ``<x>_<y>.meta.json``
+    sidecar. A payload present without its sidecar therefore unambiguously means an
+    incomplete ROI, and resume treats the sidecar as the done-marker.
+    """
+    payload_path, metadata_path = region_dense_paths(
+        output_dir, sample_id=sample_id, annotation=annotation, x=x, y=y
+    )
+    payload_path.parent.mkdir(parents=True, exist_ok=True)
+    grid_array = _ensure_array(grid)
+    tmp_path = payload_path.with_name(f"{payload_path.name}.tmp-{os.getpid()}")
+    torch.save(_ensure_tensor(grid), tmp_path)
+    os.replace(tmp_path, payload_path)
+    _write_metadata(metadata_path, metadata)
+    return DenseRegionArtifact(
+        sample_id=sample_id,
+        x=int(x),
+        y=int(y),
+        path=payload_path,
+        metadata_path=metadata_path,
+        feature_dim=int(grid_array.shape[0]),
+        grid_shape=(int(grid_array.shape[1]), int(grid_array.shape[2])),
+        annotation=annotation,
+    )
 
 
 def _setup_artifact_paths(

--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
+from uuid import uuid4
 
 import numpy as np
 import torch
@@ -137,7 +138,15 @@ def _ensure_tensor(data: Any):
 
 def _write_metadata(path: Path, metadata: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path = path.with_name(f".{path.name}.tmp-{os.getpid()}-{uuid4().hex}")
+    try:
+        tmp_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def tile_embeddings_subdir(annotation: str | None) -> str:
@@ -187,6 +196,20 @@ def hierarchical_embeddings_subdir(annotation: str | None) -> str:
     return f"hierarchical_embeddings/{annotation}"
 
 
+def _validate_path_component(value: str, *, field: str) -> str:
+    component = str(value)
+    if (
+        not component
+        or component in {".", ".."}
+        or "/" in component
+        or "\\" in component
+        or "\x00" in component
+        or PureWindowsPath(component).drive
+    ):
+        raise ValueError(f"{field} must be a non-empty filesystem path component")
+    return component
+
+
 def dense_embeddings_subdir(annotation: str | None) -> str:
     """Namespace the ``dense_embeddings`` output dir per annotation class.
 
@@ -197,7 +220,8 @@ def dense_embeddings_subdir(annotation: str | None) -> str:
     """
     if is_flattened_annotation(annotation):
         return "dense_embeddings"
-    return f"dense_embeddings/{annotation}"
+    annotation_component = _validate_path_component(annotation, field="annotation")
+    return f"dense_embeddings/{annotation_component}"
 
 
 def region_dense_paths(
@@ -208,7 +232,11 @@ def region_dense_paths(
     Geometry-independent (named only from slide + level-0 ``(x, y)`` + class), so the resume
     check can test sidecar existence before any slide is opened.
     """
-    slide_dir = (Path(output_dir) / dense_embeddings_subdir(annotation) / str(sample_id)).resolve()
+    output_root = Path(output_dir).expanduser().resolve()
+    sample_component = _validate_path_component(sample_id, field="sample_id")
+    slide_dir = (output_root / dense_embeddings_subdir(annotation) / sample_component).resolve()
+    if not slide_dir.is_relative_to(output_root):
+        raise ValueError("Dense artifact path must stay within output_dir")
     stem = f"{int(x)}_{int(y)}"
     return slide_dir / f"{stem}.pt", slide_dir / f"{stem}.meta.json"
 

--- a/slide2vec/distributed/dense_worker.py
+++ b/slide2vec/distributed/dense_worker.py
@@ -1,0 +1,98 @@
+"""torchrun entry point for distributed dense feature extraction (issue #217).
+
+One of these runs per GPU under ``torch.distributed.run``. It is deliberately near
+logic-free (D10): it reads ``RANK`` / ``WORLD_SIZE`` / ``LOCAL_RANK`` straight from the env
+torchrun exports — **no NCCL / process-group init**, because dense extraction needs no
+collectives (each rank writes its own artifacts and nobody gathers) — loads the JSON request
+plus the coordinates npz the parent staged, then calls the two pure/CPU-tested layers:
+:func:`~slide2vec.runtime.dense_shard.plan_dense_shards` to pick this rank's contiguous shard
+and :func:`~slide2vec.runtime.dense_shard.run_dense_shard` to encode + persist it.
+"""
+
+import argparse
+import json
+import os
+from contextlib import nullcontext
+from pathlib import Path
+
+
+def get_args_parser(add_help: bool = True) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser("slide2vec.distributed.dense_worker", add_help=add_help)
+    parser.add_argument("--output-dir", required=True, help="Directory dense artifacts are written to")
+    parser.add_argument("--request-path", required=True, help="JSON request produced by the parent process")
+    return parser
+
+
+def main(argv=None) -> int:
+    from slide2vec.api import Model
+    from slide2vec.progress import (
+        JsonlProgressReporter,
+        activate_progress_reporter,
+        emit_progress,
+    )
+    from slide2vec.runtime.dense_shard import plan_dense_shards, run_dense_shard
+    from slide2vec.runtime.dense_stage import (
+        region_specs_from_request,
+        resolve_output_torch_dtype,
+    )
+    from slide2vec.runtime.serialization import (
+        deserialize_dense_options,
+        deserialize_execution,
+    )
+
+    args = get_args_parser(add_help=True).parse_args(argv)
+    request = json.loads(Path(args.request_path).read_text(encoding="utf-8"))
+    output_dir = Path(args.output_dir)
+
+    # torchrun exports these; default to a single in-process rank if launched bare.
+    global_rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+
+    specs = region_specs_from_request(request)
+    shard = plan_dense_shards(specs, world_size)[global_rank]
+    if not shard:
+        return 0
+
+    model_spec = dict(request["model"])
+    model = Model.from_preset(
+        model_spec["name"],
+        device=f"cuda:{local_rank}",
+        output_variant=model_spec.get("output_variant"),
+        allow_non_recommended_settings=bool(model_spec.get("allow_non_recommended_settings", False)),
+    )
+    dense = deserialize_dense_options(request["dense"])
+    execution = deserialize_execution(request["execution"])
+    loaded = model._load_backend()
+
+    progress_events_path = request.get("progress_events_path")
+    reporter = (
+        JsonlProgressReporter(
+            progress_events_path, rank=global_rank, progress_label=f"cuda:{local_rank}"
+        )
+        if progress_events_path
+        else None
+    )
+    context = activate_progress_reporter(reporter) if reporter is not None else nullcontext()
+
+    with context:
+        def _on_batch(count: int) -> None:
+            emit_progress("dense.batch.finished", rank=global_rank, regions=int(count))
+
+        run_dense_shard(
+            shard,
+            model=loaded.model,
+            out_dir=output_dir,
+            dense=dense,
+            batch_size=int(execution.batch_size),
+            device=loaded.device,
+            precision=execution.precision,
+            output_dtype=resolve_output_torch_dtype(execution),
+            num_workers=execution.resolved_num_workers_per_gpu(),
+            on_batch=_on_batch,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slide2vec/runtime/dense_shard.py
+++ b/slide2vec/runtime/dense_shard.py
@@ -1,0 +1,314 @@
+"""ROI-granularity sharding + the device-agnostic dense encode/write loop (issue #217).
+
+The two CPU-testable layers of distributed dense extraction (D12):
+
+* :func:`plan_dense_shards` — pure. Splits the slide-ordered flat ROI list into
+  ``world_size`` contiguous shards with :func:`numpy.array_split` (balanced to ±1 ROI,
+  deterministic, an exact partition). Sharding at ROI granularity minimizes WSI re-opens —
+  only the slides straddling a shard boundary are opened twice — and, because dense
+  features depend only on the batch size ``B`` and never on batch *composition*
+  (docs/adr/0002), needs no batch-alignment or bin-packing.
+
+* :func:`run_dense_shard` — the encode+write loop each rank runs over its shard. It groups
+  the shard's ROIs by slide (contiguous runs), builds a minimal hs2p ``TilingResult`` per
+  slide, streams the dense grids through :func:`~slide2vec.runtime.dense_regions.iter_regions_dense`
+  (the shared batched WSI reader + dense encode), and writes one ``<x>_<y>.pt`` payload plus
+  one ``<x>_<y>.meta.json`` sidecar per ROI. It is device-agnostic (no ``RANK``) and carries
+  no torchrun/NCCL dependency, so it is exercised on CPU with a fake ``_open_wsi_backend``
+  backend and a random-weight encoder — the same offline seam ``iter_regions_dense`` uses.
+
+Writes are atomic and sidecar-last (D6): payload to a temp file → ``os.replace`` into place
+→ then the sidecar. So a payload with no sidecar unambiguously means an incomplete ROI, and
+resume trusts the sidecar as the done-marker. slide2vec owns the dense *write* because it
+owns the dense *distribution* (docs/adr/0001): ranks are separate OS processes and a grid is
+~1000× a pooled embedding, so ranks persist final artifacts directly and nobody gathers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import groupby
+from typing import TYPE_CHECKING, Callable, Sequence
+
+import numpy as np
+
+from slide2vec.artifacts import (
+    DenseRegionArtifact,
+    load_metadata,
+    region_dense_paths,
+    write_dense_region,
+)
+
+if TYPE_CHECKING:
+    import torch
+
+    from slide2vec.api import DenseOptions
+
+
+@dataclass(frozen=True)
+class RegionSpec:
+    """One ROI (the flat sharding unit): identity + its slide's resolved read geometry.
+
+    ``sample_id`` / ``annotation`` / ``(x, y)`` name the persisted artifact
+    (``dense_embeddings/[<class>/]<sample_id>/<x>_<y>.pt``) and are geometry-independent, so
+    the resume check can run before any slide is opened. ``read_level`` /
+    ``read_tile_size_px`` / ``requested_tile_size_px`` / ``backend`` are the per-slide read
+    plan the parent resolved once (via hs2p ``plan_spacing_read``); every ROI of a slide
+    carries the same values, so :func:`run_dense_shard` rebuilds the ``TilingResult`` without
+    re-opening the slide for metadata.
+    """
+
+    sample_id: str
+    image_path: str
+    x: int
+    y: int
+    read_level: int
+    read_tile_size_px: int
+    requested_tile_size_px: int
+    backend: str
+    annotation: str | None = None
+
+
+def plan_dense_shards(
+    regions: Sequence[RegionSpec], world_size: int
+) -> list[list[RegionSpec]]:
+    """Partition the slide-ordered flat ROI list into ``world_size`` contiguous shards.
+
+    Contiguous ``numpy.array_split`` over the ROI index range: exactly ``world_size``
+    shards, balanced to within one ROI, deterministic, and an exact ordered partition of
+    the input (union preserves order, shards are pairwise disjoint). Contiguity keeps ROIs
+    of a slide together so only boundary slides are opened twice. Shards may be empty when
+    ``world_size`` exceeds the ROI count.
+    """
+    if world_size < 1:
+        raise ValueError(f"world_size must be at least 1, got {world_size}")
+    regions = list(regions)
+    index_shards = np.array_split(np.arange(len(regions)), world_size)
+    return [[regions[int(i)] for i in shard] for shard in index_shards]
+
+
+def _slide_key(spec: RegionSpec) -> tuple:
+    """Group key: consecutive ROIs sharing this open one slide's reader + read plan."""
+    return (
+        spec.image_path,
+        spec.sample_id,
+        spec.annotation,
+        spec.read_level,
+        spec.read_tile_size_px,
+        spec.requested_tile_size_px,
+        spec.backend,
+    )
+
+
+def region_needs_encode(out_dir, spec: RegionSpec) -> bool:
+    """Resume/crash-safety predicate: a ROI needs encoding iff its sidecar is absent.
+
+    The sidecar is written last (D6), so its presence is the done-marker; a ``.pt`` with no
+    sidecar is a crashed write and is re-encoded.
+    """
+    _, sidecar_path = region_dense_paths(
+        out_dir, sample_id=spec.sample_id, annotation=spec.annotation, x=spec.x, y=spec.y
+    )
+    return not sidecar_path.exists()
+
+
+def dense_artifact_from_disk(out_dir, spec) -> DenseRegionArtifact:
+    """Rebuild the artifact record for a ROI already on disk (skipped, or the final collect).
+
+    ``spec`` need only expose ``sample_id`` / ``annotation`` / ``x`` / ``y`` — the artifact is
+    named geometry-free — so both a :class:`RegionSpec` and the parent's pre-geometry flat ROI
+    work here.
+    """
+    payload_path, sidecar_path = region_dense_paths(
+        out_dir, sample_id=spec.sample_id, annotation=spec.annotation, x=spec.x, y=spec.y
+    )
+    meta = load_metadata(sidecar_path)
+    grid_shape = tuple(int(v) for v in meta["grid_shape"])
+    return DenseRegionArtifact(
+        sample_id=spec.sample_id,
+        x=int(spec.x),
+        y=int(spec.y),
+        path=payload_path,
+        metadata_path=sidecar_path,
+        feature_dim=int(meta["feature_dim"]),
+        grid_shape=(grid_shape[0], grid_shape[1]),
+        annotation=spec.annotation,
+    )
+
+
+def _build_dense_tiling_result(specs: list[RegionSpec], dense: "DenseOptions"):
+    """Minimal hs2p ``TilingResult`` for one slide's ROIs — only the fields the dense read
+    consumes carry real values; the rest are inert placeholders (there is no tissue mask /
+    QC here). ``read_level`` / ``read_tile_size_px`` / ``requested_tile_size_px`` come from
+    the parent-resolved read plan the specs carry, so no slide is opened for metadata.
+    """
+    from hs2p.tiling.result import TileGeometry, TilingResult
+
+    head = specs[0]
+    x = np.asarray([s.x for s in specs], dtype=np.int64)
+    y = np.asarray([s.y for s in specs], dtype=np.int64)
+    requested = int(head.requested_tile_size_px)
+    read = int(head.read_tile_size_px)
+    spacing = float(dense.spacing_um)
+    tiles = TileGeometry(
+        x=x,
+        y=y,
+        tissue_fractions=np.ones(len(specs), dtype=np.float32),
+        requested_tile_size_px=requested,
+        requested_spacing_um=spacing,
+        read_level=int(head.read_level),
+        read_tile_size_px=read,
+        read_spacing_um=spacing,
+        tile_size_lv0=read,
+        is_within_tolerance=True,
+        base_spacing_um=spacing,
+        slide_dimensions=[0, 0],
+        level_downsamples=[1.0],
+        overlap=0.0,
+        min_tissue_fraction=0.0,
+    )
+    return TilingResult(
+        tiles=tiles,
+        sample_id=head.sample_id,
+        image_path=head.image_path,
+        backend=head.backend,
+        requested_backend=head.backend,
+        tolerance=float(dense.tolerance),
+        step_px_lv0=read,
+        tissue_method="none",
+        requested_seg_downsample=1,
+        seg_downsample=1,
+        seg_level=0,
+        seg_spacing_um=spacing,
+        seg_sthresh=0,
+        seg_sthresh_up=255,
+        seg_mthresh=0,
+        seg_close=0,
+        ref_tile_size_px=requested,
+        a_t=0.0,
+        a_h=0.0,
+        filter_white=False,
+        filter_black=False,
+        white_threshold=255,
+        black_threshold=0,
+        fraction_threshold=0.0,
+    )
+
+
+def _region_metadata(
+    spec: RegionSpec, *, dense: "DenseOptions", geometry, grid
+) -> dict:
+    """Extraction-geometry sidecar (D5/D7): geometry + encode params slide2vec owns, nothing else."""
+    grid_arr = np.asarray(grid)
+    return {
+        "artifact_type": "dense_embeddings",
+        "sample_id": spec.sample_id,
+        "annotation": spec.annotation,
+        "x": int(spec.x),
+        "y": int(spec.y),
+        "format": "pt",
+        "dtype": str(grid_arr.dtype),
+        "feature_dim": int(grid_arr.shape[0]),
+        "grid_shape": [int(geometry.grid_shape[0]), int(geometry.grid_shape[1])],
+        "target_size": [int(geometry.target_size[0]), int(geometry.target_size[1])],
+        "patch_size": [int(geometry.patch_size[0]), int(geometry.patch_size[1])],
+        "encoded_size": [int(geometry.encoded_size[0]), int(geometry.encoded_size[1])],
+        "pad": [int(geometry.pad[0]), int(geometry.pad[1])],
+        "spacing_um": float(dense.spacing_um),
+        "tolerance": float(dense.tolerance),
+        "backend": spec.backend,
+        "read_level": int(spec.read_level),
+        "read_tile_size_px": int(spec.read_tile_size_px),
+        "requested_tile_size_px": int(spec.requested_tile_size_px),
+        "pad_mode": dense.pad_mode,
+        "image_pad_value": dense.image_pad_value,
+        "window_size": dense.window_size,
+        "overlap": float(dense.overlap),
+        "feature_kind": dense.feature_kind,
+        "attention_blocks": [int(b) for b in dense.attention_blocks],
+        "attention_include_registers": bool(dense.attention_include_registers),
+    }
+
+
+def run_dense_shard(
+    regions: Sequence[RegionSpec],
+    *,
+    model,
+    out_dir,
+    dense: "DenseOptions",
+    batch_size: int,
+    device: "torch.device | str",
+    precision: str = "fp32",
+    output_dtype: "torch.dtype | None" = None,
+    num_workers: int = 4,
+    on_batch: Callable[[int], None] | None = None,
+) -> list[DenseRegionArtifact]:
+    """Encode + persist one shard's ROIs, one ``<x>_<y>.pt`` + sidecar per ROI.
+
+    Groups the shard's ROIs into contiguous per-slide runs (so each slide is opened once),
+    skips any ROI whose sidecar already exists (crash-safety / resume, D9), builds a minimal
+    ``TilingResult`` for the ROIs that remain, and streams their grids through
+    :func:`~slide2vec.runtime.dense_regions.iter_regions_dense` — writing each grid atomically
+    and sidecar-last (D6). Device-agnostic and RANK-free: the identical loop runs in-process
+    for ``num_gpus=1`` and on each rank under torchrun.
+
+    Returns one :class:`~slide2vec.artifacts.DenseRegionArtifact` per input ROI in input
+    order — freshly written or (when skipped) reconstructed from the ROI already on disk.
+    ``on_batch`` is invoked with each encoded batch's ROI count (per-batch progress, D10c).
+    """
+    from slide2vec.runtime.dense_regions import compute_dense_geometry, iter_regions_dense
+
+    regions = list(regions)
+    artifacts: list[DenseRegionArtifact] = []
+    for _key, group_iter in groupby(regions, key=_slide_key):
+        group = list(group_iter)
+        pending = [spec for spec in group if region_needs_encode(out_dir, spec)]
+        written: dict[tuple[int, int], DenseRegionArtifact] = {}
+        if pending:
+            # Geometry from the slide's own read size — the exact size iter_regions_dense
+            # encodes — so the sidecar's grid/pad always describe the persisted grid.
+            geometry = compute_dense_geometry(
+                target_size=int(pending[0].requested_tile_size_px), patch_size=model.patch_size
+            )
+            tiling_result = _build_dense_tiling_result(pending, dense)
+            step = max(1, int(batch_size))
+            batch_remaining = 0
+            grids = iter_regions_dense(
+                model=model,
+                device=device,
+                tiling_result=tiling_result,
+                backend=None,
+                num_workers=int(num_workers),
+                pad_mode=dense.pad_mode,
+                image_pad_value=dense.image_pad_value,
+                window_size=dense.window_size,
+                overlap=dense.overlap,
+                feature_kind=dense.feature_kind,
+                attention_blocks=dense.attention_blocks,
+                attention_include_registers=dense.attention_include_registers,
+                batch_size=step,
+                precision=precision,
+                output_dtype=output_dtype,
+            )
+            for spec, grid in zip(pending, grids):
+                artifact = write_dense_region(
+                    grid,
+                    output_dir=out_dir,
+                    sample_id=spec.sample_id,
+                    annotation=spec.annotation,
+                    x=spec.x,
+                    y=spec.y,
+                    metadata=_region_metadata(spec, dense=dense, geometry=geometry, grid=grid),
+                )
+                written[(int(spec.x), int(spec.y))] = artifact
+                if on_batch is not None:
+                    batch_remaining += 1
+                    if batch_remaining >= step:
+                        on_batch(batch_remaining)
+                        batch_remaining = 0
+            if on_batch is not None and batch_remaining:
+                on_batch(batch_remaining)
+        for spec in group:
+            key = (int(spec.x), int(spec.y))
+            artifacts.append(written.get(key) or dense_artifact_from_disk(out_dir, spec))
+    return artifacts

--- a/slide2vec/runtime/dense_stage.py
+++ b/slide2vec/runtime/dense_stage.py
@@ -78,7 +78,7 @@ def flatten_slide_regions(regions: Sequence) -> list[_FlatRegion]:
             )
         annotation = slide_regions.annotation
         sample_id = str(slide_regions.sample_id)
-        image_path = str(slide_regions.image_path)
+        image_path = str(Path(slide_regions.image_path).expanduser().resolve())
         for x, y in coordinates:
             flat.append(_FlatRegion(sample_id, image_path, int(x), int(y), annotation))
     return flat
@@ -162,7 +162,8 @@ def embed_regions_dense(
     execution,
 ) -> list[DenseRegionArtifact]:
     """Extract + persist a dense grid per ROI across all visible GPUs (the D8 entry point)."""
-    out_dir = Path(execution.output_dir)
+    out_dir = Path(execution.output_dir).expanduser().resolve()
+    execution = execution.with_output_dir(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
     flat = flatten_slide_regions(regions)
     remaining, skipped = partition_regions_by_resume(flat, out_dir)
@@ -199,6 +200,7 @@ def _run_dense_in_process(model, specs, *, dense, execution, out_dir) -> None:
         device=loaded.device,
         precision=execution.precision,
         output_dtype=resolve_output_torch_dtype(execution),
+        num_workers=execution.resolved_num_workers_per_gpu(),
     )
 
 

--- a/slide2vec/runtime/dense_stage.py
+++ b/slide2vec/runtime/dense_stage.py
@@ -1,0 +1,297 @@
+"""Parent-side orchestration for distributed dense feature extraction (issue #217).
+
+The glue that turns a caller's :class:`~slide2vec.api.SlideRegions` into persisted dense
+grids, mirroring the pooled distributed stage but writing dense artifacts directly from the
+ranks (slide2vec owns the dense write because it owns the dense distribution — docs/adr/0001):
+
+1. **flatten** every ``SlideRegions`` into the slide-ordered flat ROI list;
+2. **resume-filter** it (D9) — drop ROIs whose sidecar already exists, before sharding, so
+   no rank draws an all-done shard and idles; the skip count is logged;
+3. **resolve** each remaining slide's read plan once (hs2p ``plan_spacing_read`` against the
+   slide's own pyramid) into per-ROI :class:`~slide2vec.runtime.dense_shard.RegionSpec`;
+4. **dispatch**: ``num_gpus=1`` runs :func:`~slide2vec.runtime.dense_shard.run_dense_shard`
+   fully in-process (no torchrun); ``num_gpus>1`` writes the coordinates to an npz + a JSON
+   request and launches :mod:`slide2vec.distributed.dense_worker` under torchrun;
+5. **collect** one :class:`~slide2vec.artifacts.DenseRegionArtifact` per input ROI by reading
+   the sidecars back off disk (the ranks already persisted them; nobody gathers grids).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from itertools import groupby
+from pathlib import Path
+from subprocess import Popen
+from typing import Sequence
+
+import numpy as np
+
+from slide2vec.artifacts import DenseRegionArtifact
+from slide2vec.progress import emit_progress
+from slide2vec.runtime.dense_shard import (
+    RegionSpec,
+    dense_artifact_from_disk,
+    plan_dense_shards,
+    region_needs_encode,
+    run_dense_shard,
+)
+from slide2vec.runtime.distributed import (
+    distributed_coordination_dir,
+    reset_progress_event_logs,
+    run_torchrun_worker,
+)
+from slide2vec.runtime.distributed_stage import validate_multi_gpu_execution
+from slide2vec.runtime.model_settings import output_torch_dtype
+from slide2vec.runtime.serialization import (
+    serialize_dense_options,
+    serialize_execution,
+    serialize_model,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _FlatRegion:
+    """A ROI before its slide's read plan is resolved (enough to name/skip its artifact)."""
+
+    sample_id: str
+    image_path: str
+    x: int
+    y: int
+    annotation: str | None
+
+
+def flatten_slide_regions(regions: Sequence) -> list[_FlatRegion]:
+    """Flatten ``SlideRegions`` into the slide-ordered flat ROI list (empty slides dropped)."""
+    flat: list[_FlatRegion] = []
+    for slide_regions in regions:
+        coordinates = np.asarray(slide_regions.coordinates)
+        if coordinates.size == 0:
+            continue
+        if coordinates.ndim != 2 or coordinates.shape[1] != 2:
+            raise ValueError(
+                f"SlideRegions.coordinates must have shape (N, 2), got {coordinates.shape} "
+                f"for sample {slide_regions.sample_id!r}"
+            )
+        annotation = slide_regions.annotation
+        sample_id = str(slide_regions.sample_id)
+        image_path = str(slide_regions.image_path)
+        for x, y in coordinates:
+            flat.append(_FlatRegion(sample_id, image_path, int(x), int(y), annotation))
+    return flat
+
+
+def partition_regions_by_resume(
+    flat: Sequence[_FlatRegion], out_dir
+) -> tuple[list[_FlatRegion], int]:
+    """Split the flat list into (needs-encode, already-on-disk-count) by sidecar existence."""
+    remaining = [region for region in flat if region_needs_encode(out_dir, region)]
+    return remaining, len(flat) - len(remaining)
+
+
+def resolve_slide_read_plan(image_path: str, dense) -> tuple[int, int, str]:
+    """Resolve one slide's ``(read_level, read_tile_size_px, resolved_backend)`` for ``dense``.
+
+    Opens the slide once (hs2p ``WSI``) to read its level-0 spacing + pyramid and runs the
+    shared ``plan_spacing_read`` kernel — the identical spacing→level resolution the pooled
+    tiling path uses. This is the only step that opens a slide for metadata; it never runs on
+    the CPU test path (the encode/read seam is faked separately).
+    """
+    from hs2p.wsi.geometry import plan_spacing_read
+    from hs2p.wsi.wsi import WSI
+
+    wsi = WSI(Path(image_path), backend=dense.backend)
+    plan = plan_spacing_read(
+        requested_spacing_um=float(dense.spacing_um),
+        level0_spacing_um=float(wsi.get_level_spacing(0)),
+        level_downsamples=list(wsi.level_downsamples),
+        target_size_px=(int(dense.target_size), int(dense.target_size)),
+        tolerance=float(dense.tolerance),
+    )
+    return int(plan.level), int(plan.read_size_px[0]), str(wsi.backend)
+
+
+def resolve_region_specs(flat: Sequence[_FlatRegion], dense) -> list[RegionSpec]:
+    """Attach each slide's resolved read plan to its ROIs, preserving flat order.
+
+    The read plan is resolved once per unique slide (cached), so a slide's ROIs share one
+    ``plan_spacing_read`` call; ordering is untouched so downstream sharding stays contiguous.
+    """
+    plans: dict[str, tuple[int, int, str]] = {}
+    specs: list[RegionSpec] = []
+    for region in flat:
+        plan = plans.get(region.image_path)
+        if plan is None:
+            plan = resolve_slide_read_plan(region.image_path, dense)
+            plans[region.image_path] = plan
+        read_level, read_tile_size_px, backend = plan
+        specs.append(
+            RegionSpec(
+                sample_id=region.sample_id,
+                image_path=region.image_path,
+                x=region.x,
+                y=region.y,
+                read_level=read_level,
+                read_tile_size_px=read_tile_size_px,
+                requested_tile_size_px=int(dense.target_size),
+                backend=backend,
+                annotation=region.annotation,
+            )
+        )
+    return specs
+
+
+def resolve_output_torch_dtype(execution):
+    """The on-disk grid dtype: ``None`` follows the compute precision; else fp16/fp32.
+
+    ``ExecutionOptions`` already normalized (and rejected ``bf16`` for) ``output_dtype``.
+    """
+    if execution.output_dtype is None:
+        return None
+    return output_torch_dtype(execution.output_dtype)
+
+
+def embed_regions_dense(
+    model,
+    regions: Sequence,
+    *,
+    dense,
+    execution,
+) -> list[DenseRegionArtifact]:
+    """Extract + persist a dense grid per ROI across all visible GPUs (the D8 entry point)."""
+    out_dir = Path(execution.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
+    flat = flatten_slide_regions(regions)
+    remaining, skipped = partition_regions_by_resume(flat, out_dir)
+    if skipped:
+        logger.info(
+            "resume: %s/%s regions already on disk, encoding %s",
+            f"{skipped:,}", f"{len(flat):,}", f"{len(remaining):,}",
+        )
+    emit_progress(
+        "dense.regions.started",
+        total=len(flat),
+        skipped=skipped,
+        encoding=len(remaining),
+        num_gpus=execution.num_gpus,
+    )
+    if remaining:
+        specs = resolve_region_specs(remaining, dense)
+        if execution.num_gpus == 1:
+            _run_dense_in_process(model, specs, dense=dense, execution=execution, out_dir=out_dir)
+        else:
+            _run_dense_distributed(model, specs, dense=dense, execution=execution, out_dir=out_dir)
+    emit_progress("dense.regions.finished", total=len(flat))
+    return [dense_artifact_from_disk(out_dir, region) for region in flat]
+
+
+def _run_dense_in_process(model, specs, *, dense, execution, out_dir) -> None:
+    loaded = model._load_backend()
+    run_dense_shard(
+        specs,
+        model=loaded.model,
+        out_dir=out_dir,
+        dense=dense,
+        batch_size=int(execution.batch_size),
+        device=loaded.device,
+        precision=execution.precision,
+        output_dtype=resolve_output_torch_dtype(execution),
+    )
+
+
+def _slide_group_key(spec: RegionSpec) -> tuple:
+    return (
+        spec.image_path,
+        spec.sample_id,
+        spec.annotation,
+        spec.read_level,
+        spec.read_tile_size_px,
+        spec.requested_tile_size_px,
+        spec.backend,
+    )
+
+
+def build_dense_worker_request(specs: Sequence[RegionSpec], *, coordinates_npz_path):
+    """Split the flat specs into per-slide groups for the request JSON (coords go to npz).
+
+    Per-slide geometry (the read plan) rides in the request; the flat ``(x, y)`` coordinates
+    travel as a file (D10b), concatenated in the same slide order so the worker rebuilds the
+    identical flat spec list before it shards.
+    """
+    slides = []
+    coordinates: list[tuple[int, int]] = []
+    for _key, group_iter in groupby(specs, key=_slide_group_key):
+        group = list(group_iter)
+        head = group[0]
+        slides.append(
+            {
+                "sample_id": head.sample_id,
+                "image_path": head.image_path,
+                "annotation": head.annotation,
+                "read_level": int(head.read_level),
+                "read_tile_size_px": int(head.read_tile_size_px),
+                "requested_tile_size_px": int(head.requested_tile_size_px),
+                "backend": head.backend,
+                "num_regions": len(group),
+            }
+        )
+        coordinates.extend((int(spec.x), int(spec.y)) for spec in group)
+    coords_array = np.asarray(coordinates, dtype=np.int64).reshape(-1, 2)
+    np.savez(coordinates_npz_path, coordinates=coords_array)
+    return {"slides": slides, "coordinates_npz_path": str(coordinates_npz_path)}
+
+
+def region_specs_from_request(request: dict) -> list[RegionSpec]:
+    """Inverse of :func:`build_dense_worker_request`: request + coords npz → flat spec list."""
+    with np.load(request["coordinates_npz_path"], allow_pickle=False) as payload:
+        coordinates = np.asarray(payload["coordinates"], dtype=np.int64).reshape(-1, 2)
+    specs: list[RegionSpec] = []
+    offset = 0
+    for slide in request["slides"]:
+        count = int(slide["num_regions"])
+        for x, y in coordinates[offset : offset + count]:
+            specs.append(
+                RegionSpec(
+                    sample_id=str(slide["sample_id"]),
+                    image_path=str(slide["image_path"]),
+                    x=int(x),
+                    y=int(y),
+                    read_level=int(slide["read_level"]),
+                    read_tile_size_px=int(slide["read_tile_size_px"]),
+                    requested_tile_size_px=int(slide["requested_tile_size_px"]),
+                    backend=str(slide["backend"]),
+                    annotation=slide["annotation"],
+                )
+            )
+        offset += count
+    return specs
+
+
+def _run_dense_distributed(model, specs, *, dense, execution, out_dir) -> None:
+    validate_multi_gpu_execution(model, execution)
+    progress_events_path = out_dir / "logs" / "dense_worker.progress.jsonl"
+    reset_progress_event_logs(progress_events_path)
+    with distributed_coordination_dir(out_dir) as coordination_dir:
+        request_path = coordination_dir / "dense_request.json"
+        coordinates_npz_path = coordination_dir / "dense_coordinates.npz"
+        request = {
+            "model": serialize_model(model),
+            "dense": serialize_dense_options(dense),
+            "execution": serialize_execution(execution),
+            "output_dir": str(out_dir),
+            "progress_events_path": str(progress_events_path),
+            **build_dense_worker_request(specs, coordinates_npz_path=coordinates_npz_path),
+        }
+        request_path.write_text(json.dumps(request, indent=2, sort_keys=True), encoding="utf-8")
+        run_torchrun_worker(
+            module="slide2vec.distributed.dense_worker",
+            num_gpus=execution.num_gpus,
+            output_dir=out_dir,
+            request_path=request_path,
+            failure_title="Distributed dense feature extraction failed",
+            progress_events_path=progress_events_path,
+            popen_factory=Popen,
+        )

--- a/slide2vec/runtime/serialization.py
+++ b/slide2vec/runtime/serialization.py
@@ -2,7 +2,7 @@ import copy
 from pathlib import Path
 from typing import Any
 
-from slide2vec.api import ExecutionOptions, PreprocessingConfig
+from slide2vec.api import DenseOptions, ExecutionOptions, PreprocessingConfig
 
 
 def serialize_model(model) -> dict[str, Any]:
@@ -58,6 +58,41 @@ def serialize_execution(
         "save_slide_embeddings": execution.save_slide_embeddings,
         "save_latents": execution.save_latents,
     }
+
+
+def serialize_dense_options(dense: DenseOptions) -> dict[str, Any]:
+    """JSON-round-trippable dense settings crossing to the torchrun ranks (D10)."""
+    return {
+        "spacing_um": dense.spacing_um,
+        "target_size": dense.target_size,
+        "tolerance": dense.tolerance,
+        "backend": dense.backend,
+        "pad_mode": dense.pad_mode,
+        "image_pad_value": dense.image_pad_value,
+        "window_size": dense.window_size,
+        "overlap": dense.overlap,
+        "feature_kind": dense.feature_kind,
+        "attention_blocks": list(dense.attention_blocks),
+        "attention_include_registers": dense.attention_include_registers,
+    }
+
+
+def deserialize_dense_options(payload: dict[str, Any]) -> DenseOptions:
+    return DenseOptions(
+        spacing_um=float(payload["spacing_um"]),
+        target_size=int(payload["target_size"]),
+        tolerance=float(payload.get("tolerance", 0.05)),
+        backend=str(payload.get("backend", "auto")),
+        pad_mode=str(payload.get("pad_mode", "reflect")),
+        image_pad_value=(
+            float(payload["image_pad_value"]) if payload.get("image_pad_value") is not None else None
+        ),
+        window_size=int(payload["window_size"]) if payload.get("window_size") is not None else None,
+        overlap=float(payload.get("overlap", 0.0)),
+        feature_kind=str(payload.get("feature_kind", "patch_features")),
+        attention_blocks=tuple(int(b) for b in payload.get("attention_blocks", (-1,))),
+        attention_include_registers=bool(payload.get("attention_include_registers", False)),
+    )
 
 
 def deserialize_preprocessing(payload: dict[str, Any]) -> PreprocessingConfig:

--- a/tests/test_dense_shard.py
+++ b/tests/test_dense_shard.py
@@ -16,6 +16,7 @@ set, grids within a per-grid cosine tolerance (docs/adr/0002).
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -24,6 +25,7 @@ torch = pytest.importorskip("torch")
 timm = pytest.importorskip("timm")
 
 from slide2vec.api import DenseOptions  # noqa: E402
+from slide2vec.artifacts import region_dense_paths, write_dense_region  # noqa: E402
 from slide2vec.data import tile_reader  # noqa: E402
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
 from slide2vec.runtime.dense_shard import (  # noqa: E402
@@ -173,6 +175,88 @@ def test_plan_dense_shards_rejects_non_positive_world_size():
 # --------------------------------------------------------------------------------------
 # Layer 2: run_dense_shard (device-agnostic encode+write loop, CPU-tested)
 # --------------------------------------------------------------------------------------
+
+
+def test_region_dense_paths_rejects_sample_id_paths(tmp_path):
+    with pytest.raises(ValueError, match="sample_id"):
+        region_dense_paths(
+            tmp_path,
+            sample_id="/tmp/outside",
+            annotation=None,
+            x=0,
+            y=0,
+        )
+
+
+def test_region_dense_paths_rejects_drive_relative_sample_id(tmp_path):
+    with pytest.raises(ValueError, match="sample_id"):
+        region_dense_paths(
+            tmp_path,
+            sample_id="C:outside",
+            annotation=None,
+            x=0,
+            y=0,
+        )
+
+
+def test_region_dense_paths_rejects_symlink_escape(tmp_path):
+    output_dir = tmp_path / "output"
+    slide_dir = output_dir / "dense_embeddings" / "slide-1"
+    outside_dir = tmp_path / "outside"
+    slide_dir.parent.mkdir(parents=True)
+    outside_dir.mkdir()
+    slide_dir.symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="output_dir"):
+        region_dense_paths(
+            output_dir,
+            sample_id="slide-1",
+            annotation=None,
+            x=0,
+            y=0,
+        )
+
+
+def test_region_dense_paths_rejects_annotation_paths(tmp_path):
+    with pytest.raises(ValueError, match="annotation"):
+        region_dense_paths(
+            tmp_path,
+            sample_id="slide-1",
+            annotation="../../outside",
+            x=0,
+            y=0,
+        )
+
+
+def test_write_dense_region_does_not_publish_interrupted_sidecar(tmp_path, monkeypatch):
+    original_write_text = Path.write_text
+
+    def _interrupted_write(path, text, *, encoding):
+        original_write_text(path, text[:1], encoding=encoding)
+        raise OSError("simulated interrupted metadata write")
+
+    monkeypatch.setattr(Path, "write_text", _interrupted_write)
+
+    with pytest.raises(OSError, match="interrupted metadata write"):
+        write_dense_region(
+            torch.zeros((2, 2, 2)),
+            output_dir=tmp_path,
+            sample_id="slide-1",
+            annotation=None,
+            x=0,
+            y=0,
+            metadata={"feature_dim": 2, "grid_shape": [2, 2]},
+        )
+
+    payload_path, sidecar_path = region_dense_paths(
+        tmp_path,
+        sample_id="slide-1",
+        annotation=None,
+        x=0,
+        y=0,
+    )
+    assert payload_path.exists()
+    assert not sidecar_path.exists()
 
 
 def _dense(**kwargs) -> DenseOptions:

--- a/tests/test_dense_shard.py
+++ b/tests/test_dense_shard.py
@@ -1,0 +1,369 @@
+"""Tests for distributed dense sharding + the CPU encode/write loop (issue #217).
+
+Three layers, top two pure and CPU-testable (D12):
+
+1. ``plan_dense_shards`` — pure ROI-granularity partition of the slide-ordered flat
+   ROI list into ``world_size`` contiguous shards (balanced ±1, deterministic).
+2. ``run_dense_shard`` — the device-agnostic encode+write loop: read each ROI, encode
+   the dense grid (reusing ``iter_regions_dense``), and write ``<x>_<y>.pt`` +
+   ``<x>_<y>.meta.json`` per ROI. Tested on CPU with a fake WSI backend
+   (``_open_wsi_backend`` monkeypatch) + a random-weight encoder.
+
+The real 4-rank equivalence check runs on CPU: world_size=1 vs 4 shards, same file
+set, grids within a per-grid cosine tolerance (docs/adr/0002).
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+
+from slide2vec.api import DenseOptions  # noqa: E402
+from slide2vec.data import tile_reader  # noqa: E402
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime.dense_shard import (  # noqa: E402
+    RegionSpec,
+    plan_dense_shards,
+    run_dense_shard,
+)
+
+
+def _encoder(**kwargs) -> TimmTileEncoder:
+    return TimmTileEncoder(
+        "vit_tiny_patch16_224", pretrained=False, num_classes=0,
+        dynamic_img_size=True, **kwargs,
+    )
+
+
+def _canned_region(location, size) -> np.ndarray:
+    """Deterministic RGB region for a location, of the requested ``(width, height)``."""
+    width, height = int(size[0]), int(size[1])
+    x, y = int(location[0]), int(location[1])
+    rng = np.random.default_rng(abs(hash((x, y))) % (2**32))
+    return rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+
+
+class _FakeBackend:
+    """Serves deterministic region arrays and records every read (both read paths)."""
+
+    def __init__(self) -> None:
+        self.read_regions_calls: list[list[tuple[int, int]]] = []
+        self.read_region_calls: list[tuple[int, int]] = []
+
+    @property
+    def locations_read(self) -> list[tuple[int, int]]:
+        flat = [loc for batch in self.read_regions_calls for loc in batch]
+        return flat + list(self.read_region_calls)
+
+    def read_regions(self, locations, level, size, num_workers):
+        locs = [(int(x), int(y)) for x, y in locations]
+        self.read_regions_calls.append(locs)
+        return [_canned_region(loc, size) for loc in locs]
+
+    def read_region(self, location, level, size):
+        loc = (int(location[0]), int(location[1]))
+        self.read_region_calls.append(loc)
+        return _canned_region(loc, size)
+
+
+class _FakeBackendFactory:
+    """Stands in for ``_open_wsi_backend``: hands out one shared fake per image path."""
+
+    def __init__(self) -> None:
+        self.open_count = 0
+        self.backends: dict[str, _FakeBackend] = {}
+
+    def __call__(self, image_path, backend, gpu_decode):
+        self.open_count += 1
+        return self.backends.setdefault(str(image_path), _FakeBackend())
+
+    @property
+    def locations_read(self) -> list[tuple[int, int]]:
+        out: list[tuple[int, int]] = []
+        for b in self.backends.values():
+            out.extend(b.locations_read)
+        return out
+
+
+@pytest.fixture
+def fake_backend(monkeypatch) -> _FakeBackendFactory:
+    factory = _FakeBackendFactory()
+    monkeypatch.setattr(tile_reader, "_open_wsi_backend", factory)
+    return factory
+
+
+def _spec(x, y, *, sample_id="s0", image_path="s0.tif", annotation=None,
+          requested=64, read=None, read_level=0, backend="cucim") -> RegionSpec:
+    return RegionSpec(
+        sample_id=sample_id,
+        image_path=image_path,
+        x=int(x),
+        y=int(y),
+        read_level=int(read_level),
+        read_tile_size_px=int(read if read is not None else requested),
+        requested_tile_size_px=int(requested),
+        backend=backend,
+        annotation=annotation,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Layer 1: plan_dense_shards (pure)
+# --------------------------------------------------------------------------------------
+
+
+def test_plan_dense_shards_partitions_exactly():
+    """Union of the shards == input, in order, with no ROI dropped or duplicated."""
+    regions = [_spec(i * 64, 0) for i in range(10)]
+    shards = plan_dense_shards(regions, 4)
+    assert len(shards) == 4
+    flat = [r for shard in shards for r in shard]
+    assert flat == regions  # order preserved, exact partition
+
+
+def test_plan_dense_shards_balanced_within_one():
+    """Shard sizes differ by at most one ROI (np.array_split balance)."""
+    regions = [_spec(i * 64, 0) for i in range(10)]
+    sizes = [len(shard) for shard in plan_dense_shards(regions, 4)]
+    assert sizes == [3, 3, 2, 2]
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_plan_dense_shards_is_contiguous_and_slide_ordered():
+    """Each shard is a contiguous slice, so a slide's ROIs stay together (few re-opens)."""
+    regions = [_spec(i * 64, 0) for i in range(10)]
+    shards = plan_dense_shards(regions, 3)
+    assert [[r.x for r in shard] for shard in shards] == [
+        [0, 64, 128, 192],
+        [256, 320, 384],
+        [448, 512, 576],
+    ]
+
+
+def test_plan_dense_shards_deterministic():
+    regions = [_spec(i * 64, 0) for i in range(7)]
+    assert [
+        [r.x for r in shard] for shard in plan_dense_shards(regions, 3)
+    ] == [[r.x for r in shard] for shard in plan_dense_shards(regions, 3)]
+
+
+def test_plan_dense_shards_world_size_one_returns_input_unchanged():
+    regions = [_spec(i * 64, 0) for i in range(5)]
+    shards = plan_dense_shards(regions, 1)
+    assert len(shards) == 1
+    assert shards[0] == regions
+
+
+def test_plan_dense_shards_allows_empty_shards_when_more_ranks_than_rois():
+    regions = [_spec(0, 0), _spec(64, 0)]
+    shards = plan_dense_shards(regions, 4)
+    assert [len(s) for s in shards] == [1, 1, 0, 0]
+
+
+def test_plan_dense_shards_rejects_non_positive_world_size():
+    with pytest.raises(ValueError):
+        plan_dense_shards([_spec(0, 0)], 0)
+
+
+# --------------------------------------------------------------------------------------
+# Layer 2: run_dense_shard (device-agnostic encode+write loop, CPU-tested)
+# --------------------------------------------------------------------------------------
+
+
+def _dense(**kwargs) -> DenseOptions:
+    return DenseOptions(spacing_um=0.5, **{"target_size": 64, **kwargs})
+
+
+def _slide_dir(out_dir, sample_id="s0", annotation=None):
+    sub = "dense_embeddings" if annotation is None else f"dense_embeddings/{annotation}"
+    return out_dir / sub / sample_id
+
+
+def test_run_dense_shard_writes_payload_and_sidecar_per_region(fake_backend, tmp_path):
+    """Completeness: N ROIs in → N ``.pt`` + N ``.meta.json`` out, zero duplicates."""
+    enc = _encoder()
+    coords = [(0, 0), (64, 0), (0, 64)]
+    regions = [_spec(x, y) for x, y in coords]
+
+    artifacts = run_dense_shard(
+        regions, model=enc, out_dir=tmp_path, dense=_dense(), batch_size=2, device="cpu",
+    )
+
+    assert len(artifacts) == 3
+    slide_dir = _slide_dir(tmp_path)
+    for (x, y), art in zip(coords, artifacts):
+        payload = slide_dir / f"{x}_{y}.pt"
+        sidecar = slide_dir / f"{x}_{y}.meta.json"
+        assert payload.exists() and sidecar.exists()
+        assert art.path == payload.resolve()
+        assert art.metadata_path == sidecar.resolve()
+        assert art.grid_shape == (4, 4)
+        assert art.feature_dim == enc.encode_dim
+        assert (art.x, art.y) == (x, y)
+    # Exactly N payloads/sidecars in the slide directory — no duplicates, no temp files.
+    assert sorted(p.name for p in slide_dir.glob("*.pt")) == ["0_0.pt", "0_64.pt", "64_0.pt"]
+    assert len(list(slide_dir.glob("*.meta.json"))) == 3
+    assert list(slide_dir.glob("*.tmp*")) == []
+
+
+def _multi_slide_regions() -> list[RegionSpec]:
+    """Two slides, seven ROIs — a 4-way split crosses the slide boundary (boundary re-open)."""
+    a = [_spec(x, y, sample_id="a", image_path="a.tif") for x, y in [(0, 0), (64, 0), (0, 64)]]
+    b = [
+        _spec(x, y, sample_id="b", image_path="b.tif")
+        for x, y in [(0, 0), (64, 0), (0, 64), (64, 64)]
+    ]
+    return a + b
+
+
+def _dense_dir_files(out_dir) -> set:
+    root = out_dir / "dense_embeddings"
+    return {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+
+
+def test_multi_rank_matches_single_rank(fake_backend, tmp_path):
+    """Equivalence (D4): 4 shards vs 1 → identical file set, grids cosine ≥ 1 − 1e-4."""
+    regions = _multi_slide_regions()
+    enc = _encoder()  # every rank loads the same checkpoint → one shared encoder here
+
+    single_dir = tmp_path / "single"
+    run_dense_shard(regions, model=enc, out_dir=single_dir, dense=_dense(),
+                    batch_size=3, device="cpu")
+
+    multi_dir = tmp_path / "multi"
+    shards = plan_dense_shards(regions, 4)
+    for shard in shards:  # ranks run the identical loop over their contiguous shard
+        run_dense_shard(shard, model=enc, out_dir=multi_dir, dense=_dense(),
+                        batch_size=3, device="cpu")
+
+    # Same set of payloads + sidecars regardless of how ROIs were sharded.
+    assert _dense_dir_files(single_dir) == _dense_dir_files(multi_dir)
+
+    for rel in _dense_dir_files(single_dir):
+        if not rel.endswith(".pt"):
+            continue
+        g1 = torch.load(single_dir / "dense_embeddings" / rel, weights_only=True).float().numpy().ravel()
+        g4 = torch.load(multi_dir / "dense_embeddings" / rel, weights_only=True).float().numpy().ravel()
+        cos = float(np.dot(g1, g4) / (np.linalg.norm(g1) * np.linalg.norm(g4) + 1e-12))
+        assert cos >= 1 - 1e-4, f"{rel}: cos={cos}"
+
+
+def test_run_dense_shard_skips_regions_with_existing_sidecar(fake_backend, tmp_path):
+    """Resume/crash-safety (D9): a ROI whose sidecar exists is not re-read or re-encoded."""
+    enc = _encoder()
+    regions = [_spec(x, y) for x, y in [(0, 0), (64, 0), (0, 64)]]
+
+    first = run_dense_shard(regions, model=enc, out_dir=tmp_path, dense=_dense(),
+                            batch_size=2, device="cpu")
+    reads_after_first = len(fake_backend.locations_read)
+
+    # Re-running with every sidecar already on disk reads nothing and still returns all N.
+    second = run_dense_shard(regions, model=enc, out_dir=tmp_path, dense=_dense(),
+                             batch_size=2, device="cpu")
+    assert len(fake_backend.locations_read) == reads_after_first  # no new reads
+    assert [(a.x, a.y) for a in second] == [(a.x, a.y) for a in first]
+    assert [a.path for a in second] == [a.path for a in first]
+
+
+def test_run_dense_shard_reencodes_payload_missing_its_sidecar(fake_backend, tmp_path):
+    """Crash-safety (D6): a ``.pt`` with no sidecar is re-encoded, never counted as done."""
+    enc = _encoder()
+    regions = [_spec(x, y) for x, y in [(0, 0), (64, 0), (0, 64)]]
+    run_dense_shard(regions, model=enc, out_dir=tmp_path, dense=_dense(),
+                    batch_size=2, device="cpu")
+
+    # Simulate a crash after the payload landed but before the sidecar: drop (64,0)'s sidecar.
+    slide_dir = _slide_dir(tmp_path)
+    (slide_dir / "64_0.meta.json").unlink()
+    reads_before = len(fake_backend.locations_read)
+
+    run_dense_shard(regions, model=enc, out_dir=tmp_path, dense=_dense(),
+                    batch_size=2, device="cpu")
+
+    new_reads = fake_backend.locations_read[reads_before:]
+    assert new_reads == [(64, 0)]  # only the incomplete ROI is re-read/re-encoded
+    assert (slide_dir / "64_0.meta.json").exists()  # sidecar restored
+
+
+def test_run_dense_shard_namespaces_annotation_subdir(fake_backend, tmp_path):
+    """A real annotation class lands under ``dense_embeddings/<class>/<sample_id>/`` (D5)."""
+    enc = _encoder()
+    regions = [_spec(0, 0, annotation="tumor"), _spec(64, 0, annotation="tumor")]
+    run_dense_shard(regions, model=enc, out_dir=tmp_path, dense=_dense(),
+                    batch_size=2, device="cpu")
+    slide_dir = _slide_dir(tmp_path, annotation="tumor")
+    assert (slide_dir / "0_0.pt").exists()
+    assert (slide_dir / "64_0.meta.json").exists()
+    assert not (tmp_path / "dense_embeddings" / "s0").exists()  # not the flat root
+
+
+def test_run_dense_shard_sidecar_records_extraction_geometry_only(fake_backend, tmp_path):
+    """The sidecar carries the extraction geometry + encode params slide2vec owns — and no
+    caller ``extra`` passthrough (D7)."""
+    enc = _encoder()
+    dense = _dense(target_size=60, window_size=32, overlap=0.25, pad_mode="reflect")
+    run_dense_shard([_spec(128, 256, requested=60)], model=enc, out_dir=tmp_path,
+                    dense=dense, batch_size=1, device="cpu")
+    meta = json.loads((_slide_dir(tmp_path) / "128_256.meta.json").read_text())
+    assert meta == {
+        "artifact_type": "dense_embeddings",
+        "sample_id": "s0",
+        "annotation": None,
+        "x": 128,
+        "y": 256,
+        "format": "pt",
+        "dtype": "float32",
+        "feature_dim": enc.encode_dim,
+        "grid_shape": [4, 4],          # 60 padded up to 64 → 4×4 tokens
+        "target_size": [60, 60],
+        "patch_size": [16, 16],
+        "encoded_size": [64, 64],
+        "pad": [4, 4],
+        "spacing_um": 0.5,
+        "tolerance": 0.05,
+        "backend": "cucim",
+        "read_level": 0,
+        "read_tile_size_px": 60,
+        "requested_tile_size_px": 60,
+        "pad_mode": "reflect",
+        "image_pad_value": None,
+        "window_size": 32,
+        "overlap": 0.25,
+        "feature_kind": "patch_features",
+        "attention_blocks": [-1],
+        "attention_include_registers": False,
+    }
+
+
+def test_run_dense_shard_supports_cls_attention_feature_kind(fake_backend, tmp_path):
+    enc = _encoder()
+    regions = [_spec(0, 0)]
+    artifacts = run_dense_shard(
+        regions, model=enc, out_dir=tmp_path, dense=_dense(feature_kind="cls_attention"),
+        batch_size=1, device="cpu",
+    )
+    assert len(artifacts) == 1
+    assert artifacts[0].grid_shape == (4, 4)
+    meta = json.loads(artifacts[0].metadata_path.read_text())
+    assert meta["feature_kind"] == "cls_attention"
+
+
+def test_run_dense_shard_spanning_two_slides_opens_each(fake_backend, tmp_path):
+    """A contiguous shard crossing a slide boundary encodes both slides into their own dirs."""
+    enc = _encoder()
+    regions = [
+        _spec(0, 0, sample_id="a", image_path="a.tif"),
+        _spec(64, 0, sample_id="a", image_path="a.tif"),
+        _spec(0, 0, sample_id="b", image_path="b.tif"),
+    ]
+    run_dense_shard(regions, model=enc, out_dir=tmp_path, dense=_dense(),
+                    batch_size=2, device="cpu")
+    assert (_slide_dir(tmp_path, "a") / "0_0.pt").exists()
+    assert (_slide_dir(tmp_path, "a") / "64_0.pt").exists()
+    assert (_slide_dir(tmp_path, "b") / "0_0.pt").exists()
+    assert set(fake_backend.backends) == {"a.tif", "b.tif"}  # both slides opened

--- a/tests/test_dense_stage.py
+++ b/tests/test_dense_stage.py
@@ -41,10 +41,12 @@ def _canned_region(location, size) -> np.ndarray:
 class _FakeBackend:
     def __init__(self) -> None:
         self.locations: list[tuple[int, int]] = []
+        self.num_workers: list[int] = []
 
     def read_regions(self, locations, level, size, num_workers):
         locs = [(int(x), int(y)) for x, y in locations]
         self.locations.extend(locs)
+        self.num_workers.append(int(num_workers))
         return [_canned_region(loc, size) for loc in locs]
 
     def read_region(self, location, level, size):
@@ -112,7 +114,12 @@ def test_embed_regions_dense_num_gpus_one_runs_in_process(fake_backend, stub_rea
         lambda **kwargs: pytest.fail("num_gpus=1 must not launch torchrun"),
     )
     model = _FakeModel(_encoder())
-    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=1, precision="fp32")
+    execution = ExecutionOptions(
+        output_dir=tmp_path,
+        num_gpus=1,
+        num_workers_per_gpu=7,
+        precision="fp32",
+    )
 
     artifacts = dense_stage.embed_regions_dense(
         model, [_regions()], dense=_dense(), execution=execution,
@@ -124,6 +131,7 @@ def test_embed_regions_dense_num_gpus_one_runs_in_process(fake_backend, stub_rea
     for art in artifacts:
         assert art.metadata_path.exists()
         assert art.grid_shape == (4, 4)
+    assert {num_workers for backend in fake_backend.values() for num_workers in backend.num_workers} == {7}
 
 
 def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend, stub_read_plan, tmp_path, monkeypatch):
@@ -133,6 +141,9 @@ def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend,
     from slide2vec.runtime.dense_shard import plan_dense_shards, run_dense_shard
     from slide2vec.runtime.serialization import deserialize_dense_options
 
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    monkeypatch.chdir(caller_dir)
     captured = {}
     rank_encoder = _encoder()  # every rank loads the same checkpoint
 
@@ -140,7 +151,14 @@ def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend,
         request = json.loads(Path(request_path).read_text())
         with np.load(request["coordinates_npz_path"], allow_pickle=False) as payload:
             coords = np.asarray(payload["coordinates"])
-        captured.update(module=module, num_gpus=num_gpus, request=request, coords=coords)
+        captured.update(
+            module=module,
+            num_gpus=num_gpus,
+            output_dir=output_dir,
+            request_path=request_path,
+            request=request,
+            coords=coords,
+        )
         # Simulate the ranks: rebuild the flat specs, shard, encode each shard on CPU.
         specs = dense_stage.region_specs_from_request(request)
         dense = deserialize_dense_options(request["dense"])
@@ -156,7 +174,7 @@ def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend,
         lambda *a, **k: pytest.fail("num_gpus>1 must not encode in-process"),
     )
     model = _FakeModel(_encoder())
-    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=3, precision="fp32")
+    execution = ExecutionOptions(output_dir=Path("output"), num_gpus=3, precision="fp32")
 
     artifacts = dense_stage.embed_regions_dense(
         model,
@@ -166,14 +184,19 @@ def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend,
 
     assert captured["module"] == "slide2vec.distributed.dense_worker"
     assert captured["num_gpus"] == 3
+    expected_output_dir = (caller_dir / "output").resolve()
+    assert Path(captured["output_dir"]) == expected_output_dir
+    assert Path(captured["request_path"]).is_absolute()
+    assert captured["request"]["execution"]["output_dir"] == str(expected_output_dir)
+    assert all(Path(slide["image_path"]).is_absolute() for slide in captured["request"]["slides"])
     # All three ROIs travelled to the npz, slide-ordered.
     assert captured["coords"].tolist() == [[0, 0], [64, 0], [0, 0]]
     assert [s["sample_id"] for s in captured["request"]["slides"]] == ["s0", "s1"]
     assert captured["request"]["dense"]["target_size"] == 64
     # Collection returns one artifact per input ROI, read back off disk (nobody gathered grids).
     assert len(artifacts) == 3
-    assert (tmp_path / "dense_embeddings" / "s0" / "0_0.pt").exists()
-    assert (tmp_path / "dense_embeddings" / "s1" / "0_0.pt").exists()
+    assert (expected_output_dir / "dense_embeddings" / "s0" / "0_0.pt").exists()
+    assert (expected_output_dir / "dense_embeddings" / "s1" / "0_0.pt").exists()
 
 
 def test_embed_regions_dense_resume_skips_existing_and_logs(fake_backend, stub_read_plan, tmp_path, caplog):

--- a/tests/test_dense_stage.py
+++ b/tests/test_dense_stage.py
@@ -1,0 +1,251 @@
+"""Tests for the parent-side dense orchestration (issue #217, layer 3 glue).
+
+``embed_regions_dense`` flattens the caller's ``SlideRegions`` into the slide-ordered flat
+ROI list, resume-filters it (D9), resolves each slide's read plan once, then either runs the
+encode/write loop in-process (``num_gpus=1``) or fans it out over torchrun ranks
+(``num_gpus>1``). These tests run on CPU: the WSI reads go through the fake
+``_open_wsi_backend`` seam, the per-slide read-plan resolution is stubbed (no real slide), and
+the torchrun launch is captured rather than executed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+
+from slide2vec.api import DenseOptions, ExecutionOptions, SlideRegions  # noqa: E402
+from slide2vec.data import tile_reader  # noqa: E402
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime import dense_stage  # noqa: E402
+
+
+def _encoder() -> TimmTileEncoder:
+    return TimmTileEncoder("vit_tiny_patch16_224", pretrained=False, num_classes=0,
+                           dynamic_img_size=True)
+
+
+def _canned_region(location, size) -> np.ndarray:
+    width, height = int(size[0]), int(size[1])
+    x, y = int(location[0]), int(location[1])
+    rng = np.random.default_rng(abs(hash((x, y))) % (2**32))
+    return rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+
+
+class _FakeBackend:
+    def __init__(self) -> None:
+        self.locations: list[tuple[int, int]] = []
+
+    def read_regions(self, locations, level, size, num_workers):
+        locs = [(int(x), int(y)) for x, y in locations]
+        self.locations.extend(locs)
+        return [_canned_region(loc, size) for loc in locs]
+
+    def read_region(self, location, level, size):
+        loc = (int(location[0]), int(location[1]))
+        self.locations.append(loc)
+        return _canned_region(loc, size)
+
+
+@pytest.fixture
+def fake_backend(monkeypatch):
+    backends: dict[str, _FakeBackend] = {}
+
+    def _open(image_path, backend, gpu_decode):
+        return backends.setdefault(str(image_path), _FakeBackend())
+
+    monkeypatch.setattr(tile_reader, "_open_wsi_backend", _open)
+    return backends
+
+
+@pytest.fixture
+def stub_read_plan(monkeypatch):
+    """Stub per-slide read-plan resolution so no real slide is opened for metadata."""
+    monkeypatch.setattr(
+        dense_stage, "resolve_slide_read_plan",
+        lambda image_path, dense: (0, int(dense.target_size), "cucim"),
+    )
+
+
+class _FakeModel:
+    """Minimal Model stand-in exposing what the in-process dense path reads."""
+
+    def __init__(self, encoder, device="cpu") -> None:
+        self._encoder = encoder
+        self._device = device
+        self.name = "fake-encoder"
+        self._output_variant = None
+        self._requested_device = device
+        self.allow_non_recommended_settings = False
+
+    def _load_backend(self):
+        return SimpleNamespace(model=self._encoder, device=self._device)
+
+    @property
+    def device(self):
+        return self._device
+
+
+def _regions(sample_id="s0", image_path="s0.tif", coords=((0, 0), (64, 0), (0, 64)),
+             annotation=None) -> SlideRegions:
+    return SlideRegions(
+        sample_id=sample_id, image_path=image_path,
+        coordinates=np.asarray(coords, dtype=np.int64), annotation=annotation,
+    )
+
+
+def _dense(**kwargs) -> DenseOptions:
+    return DenseOptions(spacing_um=0.5, **{"target_size": 64, **kwargs})
+
+
+def test_embed_regions_dense_num_gpus_one_runs_in_process(fake_backend, stub_read_plan, tmp_path, monkeypatch):
+    """``num_gpus=1`` encodes in-process — no torchrun subprocess — and writes every ROI."""
+    # Any attempt to launch torchrun in the single-GPU path is a bug.
+    monkeypatch.setattr(
+        dense_stage, "run_torchrun_worker",
+        lambda **kwargs: pytest.fail("num_gpus=1 must not launch torchrun"),
+    )
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=1, precision="fp32")
+
+    artifacts = dense_stage.embed_regions_dense(
+        model, [_regions()], dense=_dense(), execution=execution,
+    )
+
+    assert len(artifacts) == 3
+    slide_dir = tmp_path / "dense_embeddings" / "s0"
+    assert sorted(p.name for p in slide_dir.glob("*.pt")) == ["0_0.pt", "0_64.pt", "64_0.pt"]
+    for art in artifacts:
+        assert art.metadata_path.exists()
+        assert art.grid_shape == (4, 4)
+
+
+def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend, stub_read_plan, tmp_path, monkeypatch):
+    """``num_gpus>1`` launches ``slide2vec.distributed.dense_worker`` under torchrun, handing
+    it the coordinates as an npz (D10b) — the parent itself encodes nothing. The fake torchrun
+    stands in for the ranks (reconstruct specs → shard → encode) so collection sees N grids."""
+    from slide2vec.runtime.dense_shard import plan_dense_shards, run_dense_shard
+    from slide2vec.runtime.serialization import deserialize_dense_options
+
+    captured = {}
+    rank_encoder = _encoder()  # every rank loads the same checkpoint
+
+    def _fake_run(*, module, num_gpus, output_dir, request_path, **kwargs):
+        request = json.loads(Path(request_path).read_text())
+        with np.load(request["coordinates_npz_path"], allow_pickle=False) as payload:
+            coords = np.asarray(payload["coordinates"])
+        captured.update(module=module, num_gpus=num_gpus, request=request, coords=coords)
+        # Simulate the ranks: rebuild the flat specs, shard, encode each shard on CPU.
+        specs = dense_stage.region_specs_from_request(request)
+        dense = deserialize_dense_options(request["dense"])
+        for shard in plan_dense_shards(specs, num_gpus):
+            run_dense_shard(shard, model=rank_encoder, out_dir=Path(output_dir), dense=dense,
+                            batch_size=2, device="cpu")
+
+    monkeypatch.setattr(dense_stage, "run_torchrun_worker", _fake_run)
+    monkeypatch.setattr(dense_stage, "validate_multi_gpu_execution", lambda *a, **k: None)
+    # No in-process encode may happen on the multi-GPU path.
+    monkeypatch.setattr(
+        dense_stage, "_run_dense_in_process",
+        lambda *a, **k: pytest.fail("num_gpus>1 must not encode in-process"),
+    )
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=3, precision="fp32")
+
+    artifacts = dense_stage.embed_regions_dense(
+        model,
+        [_regions(coords=((0, 0), (64, 0))), _regions(sample_id="s1", image_path="s1.tif", coords=((0, 0),))],
+        dense=_dense(), execution=execution,
+    )
+
+    assert captured["module"] == "slide2vec.distributed.dense_worker"
+    assert captured["num_gpus"] == 3
+    # All three ROIs travelled to the npz, slide-ordered.
+    assert captured["coords"].tolist() == [[0, 0], [64, 0], [0, 0]]
+    assert [s["sample_id"] for s in captured["request"]["slides"]] == ["s0", "s1"]
+    assert captured["request"]["dense"]["target_size"] == 64
+    # Collection returns one artifact per input ROI, read back off disk (nobody gathered grids).
+    assert len(artifacts) == 3
+    assert (tmp_path / "dense_embeddings" / "s0" / "0_0.pt").exists()
+    assert (tmp_path / "dense_embeddings" / "s1" / "0_0.pt").exists()
+
+
+def test_embed_regions_dense_resume_skips_existing_and_logs(fake_backend, stub_read_plan, tmp_path, caplog):
+    """Resume (D9): pre-existing ROIs are filtered before dispatch; the skip count is logged."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=1, precision="fp32")
+
+    dense_stage.embed_regions_dense(model, [_regions(coords=((0, 0), (64, 0)))],
+                                    dense=_dense(), execution=execution)
+    reads_after_first = sum(len(b.locations) for b in fake_backend.values())
+
+    with caplog.at_level("INFO", logger="slide2vec.runtime.dense_stage"):
+        artifacts = dense_stage.embed_regions_dense(
+            model, [_regions(coords=((0, 0), (64, 0), (0, 64)))], dense=_dense(), execution=execution,
+        )
+
+    assert len(artifacts) == 3
+    reads_after_second = sum(len(b.locations) for b in fake_backend.values())
+    assert reads_after_second - reads_after_first == 1  # only the one new ROI is read
+    assert "2/3 regions already on disk, encoding 1" in caplog.text
+
+
+def test_embed_regions_dense_all_present_does_not_dispatch(fake_backend, stub_read_plan, tmp_path, monkeypatch):
+    """A fully-resumed run encodes nothing (no in-process encode, no torchrun) yet returns all N."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path, num_gpus=1, precision="fp32")
+    dense_stage.embed_regions_dense(model, [_regions()], dense=_dense(), execution=execution)
+
+    monkeypatch.setattr(dense_stage, "_run_dense_in_process",
+                        lambda *a, **k: pytest.fail("nothing to encode"))
+    monkeypatch.setattr(dense_stage, "run_torchrun_worker",
+                        lambda **k: pytest.fail("nothing to encode"))
+    artifacts = dense_stage.embed_regions_dense(model, [_regions()], dense=_dense(), execution=execution)
+    assert len(artifacts) == 3
+
+
+def test_model_embed_regions_dense_delegates_and_requires_output_dir(monkeypatch, tmp_path):
+    """The public API coerces execution, requires an output dir, and delegates to the stage."""
+    import slide2vec.runtime.dense_stage as stage_mod
+    from slide2vec.api import Model
+
+    seen = {}
+
+    def _fake_stage(model, regions, *, dense, execution):
+        seen.update(model=model, regions=regions, dense=dense, execution=execution)
+        return ["artifact"]
+
+    monkeypatch.setattr(stage_mod, "embed_regions_dense", _fake_stage)
+    model = Model(name="virchow2")  # constructing a Model does not load weights
+
+    # Missing output_dir is rejected up front, before any work.
+    with pytest.raises(ValueError):
+        model.embed_regions_dense([_regions()], dense=_dense(), execution=ExecutionOptions(num_gpus=1))
+
+    result = model.embed_regions_dense(
+        [_regions()], dense=_dense(), execution=ExecutionOptions(output_dir=tmp_path, num_gpus=1),
+    )
+    assert result == ["artifact"]
+    assert seen["model"] is model
+    assert seen["execution"].output_dir == tmp_path
+
+
+def test_region_specs_round_trip_through_request(tmp_path):
+    """The npz + request rebuild the exact flat spec list the parent sharded (worker inverse)."""
+    from slide2vec.runtime.dense_shard import RegionSpec
+
+    specs = [
+        RegionSpec("s0", "s0.tif", 0, 0, 0, 64, 64, "cucim", None),
+        RegionSpec("s0", "s0.tif", 64, 0, 0, 64, 64, "cucim", None),
+        RegionSpec("s1", "s1.tif", 10, 20, 1, 96, 64, "cucim", "tumor"),
+    ]
+    request = dense_stage.build_dense_worker_request(
+        specs, coordinates_npz_path=tmp_path / "coords.npz"
+    )
+    assert dense_stage.region_specs_from_request(request) == specs

--- a/tests/test_dense_worker.py
+++ b/tests/test_dense_worker.py
@@ -1,0 +1,94 @@
+"""Smoke test for the torchrun dense worker entry (issue #217, layer 3).
+
+The worker is deliberately near logic-free: read ``RANK`` / ``WORLD_SIZE`` from the env (no
+NCCL), load the JSON request + coordinates npz, then call the two CPU-tested layers. This
+exercises that wiring on CPU — env-driven rank selection, request/npz decode, and the fact
+that a rank only encodes its own contiguous shard — with the model load and WSI reads faked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+
+import slide2vec.api as api  # noqa: E402
+from slide2vec.api import DenseOptions, ExecutionOptions  # noqa: E402
+from slide2vec.data import tile_reader  # noqa: E402
+from slide2vec.distributed import dense_worker  # noqa: E402
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime import dense_stage  # noqa: E402
+from slide2vec.runtime.dense_shard import RegionSpec  # noqa: E402
+from slide2vec.runtime.serialization import (  # noqa: E402
+    serialize_dense_options,
+    serialize_execution,
+)
+
+
+def _canned_region(location, size) -> np.ndarray:
+    width, height = int(size[0]), int(size[1])
+    x, y = int(location[0]), int(location[1])
+    rng = np.random.default_rng(abs(hash((x, y))) % (2**32))
+    return rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+
+
+class _FakeBackend:
+    def __init__(self) -> None:
+        self.locations: list[tuple[int, int]] = []
+
+    def read_regions(self, locations, level, size, num_workers):
+        locs = [(int(x), int(y)) for x, y in locations]
+        self.locations.extend(locs)
+        return [_canned_region(loc, size) for loc in locs]
+
+    def read_region(self, location, level, size):
+        loc = (int(location[0]), int(location[1]))
+        self.locations.append(loc)
+        return _canned_region(loc, size)
+
+
+def test_dense_worker_encodes_only_its_rank_shard(monkeypatch, tmp_path):
+    backends: dict[str, _FakeBackend] = {}
+    monkeypatch.setattr(
+        tile_reader, "_open_wsi_backend",
+        lambda image_path, backend, gpu_decode: backends.setdefault(str(image_path), _FakeBackend()),
+    )
+
+    encoder = TimmTileEncoder("vit_tiny_patch16_224", pretrained=False, num_classes=0,
+                              dynamic_img_size=True)
+    monkeypatch.setattr(
+        api.Model, "from_preset",
+        classmethod(lambda cls, name, **kwargs: SimpleNamespace(
+            _load_backend=lambda: SimpleNamespace(model=encoder, device="cpu"))),
+    )
+
+    specs = [RegionSpec("s0", "s0.tif", i * 64, 0, 0, 64, 64, "cucim", None) for i in range(4)]
+    request = {
+        "model": {"name": "fake", "output_variant": None, "allow_non_recommended_settings": False},
+        "dense": serialize_dense_options(DenseOptions(spacing_um=0.5, target_size=64)),
+        "execution": serialize_execution(ExecutionOptions(output_dir=tmp_path, num_gpus=2, precision="fp32", batch_size=2)),
+        "output_dir": str(tmp_path),
+        "progress_events_path": None,
+        **dense_stage.build_dense_worker_request(specs, coordinates_npz_path=tmp_path / "coords.npz"),
+    }
+    request_path = tmp_path / "dense_request.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    # World of 2 ranks: plan_dense_shards([0,1,2,3], 2) => rank 1 owns ROIs [2, 3].
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+
+    rc = dense_worker.main(["--output-dir", str(tmp_path), "--request-path", str(request_path)])
+    assert rc == 0
+
+    slide_dir = tmp_path / "dense_embeddings" / "s0"
+    assert sorted(p.name for p in slide_dir.glob("*.pt")) == ["128_0.pt", "192_0.pt"]
+    # This rank read only its own shard's coordinates.
+    assert backends["s0.tif"].locations == [(128, 0), (192, 0)]

--- a/tests/test_hs2p_package_cutover.py
+++ b/tests/test_hs2p_package_cutover.py
@@ -17,6 +17,9 @@ def test_package_root_exports_api():
     assert hasattr(package, "EmbeddedSlide")
     assert hasattr(package, "TileEmbeddingArtifact")
     assert hasattr(package, "SlideEmbeddingArtifact")
+    assert hasattr(package, "DenseOptions")
+    assert hasattr(package, "SlideRegions")
+    assert hasattr(package, "DenseRegionArtifact")
 
 
 def test_load_slide_manifest_requires_hs2p_schema(tmp_path: Path):


### PR DESCRIPTION
## Summary

Adds first-class distributed extraction for dense `(d, gh, gw)` feature grids over caller-supplied WSI regions. ROIs are split across visible GPUs; each rank writes its final grids directly, avoiding a parent gather for artifacts that are roughly 1000× larger than pooled embeddings.

This is the slide2vec prerequisite for soma #279. Scope is Python-only: no CLI, YAML, or manifest changes.

## Architecture

1. **Parent orchestration** flattens `SlideRegions`, filters completed ROIs before sharding, resolves each slide's spacing-aware read plan once, and dispatches in-process for `num_gpus=1` or through torchrun for multiple GPUs.
2. **`plan_dense_shards`** performs deterministic, contiguous ROI-level `np.array_split`, balanced to ±1 ROI. No batch alignment is needed because features depend on batch size, not batch composition ([ADR 0002](../blob/main/docs/adr/0002-features-are-reproducible-to-a-tolerance.md)).
3. **`run_dense_shard`** groups consecutive ROIs by slide, reuses `iter_regions_dense` for batched reads and encoding, and persists one payload plus sidecar per ROI.
4. **`dense_worker`** reads `RANK`, `WORLD_SIZE`, and `LOCAL_RANK` from torchrun, loads coordinates from NPZ, and runs its shard without NCCL or process-group initialization.

Ranks persist dense artifacts directly; nobody gathers grids in the parent ([ADR 0001](../blob/main/docs/adr/0001-slide2vec-owns-dense-persistence.md)).

## Public interface and artifacts

```python
from slide2vec import DenseOptions, DenseRegionArtifact, ExecutionOptions, SlideRegions

artifacts: list[DenseRegionArtifact] = model.embed_regions_dense(
    regions,
    dense=DenseOptions(...),
    execution=ExecutionOptions(...),
)
```

Artifact layout:

```text
dense_embeddings/[<class>/]<sample_id>/<x>_<y>.pt
dense_embeddings/[<class>/]<sample_id>/<x>_<y>.meta.json
```

Sidecars contain extraction geometry and encoding parameters owned by slide2vec; downstream supervision metadata remains downstream.

## Reliability and safety

- Payloads and sidecars are published atomically, with the sidecar last as the completion marker.
- Resume filtering happens before sharding; payloads without sidecars are re-encoded.
- Output, request, and slide paths are absolute before workers change `cwd`.
- Sample IDs and annotations are validated as path components, including Windows drive-relative paths, and resolved artifact paths must remain within `output_dir` even through existing symlinks.
- Both single- and multi-GPU paths honor `num_workers_per_gpu`.

## Verification

| Behavior | Proof |
| --- | --- |
| Exact, balanced, deterministic partition | `test_plan_dense_shards_*` |
| N ROIs → N payloads + sidecars | `test_run_dense_shard_writes_payload_and_sidecar_per_region` |
| Multi-rank equivalence within cosine tolerance | `test_multi_rank_matches_single_rank` |
| Resume and crash recovery | `test_run_dense_shard_skips_regions_with_existing_sidecar`, `test_run_dense_shard_reencodes_payload_missing_its_sidecar`, `test_write_dense_region_does_not_publish_interrupted_sidecar` |
| Single-GPU in-process execution and worker count | `test_embed_regions_dense_num_gpus_one_runs_in_process` |
| Torchrun fan-out, NPZ coordinates, and absolute worker paths | `test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker`, `test_dense_worker_encodes_only_its_rank_shard`, `test_region_specs_round_trip_through_request` |
| Artifact containment and public exports | `test_region_dense_paths_rejects_*`, `test_package_root_exports_api` |

## Test result

`python -m pytest --no-cov -q -m "not heavy"`: **496 passed, 1 skipped, 25 deselected**.

Final structured review: **clean, no actionable findings**.

Near-linear speedup remains a manual multi-GPU acceptance check because CI has no GPU.

Closes #217