### PR TITLE
Unwrap gigapath slide-encoder list output before squeeze

### DIFF
--- a/slide2vec/encoders/models/gigapath.py
+++ b/slide2vec/encoders/models/gigapath.py
@@ -117,4 +117,9 @@ class GigaPathSlideEncoder(SlideEncoder):
             tile_features = tile_features.unsqueeze(0)
         if coordinates.ndim == 2:
             coordinates = coordinates.unsqueeze(0)
-        return self._model(tile_features, coordinates).squeeze(0)
+        # gigapath_slide_enc12l768d.forward always returns a list of per-layer
+        # embeddings (a single element when all_layer_embed is False); the final
+        # slide embedding is the last layer, matching prov-gigapath's own usage.
+        outputs = self._model(tile_features, coordinates)
+        slide_embedding = outputs[-1] if isinstance(outputs, (list, tuple)) else outputs
+        return slide_embedding.squeeze(0)


### PR DESCRIPTION
## Problem

Running the `gigapath-slide` encoder crashes in `encode_slide`:

```
File ".../slide2vec/encoders/models/gigapath.py", line 120, in encode_slide
    return self._model(tile_features, coordinates).squeeze(0)
AttributeError: 'list' object has no attribute 'squeeze'
```

This is specific to `gigapath-slide` because it's the only encoder that calls into prov-gigapath's slide-encoder forward pass.

## Cause

`gigapath_slide_enc12l768d.forward` **always returns a Python `list`** of per-layer embeddings — even with the default `all_layer_embed=False`, where the list holds a single element (the final slide embedding). The code called `.squeeze(0)` directly on that list.

## Fix

Take the last layer's embedding before squeezing the batch dim, matching prov-gigapath's own `last_layer_embed = slide_embeds[-1]` usage:

```python
outputs = self._model(tile_features, coordinates)
slide_embedding = outputs[-1] if isinstance(outputs, (list, tuple)) else outputs
return slide_embedding.squeeze(0)
```

The `isinstance` guard keeps it working if a future/variant model returns a bare tensor.

## Verification

Exercised `encode_slide` with a stub model mirroring the real forward (returns `[tensor]` of shape `[N, 768]`, `N=1`) and a 2-D `[num_tiles, 1536]` feature input. It now returns a 1-D `[768]` tensor as expected.