### PR TITLE
align with hs2p 4.3.0

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,7 +27,7 @@ PreprocessingConfig
    :members:
    :undoc-members:
    :no-index:
-   :exclude-members: from_config, with_backend
+   :exclude-members: from_config, with_backend, with_mask_backend
 
 For a full breakdown of backends, segmentation methods, and preview options,
 see :doc:`preprocessing`.

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -7,7 +7,7 @@ and how to configure them.
 .. autoclass:: slide2vec.PreprocessingConfig
    :members:
    :undoc-members:
-   :exclude-members: from_config, with_backend
+   :exclude-members: from_config, with_backend, with_mask_backend
 
 
 Backends
@@ -20,6 +20,14 @@ The ``backend`` field controls which slide-reading library is used:
 - ``"openslide"`` — broad format support, CPU-only
 - ``"vips"`` — libvips, good for large TIFF files
 - ``"asap"`` — ASAP reader (requires separate installation)
+
+The ``mask_backend`` field (hs2p ≥ 4.3.0) controls the reader used for **source masks**
+— precomputed tissue masks and annotation masks — and accepts the same values. It is
+resolved independently from the *mask* path, so a mask can use a different decoder than its
+slide. Since hs2p no longer silently falls back to another reader, set ``mask_backend``
+explicitly (e.g. ``"openslide"``) when a mask cannot be decoded by the slide backend — for
+example a deflate-compressed label TIFF that cuCIM can open but not decode. It defaults to
+``"auto"`` and is ignored for slides with no source mask.
 
 
 Pooled Tile Geometry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.2.0",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.3.0",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -88,7 +88,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.2.0",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.3.0",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -103,6 +103,13 @@ class PreprocessingConfig:
     #: Slide reading backend. ``"auto"`` tries cucim → openslide → vips in order.
     #: Explicit choices: ``"cucim"``, ``"openslide"``, ``"vips"``, ``"asap"``.
     backend: str = "auto"
+    #: Source-mask reading backend, resolved independently from the *mask* path
+    #: (hs2p ≥ 4.3.0). ``"auto"`` probes openability just like :attr:`backend`. Set this
+    #: explicitly (e.g. ``"openslide"``) when a precomputed tissue or annotation mask needs
+    #: a different decoder than its slide — hs2p no longer silently falls back to another
+    #: reader, so a mask the slide backend cannot decode fails unless overridden here.
+    #: Accepts the same values as :attr:`backend`; ignored for slides with no source mask.
+    mask_backend: str = "auto"
     #: Target spacing in µm/px. Resolved from the model preset when ``None``.
     requested_spacing_um: float | None = None
     #: Tile side length in pixels at *requested_spacing_um*.
@@ -183,6 +190,7 @@ class PreprocessingConfig:
         region_tile_multiple = getattr(tiling.params, "region_tile_multiple", None)
         return cls(
             backend=tiling.backend,
+            mask_backend=getattr(tiling, "mask_backend", "auto"),
             requested_spacing_um=float(tiling.params.requested_spacing_um),
             requested_tile_size_px=int(tiling.params.requested_tile_size_px),
             requested_region_size_px=int(region_size_px) if region_size_px is not None else None,
@@ -209,6 +217,9 @@ class PreprocessingConfig:
 
     def with_backend(self, backend: str) -> "PreprocessingConfig":
         return replace(self, backend=backend)
+
+    def with_mask_backend(self, mask_backend: str) -> "PreprocessingConfig":
+        return replace(self, mask_backend=mask_backend)
 
 
 

--- a/slide2vec/configs/default.yaml
+++ b/slide2vec/configs/default.yaml
@@ -26,6 +26,7 @@ tiling:
   read_coordinates_from: # path to an existing directory containing pre-extracted `.coordinates.npz` / `.coordinates.meta.json` artifacts to reuse instead of starting tiling from scratch
   read_tiles_from: # path to an existing directory containing pre-extracted `.tiles.tar` tile stores to reuse instead of starting tiling from scratch
   backend: "auto" # backend to use for slide reading; "auto" lets hs2p resolve the best backend per slide, preferring cuCIM when available
+  mask_backend: "auto" # backend for reading source masks (precomputed tissue / annotation), resolved independently from the mask path; "auto" probes openability like `backend`. Set explicitly (e.g. "openslide") when a mask needs a different decoder than its slide — hs2p (>=4.3.0) no longer silently falls back
   independent_sampling: true # selection strategy when annotation sampling is active. true: sample each class independently against its own binary mask (independent selection); false: sample once over the union of active classes, then post-filter per class by coverage (joint selection). Ignored when the masks vocabulary is left at the tissue-only default.
   masks:
     # Annotation-mask vocabulary forwarded to hs2p's sampling resolver. The shipped default

--- a/slide2vec/progress.py
+++ b/slide2vec/progress.py
@@ -75,6 +75,29 @@ def _format_backend_selected_message(payload: dict[str, Any]) -> str:
     return f"[backend] {payload['sample_id']}: using {payload['backend']}"
 
 
+def _format_mask_backend_selected_message(payload: dict[str, Any]) -> str:
+    sample_id = payload["sample_id"]
+    mask_path = payload.get("mask_path")
+    reason = payload.get("reason")
+    if reason:
+        return f"[mask backend] {sample_id} ({mask_path}): {reason}"
+    return f"[mask backend] {sample_id} ({mask_path}): using {payload['backend']}"
+
+
+def _empty_masks_suffix(payload: dict[str, Any]) -> str:
+    """Render ``, empty_masks=N`` only when a precomputed mask resolved empty (N > 0).
+
+    hs2p (>=4.3.0) folds the running ``empty_masks`` count into its tissue/tiling progress
+    payloads and forwards them verbatim through the bridge. Zero is the common path, so we
+    stay silent then and surface the count only when there is something to flag.
+    """
+    try:
+        count = int(payload.get("empty_masks", 0))
+    except (TypeError, ValueError):
+        return ""
+    return f", empty_masks={count}" if count > 0 else ""
+
+
 class PlainTextCliProgressReporter:
     def __init__(self, *, stream=None) -> None:
         self.stream = stream or sys.stdout
@@ -111,12 +134,12 @@ class PlainTextCliProgressReporter:
         if kind == "tissue.progress":
             return (
                 f"Tissue resolution: {payload['completed']}/{payload['total']} complete, "
-                f"{payload['failed']} failed"
+                f"{payload['failed']} failed{_empty_masks_suffix(payload)}"
             )
         if kind == "tissue.finished":
             return (
                 f"Tissue resolution finished: {payload['completed']}/{payload['total']} complete, "
-                f"{payload['failed']} failed"
+                f"{payload['failed']} failed{_empty_masks_suffix(payload)}"
             )
         if kind == "tiling.started":
             return f"Tiling slides ({payload['slide_count']} total)..."
@@ -129,6 +152,7 @@ class PlainTextCliProgressReporter:
             return (
                 f"Tiling finished: {payload['completed']}/{payload['total']} complete, "
                 f"{payload['failed']} failed, {payload['discovered_tiles']} tiles"
+                f"{_empty_masks_suffix(payload)}"
             )
         if kind == "tiling.summary":
             return (
@@ -189,6 +213,8 @@ class PlainTextCliProgressReporter:
             )
         if kind == "backend.selected":
             return _format_backend_selected_message(payload)
+        if kind == "mask_backend.selected":
+            return _format_mask_backend_selected_message(payload)
         if kind == "run.finished":
             return f"Run finished successfully. Logs: {payload['logs_dir']}"
         if kind == "run.failed":
@@ -254,7 +280,8 @@ class RichCliProgressReporter:
                     task_id,
                     completed=payload["completed"] + payload["failed"],
                     description=(
-                        f"Resolving tissue masks ({payload['completed']}/{payload['total']} resolved)"
+                        f"Resolving tissue masks ({payload['completed']}/{payload['total']} resolved"
+                        f"{_empty_masks_suffix(payload)})"
                     ),
                 )
             return
@@ -264,7 +291,7 @@ class RichCliProgressReporter:
                 self.progress.remove_task(task_id)
             self.progress.print(
                 f"Tissue resolution finished: {payload['completed']}/{payload['total']} complete, "
-                f"{payload['failed']} failed"
+                f"{payload['failed']} failed{_empty_masks_suffix(payload)}"
             )
             return
         if kind == "tiling.started":
@@ -469,6 +496,9 @@ class RichCliProgressReporter:
             return
         if kind == "backend.selected":
             self.console.print(_format_backend_selected_message(payload))
+            return
+        if kind == "mask_backend.selected":
+            self.console.print(_format_mask_backend_selected_message(payload))
             return
         if kind == "run.finished":
             self._print_summary(

--- a/slide2vec/progress.py
+++ b/slide2vec/progress.py
@@ -316,6 +316,13 @@ class RichCliProgressReporter:
             if task_id is not None:
                 self.progress.remove_task(task_id)
                 self._task_ids.pop("tiling", None)
+            empty_masks_suffix = _empty_masks_suffix(payload)
+            if empty_masks_suffix:
+                self.progress.print(
+                    f"Tiling finished: {payload['completed']}/{payload['total']} complete, "
+                    f"{payload['failed']} failed, {payload['discovered_tiles']} tiles"
+                    f"{empty_masks_suffix}"
+                )
             return
         if kind == "tiling.summary":
             self._print_summary(

--- a/slide2vec/runtime/progress_bridge.py
+++ b/slide2vec/runtime/progress_bridge.py
@@ -10,6 +10,7 @@ from slide2vec.progress import (
 
 _BRIDGED_HS2P_PROGRESS_KINDS = {
     "backend.selected",
+    "mask_backend.selected",
     "tissue.started",
     "tissue.progress",
     "tissue.finished",

--- a/slide2vec/runtime/serialization.py
+++ b/slide2vec/runtime/serialization.py
@@ -18,6 +18,7 @@ def serialize_model(model) -> dict[str, Any]:
 def serialize_preprocessing(preprocessing: PreprocessingConfig) -> dict[str, Any]:
     return {
         "backend": preprocessing.backend,
+        "mask_backend": preprocessing.mask_backend,
         "requested_spacing_um": preprocessing.requested_spacing_um,
         "requested_tile_size_px": preprocessing.requested_tile_size_px,
         "requested_region_size_px": preprocessing.requested_region_size_px,
@@ -114,6 +115,7 @@ def deserialize_preprocessing(payload: dict[str, Any]) -> PreprocessingConfig:
     )
     return PreprocessingConfig(
         backend=payload["backend"],
+        mask_backend=payload.get("mask_backend", "auto"),
         requested_spacing_um=float(payload["requested_spacing_um"]),
         requested_tile_size_px=int(payload["requested_tile_size_px"]),
         requested_region_size_px=(

--- a/slide2vec/runtime/tiling.py
+++ b/slide2vec/runtime/tiling.py
@@ -60,6 +60,10 @@ def build_hs2p_configs(
             ),
             independent_sampling=preprocessing.independent_sampling,
             backend=resolve_tiling_backend(preprocessing),
+            # Mask backend is resolved independently from the mask path by hs2p; pass the
+            # requested value straight through (default "auto"). Unlike the slide backend it
+            # has no "asap" fallback — a maskless slide simply never resolves it.
+            mask_backend=preprocessing.mask_backend,
         )
     )
     tiling_cfg = resolve_tiling_config(tiling_adapter)

--- a/slide2vec/utils/tiling_io.py
+++ b/slide2vec/utils/tiling_io.py
@@ -62,6 +62,8 @@ BASE_TILING_ORDERED_COLUMNS = (
     "mask_path",
     "requested_backend",
     "backend",
+    "requested_mask_backend",
+    "mask_backend",
     "spacing_at_level_0",
     "tiling_status",
     "num_tiles",
@@ -80,6 +82,8 @@ BASE_EMBEDDING_ORDERED_COLUMNS = (
     "mask_path",
     "requested_backend",
     "backend",
+    "requested_mask_backend",
+    "mask_backend",
     "spacing_at_level_0",
     "tiling_status",
     "num_tiles",
@@ -187,6 +191,13 @@ def _load_base_process_df(process_list_path: str | Path) -> pd.DataFrame:
         )
     if "spacing_at_level_0" not in df.columns:
         df["spacing_at_level_0"] = [None] * len(df)
+    # Mask-role backend provenance (hs2p >= 4.3.0). Not in BASE_PROCESS_COLUMNS so process
+    # lists produced by older hs2p still load; backfilled to None here so the ordered views
+    # can select them unconditionally, and preserved verbatim when hs2p wrote them.
+    if "requested_mask_backend" not in df.columns:
+        df["requested_mask_backend"] = [None] * len(df)
+    if "mask_backend" not in df.columns:
+        df["mask_backend"] = [None] * len(df)
     if "annotation" not in df.columns:
         df["annotation"] = ["tissue"] * len(df)
     if "tiles_tar_path" not in df.columns:

--- a/tests/test_hs2p_package_cutover.py
+++ b/tests/test_hs2p_package_cutover.py
@@ -83,8 +83,8 @@ def test_load_tiling_process_df_accepts_hs2p_process_list_columns(tmp_path: Path
 
     process_list = tmp_path / "process_list.csv"
     process_list.write_text(
-        "sample_id,annotation,image_path,mask_path,requested_backend,backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
-        "slide-1,tissue,/data/slide-1.svs,/data/slide-1-mask.png,auto,openslide,success,4,/tmp/slide-1.coordinates.npz,/tmp/slide-1.coordinates.meta.json,,\n",
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,requested_mask_backend,mask_backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
+        "slide-1,tissue,/data/slide-1.svs,/data/slide-1-mask.png,auto,openslide,auto,cucim,success,4,/tmp/slide-1.coordinates.npz,/tmp/slide-1.coordinates.meta.json,,\n",
         encoding="utf-8",
     )
     df = helper.load_tiling_process_df(process_list)
@@ -95,6 +95,8 @@ def test_load_tiling_process_df_accepts_hs2p_process_list_columns(tmp_path: Path
         "mask_path",
         "requested_backend",
         "backend",
+        "requested_mask_backend",
+        "mask_backend",
         "spacing_at_level_0",
         "tiling_status",
         "num_tiles",
@@ -109,6 +111,26 @@ def test_load_tiling_process_df_accepts_hs2p_process_list_columns(tmp_path: Path
     assert df.loc[0, "mask_path"] == "/data/slide-1-mask.png"
     assert df.loc[0, "requested_backend"] == "auto"
     assert df.loc[0, "backend"] == "openslide"
+    assert df.loc[0, "requested_mask_backend"] == "auto"
+    assert df.loc[0, "mask_backend"] == "cucim"
+
+
+def test_load_tiling_process_df_backfills_missing_mask_backend_columns(tmp_path: Path):
+    """A process_list.csv from hs2p < 4.3.0 (no mask-backend columns) still loads: the
+    columns are backfilled to NaN rather than raising."""
+    helper = importlib.import_module("slide2vec.utils.tiling_io")
+
+    process_list = tmp_path / "process_list.csv"
+    process_list.write_text(
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
+        "slide-1,tissue,/data/slide-1.svs,/data/slide-1-mask.png,auto,openslide,success,4,/tmp/slide-1.coordinates.npz,/tmp/slide-1.coordinates.meta.json,,\n",
+        encoding="utf-8",
+    )
+    df = helper.load_tiling_process_df(process_list)
+    assert "requested_mask_backend" in df.columns
+    assert "mask_backend" in df.columns
+    assert pd.isna(df.loc[0, "requested_mask_backend"])
+    assert pd.isna(df.loc[0, "mask_backend"])
 
 
 def test_load_embedding_process_df_accepts_hs2p_process_list_columns(tmp_path: Path):
@@ -116,8 +138,8 @@ def test_load_embedding_process_df_accepts_hs2p_process_list_columns(tmp_path: P
 
     process_list = tmp_path / "process_list.csv"
     process_list.write_text(
-        "sample_id,annotation,image_path,mask_path,requested_backend,backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
-        "slide-1,tissue,/data/slide-1.svs,/data/slide-1-mask.png,auto,openslide,success,4,/tmp/slide-1.coordinates.npz,/tmp/slide-1.coordinates.meta.json,,\n",
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,requested_mask_backend,mask_backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
+        "slide-1,tissue,/data/slide-1.svs,/data/slide-1-mask.png,auto,openslide,auto,cucim,success,4,/tmp/slide-1.coordinates.npz,/tmp/slide-1.coordinates.meta.json,,\n",
         encoding="utf-8",
     )
     df = helper.load_embedding_process_df(process_list, include_aggregation_status=True)
@@ -128,6 +150,8 @@ def test_load_embedding_process_df_accepts_hs2p_process_list_columns(tmp_path: P
         "mask_path",
         "requested_backend",
         "backend",
+        "requested_mask_backend",
+        "mask_backend",
         "spacing_at_level_0",
         "tiling_status",
         "num_tiles",
@@ -145,6 +169,8 @@ def test_load_embedding_process_df_accepts_hs2p_process_list_columns(tmp_path: P
         "error",
         "traceback",
     ]
+    assert df.loc[0, "requested_mask_backend"] == "auto"
+    assert df.loc[0, "mask_backend"] == "cucim"
     assert df.loc[0, "feature_status"] == "tbp"
     assert pd.isna(df.loc[0, "feature_path"])
     assert pd.isna(df.loc[0, "encoder_name"])

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -407,6 +407,79 @@ def test_plain_text_reporter_formats_tissue_progress():
     )
 
 
+def test_plain_text_reporter_formats_mask_backend_selected():
+    import slide2vec.progress as progress
+
+    reporter = progress.PlainTextCliProgressReporter(stream=io.StringIO())
+
+    assert (
+        reporter._format_line(
+            "mask_backend.selected",
+            {
+                "sample_id": "slide-a",
+                "mask_path": "/data/slide-a-mask.tif",
+                "backend": "openslide",
+                "reason": "selected openslide for auto mask backend",
+            },
+        )
+        == "[mask backend] slide-a (/data/slide-a-mask.tif): selected openslide for auto mask backend"
+    )
+    assert (
+        reporter._format_line(
+            "mask_backend.selected",
+            {
+                "sample_id": "slide-a",
+                "mask_path": "/data/slide-a-mask.tif",
+                "backend": "openslide",
+            },
+        )
+        == "[mask backend] slide-a (/data/slide-a-mask.tif): using openslide"
+    )
+
+
+def test_plain_text_reporter_surfaces_empty_masks_only_when_present():
+    import slide2vec.progress as progress
+
+    reporter = progress.PlainTextCliProgressReporter(stream=io.StringIO())
+
+    # Zero (or missing) empty_masks leaves the existing lines untouched.
+    assert (
+        reporter._format_line(
+            "tissue.finished",
+            {"total": 3, "completed": 3, "failed": 0, "empty_masks": 0},
+        )
+        == "Tissue resolution finished: 3/3 complete, 0 failed"
+    )
+    # A non-zero count is surfaced across tissue + tiling lines.
+    assert (
+        reporter._format_line(
+            "tissue.progress",
+            {"total": 3, "completed": 2, "failed": 0, "empty_masks": 1},
+        )
+        == "Tissue resolution: 2/3 complete, 0 failed, empty_masks=1"
+    )
+    assert (
+        reporter._format_line(
+            "tissue.finished",
+            {"total": 3, "completed": 3, "failed": 0, "empty_masks": 2},
+        )
+        == "Tissue resolution finished: 3/3 complete, 0 failed, empty_masks=2"
+    )
+    assert (
+        reporter._format_line(
+            "tiling.finished",
+            {
+                "total": 3,
+                "completed": 3,
+                "failed": 0,
+                "discovered_tiles": 12,
+                "empty_masks": 2,
+            },
+        )
+        == "Tiling finished: 3/3 complete, 0 failed, 12 tiles, empty_masks=2"
+    )
+
+
 def test_run_forward_pass_reports_processed_tile_counts():
     torch = pytest.importorskip("torch")
     import slide2vec.inference as inference
@@ -991,6 +1064,74 @@ def test_rich_reporter_emits_backend_selected_via_console_print(monkeypatch):
     ]
 
 
+def test_rich_reporter_emits_mask_backend_selected_via_console_print(monkeypatch):
+    import slide2vec.progress as progress
+
+    FakeConsole, _FakeProgress = _install_fake_rich_runtime(monkeypatch)
+    console = FakeConsole()
+    reporter = progress.RichCliProgressReporter(console=console)
+
+    def _fail_if_used(*args, **kwargs):
+        raise AssertionError("mask_backend.selected should not go through Progress.print")
+
+    reporter.progress.print = _fail_if_used
+
+    reporter.emit(
+        progress.ProgressEvent(
+            kind="mask_backend.selected",
+            payload={
+                "sample_id": "slide-a",
+                "mask_path": "/data/slide-a-mask.tif",
+                "backend": "openslide",
+                "reason": "selected openslide for auto mask backend",
+            },
+        )
+    )
+
+    assert [line[0] for line in console.lines] == [
+        "[mask backend] slide-a (/data/slide-a-mask.tif): selected openslide for auto mask backend"
+    ]
+
+
+def test_rich_reporter_surfaces_empty_masks_in_tissue_finished(monkeypatch):
+    import slide2vec.progress as progress
+
+    FakeConsole, _FakeProgress = _install_fake_rich_runtime(monkeypatch)
+    console = FakeConsole()
+    reporter = progress.RichCliProgressReporter(console=console)
+
+    reporter.emit(progress.ProgressEvent(kind="tissue.started", payload={"total": 3}))
+    reporter.emit(
+        progress.ProgressEvent(
+            kind="tissue.finished",
+            payload={"total": 3, "completed": 3, "failed": 0, "empty_masks": 1},
+        )
+    )
+
+    assert [line[0] for line in console.lines] == [
+        "Resolving tissue masks (3 total)...",
+        "Tissue resolution finished: 3/3 complete, 0 failed, empty_masks=1",
+    ]
+
+
+def test_progress_bridge_forwards_mask_backend_selected_and_drops_unbridged_kinds():
+    import slide2vec.progress as progress
+    from slide2vec.runtime.progress_bridge import _Hs2pProgressBridge
+
+    captured = []
+
+    class _Capture:
+        def emit(self, event):
+            captured.append((event.kind, dict(event.payload)))
+
+    bridge = _Hs2pProgressBridge(_Capture())
+
+    mask_payload = {"sample_id": "slide-a", "mask_path": "/m.tif", "backend": "openslide"}
+    bridge.emit(progress.ProgressEvent(kind="mask_backend.selected", payload=mask_payload))
+    # A kind slide2vec does not bridge (e.g. an hs2p run-level event) is dropped.
+    bridge.emit(progress.ProgressEvent(kind="run.started", payload={"x": 1}))
+
+    assert captured == [("mask_backend.selected", mask_payload)]
 
 
 def test_jsonl_progress_reporter_tags_worker_events_with_gpu_label(tmp_path: Path):

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -986,6 +986,33 @@ def test_rich_reporter_defers_tiling_bar_until_progress(monkeypatch):
     assert 2 not in reporter.progress.tasks
 
 
+def test_rich_reporter_surfaces_empty_masks_in_tiling_finished(monkeypatch):
+    import slide2vec.progress as progress
+
+    FakeConsole, _FakeProgress = _install_fake_rich_runtime(monkeypatch)
+    console = FakeConsole()
+    reporter = progress.RichCliProgressReporter(console=console)
+
+    reporter.emit(progress.ProgressEvent(kind="tiling.started", payload={"slide_count": 3}))
+    reporter.emit(
+        progress.ProgressEvent(
+            kind="tiling.finished",
+            payload={
+                "total": 3,
+                "completed": 3,
+                "failed": 0,
+                "discovered_tiles": 12,
+                "empty_masks": 1,
+            },
+        )
+    )
+
+    assert [line[0] for line in console.lines] == [
+        "Tiling slides (3 total)...",
+        "Tiling finished: 3/3 complete, 0 failed, 12 tiles, empty_masks=1",
+    ]
+
+
 def test_rich_reporter_updates_embedding_total_for_resume_skips(monkeypatch):
     import slide2vec.progress as progress
 

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -40,6 +40,8 @@ def test_packaged_preprocessing_config_matches_hs2p_4_tiling_schema():
     cfg = load_config("default")
 
     assert hasattr(cfg, "save_tiles")
+    assert cfg.tiling.backend == "auto"
+    assert cfg.tiling.mask_backend == "auto"
     assert hasattr(cfg.tiling.filter_params, "filter_grayspace")
     assert hasattr(cfg.tiling.filter_params, "filter_blur")
     assert hasattr(cfg.tiling.filter_params, "qc_spacing_um")
@@ -840,6 +842,63 @@ def test_preprocessing_with_backend_preserves_other_fields():
     assert updated.read_coordinates_from == base.read_coordinates_from
     assert updated.read_tiles_from == base.read_tiles_from
     assert updated is not base
+
+
+def test_preprocessing_mask_backend_defaults_to_auto_and_is_overridable():
+    base = PreprocessingConfig(requested_spacing_um=0.5, requested_tile_size_px=224)
+    assert base.mask_backend == "auto"
+
+    updated = base.with_mask_backend("openslide")
+
+    assert updated.mask_backend == "openslide"
+    assert updated.backend == base.backend
+    assert updated.requested_spacing_um == base.requested_spacing_um
+    assert updated is not base
+
+
+def test_serialize_preprocessing_round_trips_mask_backend():
+    from slide2vec.runtime.serialization import (
+        deserialize_preprocessing,
+        serialize_preprocessing,
+    )
+
+    preprocessing = PreprocessingConfig(
+        requested_spacing_um=0.5,
+        requested_tile_size_px=224,
+        mask_backend="openslide",
+    )
+    payload = serialize_preprocessing(preprocessing)
+    assert payload["mask_backend"] == "openslide"
+    assert deserialize_preprocessing(payload).mask_backend == "openslide"
+
+    # Legacy worker payloads without the key deserialize to the "auto" default.
+    legacy = {k: v for k, v in payload.items() if k != "mask_backend"}
+    assert deserialize_preprocessing(legacy).mask_backend == "auto"
+
+
+def test_build_hs2p_configs_threads_mask_backend_into_tiling_config():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = (
+        _masks_preprocessing({"min_coverage": {"tissue": 0.1}})
+        .with_backend("cucim")
+        .with_mask_backend("openslide")
+    )
+
+    tiling_cfg = build_hs2p_configs(preprocessing)[0]
+
+    assert tiling_cfg.backend == "cucim"
+    assert tiling_cfg.mask_backend == "openslide"
+
+
+def test_build_hs2p_configs_defaults_mask_backend_to_auto():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = _masks_preprocessing({"min_coverage": {"tissue": 0.1}})
+
+    tiling_cfg = build_hs2p_configs(preprocessing)[0]
+
+    assert tiling_cfg.mask_backend == "auto"
 
 
 def test_masks_min_coverage_tissue_drives_derived_tiling_threshold():


### PR DESCRIPTION
## Why

hs2p 4.3.0 ([ADR 0001](https://github.com/clemsgrs/hs2p/blob/main/docs/adr/0001-authoritative-mask-decoding.md) / [ADR 0002](https://github.com/clemsgrs/hs2p/blob/main/docs/adr/0002-independent-mask-backend.md)) resolves the **source-mask** reader independently from the slide reader (`TilingConfig.mask_backend`) and makes mask decoding **authoritative** — the silent PIL/OpenSlide fallback is gone. A precomputed tissue or annotation mask that the slide backend cannot decode (e.g. a deflate-compressed label TIFF that cuCIM opens but can't decode) now fails unless a mask backend is chosen explicitly, and slide2vec previously gave users no way to set it.

slide2vec already runs unchanged on 4.3.0 (the `>=4.2.0` floor permitted it and the full suite passed), so this PR is about **closing the feature-parity gap**, not fixing a break.

## What

**Expose `mask_backend`**
- `PreprocessingConfig.mask_backend` (default `"auto"`) + `with_mask_backend()`, threaded through `from_config`, the packaged `configs/default.yaml`, `build_hs2p_configs` (into the hs2p `TilingConfig`), and the worker `serialize`/`deserialize_preprocessing` path (missing key → `"auto"`, so older worker payloads still deserialize).
- Bump the hs2p floor to `>=4.3.0` (the field is silently ignored by older hs2p).
- Doc note in `preprocessing.rst`; autodoc `exclude-members` updated.

**Progress rendering**
- Bridge and render the new `mask_backend.selected` event in both the plain-text and Rich reporters (mirroring hs2p's `[mask backend] sample (path): …` format).
- Surface the `empty_masks` count in the `tissue.progress` / `tissue.finished` / `tiling.finished` lines — **only when > 0**, so the common path stays quiet.

**Process-list schema**
- Carry `requested_mask_backend` / `mask_backend` through the tiling and embedding ordered-column schemas (adjacent to the slide-backend pair), backfilling them to `None` when a pre-4.3.0 `process_list.csv` omits them (kept out of the *required* set so older lists still load).

## Testing

Full non-heavy suite **536 passed** against hs2p 4.3.0 (+10 new tests: config default/override, serialization round-trip, `build_hs2p_configs` threading, both progress reporters, bridge forwarding, and process-list pass-through + backfill).

## Note for reviewers / CI

The two `build_hs2p_configs` tests assert on the hs2p `TilingConfig.mask_backend` field, which requires **hs2p 4.3.0**. CI images / environments must install `hs2p>=4.3.0` to match the bumped floor.