### PR TITLE
Make the encoder-input contract explicit and non-defaultable at model load

### DIFF
--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -59,6 +59,20 @@ the model's patch geometry. The permitted path applies normalization only, so
 the exact requested square reaches ``encode_tiles``. Fixed-size or
 patch-incompatible requests fail before slide reading begins.
 
+Which of those two rules applies is stated explicitly at model load rather than
+inferred. Every entry point resolves an ``EncoderInputContract`` in one of two
+regimes and passes it to ``load_model``, which has no default for it:
+
+- **Declared geometry** — the caller states the encoder input it wants, and
+  slide2vec honors it exactly or raises (the rules above).
+- **Given geometry** — the caller supplies pixels it never requested. The
+  encoder's shipped transform is the contract, and slide2vec *records* the
+  resulting ``encoder_input_size_px`` rather than vetoing it.
+
+Omitting the contract is an error, not a silent fallback to the shipped recipe:
+"the caller never requested this geometry" and "the caller forgot" must not look
+alike at the seam where the transform is chosen.
+
 This reader convergence intentionally changes pooled embeddings for runs where
 ``read_tile_size_px != requested_tile_size_px``: older runs could pass the raw
 pyramid read directly to the model transform. There is no legacy compatibility

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -463,11 +463,12 @@ class Model:
         self.allow_non_recommended_settings = bool(allow_non_recommended_settings)
         self._output_variant = output_variant
         self._backend: LoadedModel | None = None
-        # A freshly constructed Model has been handed no geometry, which is exactly the
-        # Given regime: anything encoded through it right now goes through the shipped
-        # transform. Every route that reads tiles at a requested size declares its
-        # geometry (``_declare_encoder_input``) before the backend is loaded.
-        self._encoder_input: EncoderInputContract = EncoderInputContract.given()
+        # Unset, deliberately: a Model has no encoder-input contract until a route
+        # declares one. There is no initial Given contract, because an initial value is
+        # a default by another name — it would silently hand the shipped transform to
+        # any route that forgot to declare, which is the confusion this contract exists
+        # to delete. ``_load_backend`` refuses to load until this is set.
+        self._encoder_input: EncoderInputContract | None = None
         self._backend_encoder_input: EncoderInputContract | None = None
 
     @classmethod
@@ -488,11 +489,13 @@ class Model:
 
     @property
     def device(self) -> Any:
-        return self._load_backend().device
+        # Construction fact, not an encode: see _load_backend_without_transform.
+        return self._load_backend_without_transform().device
 
     @property
     def feature_dim(self) -> int:
-        return int(self._load_backend().feature_dim)
+        # Construction fact, not an encode: see _load_backend_without_transform.
+        return int(self._load_backend_without_transform().feature_dim)
 
     def embed_tiles(
         self,
@@ -726,21 +729,58 @@ class Model:
         return contract
 
     def _load_backend(self) -> LoadedModel:
-        if (
-            self._backend is None
-            or self._backend_encoder_input != self._encoder_input
-        ):
+        """Load the backend under this run's declared encoder-input contract.
+
+        Every caller that reads ``loaded.transforms`` — i.e. everything that turns
+        pixels into features — must come through here, and must therefore have
+        declared its geometry first.
+        """
+        if self._encoder_input is None:
+            raise ValueError(
+                f"No encoder-input contract has been declared for model '{self.name}'. "
+                "A route that encodes pixels must state its geometry before the "
+                "backend is loaded: call _declare_encoder_input(preprocessing, ...) "
+                "for a run that requested a tile size. Callers that never read "
+                "loaded.transforms use _load_backend_without_transform() instead."
+            )
+        return self._load_backend_under(self._encoder_input)
+
+    def _load_backend_without_transform(self) -> LoadedModel:
+        """Load the backend for callers that never read ``loaded.transforms``.
+
+        Three kinds of caller need the constructed encoder module without ever
+        selecting a tile transform: the ``device``/``feature_dim`` properties (pure
+        construction facts), tile→slide/patient aggregation (``encode_slide`` /
+        ``encode_patient`` consume already-computed features), and dense extraction
+        (which builds its own normalization transform from the module — dense gets its
+        own contract separately). They cannot observe, let alone encode through, the
+        transform the backend happens to carry.
+
+        A declared contract is honored when one exists so the cached backend is shared;
+        otherwise an explicit Given contract is used for this load only. This never
+        assigns ``_encoder_input``: an embed route still has to declare, and
+        ``_load_backend`` reloads when the declared contract differs from the one the
+        cached backend was built under.
+        """
+        return self._load_backend_under(
+            self._encoder_input
+            if self._encoder_input is not None
+            else EncoderInputContract.given()
+        )
+
+    def _load_backend_under(self, encoder_input: EncoderInputContract) -> LoadedModel:
+        if self._backend is None or self._backend_encoder_input != encoder_input:
             from slide2vec.inference import load_model
 
             emit_progress("model.loading", model_name=self.name)
             self._backend = load_model(
                 name=self.name,
-                encoder_input=self._encoder_input,
+                encoder_input=encoder_input,
                 device=self._requested_device,
                 output_variant=self._output_variant,
                 allow_non_recommended_settings=self.allow_non_recommended_settings,
             )
-            self._backend_encoder_input = self._encoder_input
+            self._backend_encoder_input = encoder_input
             emit_progress("model.ready", model_name=self.name, device=str(self._backend.device))
         return self._backend
 

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -29,7 +29,7 @@ from slide2vec.runtime.model_settings import (
 )
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.types import LoadedModel
-from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 from slide2vec.utils.utils import cpu_worker_limit, slurm_cpu_limit
 
 PathLike = str | Path
@@ -463,8 +463,12 @@ class Model:
         self.allow_non_recommended_settings = bool(allow_non_recommended_settings)
         self._output_variant = output_variant
         self._backend: LoadedModel | None = None
-        self._pooled_input_plan: PooledEncoderInputPlan | None = None
-        self._backend_pooled_input_plan: PooledEncoderInputPlan | None = None
+        # A freshly constructed Model has been handed no geometry, which is exactly the
+        # Given regime: anything encoded through it right now goes through the shipped
+        # transform. Every route that reads tiles at a requested size declares its
+        # geometry (``_declare_encoder_input``) before the backend is loaded.
+        self._encoder_input: EncoderInputContract = EncoderInputContract.given()
+        self._backend_encoder_input: EncoderInputContract | None = None
 
     @classmethod
     def from_preset(
@@ -686,18 +690,30 @@ class Model:
         with _auto_progress_reporting(output_dir=resolved.output_dir):
             return embed_regions_dense(self, regions, dense=dense, execution=resolved)
 
-    def _prepare_pooled_input(
+    def _declare_encoder_input(
         self,
         preprocessing: PreprocessingConfig,
         *,
         emit_run_info: bool,
-    ) -> PooledEncoderInputPlan:
-        plan = PooledEncoderInputPlan.resolve(
+    ) -> EncoderInputContract:
+        """Declare the encoder input geometry this run requested, or raise.
+
+        Idempotent: resolving the same preprocessing twice yields an equal contract, so
+        every layer that reaches the encoder may declare for itself rather than trust
+        the layer above to have done it.
+        """
+        if preprocessing.requested_tile_size_px is None:
+            raise ValueError(
+                "requested_tile_size_px must be resolved before declaring the encoder "
+                "input geometry; a pooled run reads tiles at a size it requested."
+            )
+        contract = EncoderInputContract.declared(
             self.name,
             requested_tile_size_px=int(preprocessing.requested_tile_size_px),
             allow_non_recommended_settings=self.allow_non_recommended_settings,
         )
-        self._pooled_input_plan = plan
+        self._encoder_input = contract
+        plan = contract.plan
         if emit_run_info and plan.requires_variable_model_input:
             logging.getLogger("slide2vec").info(
                 "Pooled encoder input for '%s': preset %dpx, requested %dpx, "
@@ -707,24 +723,24 @@ class Model:
                 plan.requested_tile_size_px,
                 plan.expected_encoder_input_size_px,
             )
-        return plan
+        return contract
 
     def _load_backend(self) -> LoadedModel:
         if (
             self._backend is None
-            or self._backend_pooled_input_plan != self._pooled_input_plan
+            or self._backend_encoder_input != self._encoder_input
         ):
             from slide2vec.inference import load_model
 
             emit_progress("model.loading", model_name=self.name)
             self._backend = load_model(
                 name=self.name,
+                encoder_input=self._encoder_input,
                 device=self._requested_device,
                 output_variant=self._output_variant,
                 allow_non_recommended_settings=self.allow_non_recommended_settings,
-                pooled_input_plan=self._pooled_input_plan,
             )
-            self._backend_pooled_input_plan = self._pooled_input_plan
+            self._backend_encoder_input = self._encoder_input
             emit_progress("model.ready", model_name=self.name, device=str(self._backend.device))
         return self._backend
 
@@ -965,7 +981,7 @@ def _validate_model_config(
         info = encoder_registry.info(name)
         if info["level"] != "tile":
             raise ValueError("Hierarchical preprocessing is only supported for tile encoders")
-    model._prepare_pooled_input(preprocessing, emit_run_info=True)
+    model._declare_encoder_input(preprocessing, emit_run_info=True)
     # Skip precision validation for CPU execution (fp32 is always valid on CPU).
     on_cpu = model._requested_device == "cpu"
     precision = None if on_cpu or execution is None else execution.precision

--- a/slide2vec/distributed/dense_worker.py
+++ b/slide2vec/distributed/dense_worker.py
@@ -63,7 +63,9 @@ def main(argv=None) -> int:
     )
     dense = deserialize_dense_options(request["dense"])
     execution = deserialize_execution(request["execution"])
-    loaded = model._load_backend()
+    # Dense builds its own transform from the encoder module (see dense_regions:
+    # get_normalization_transform) and never reads loaded.transforms.
+    loaded = model._load_backend_without_transform()
 
     progress_events_path = request.get("progress_events_path")
     reporter = (

--- a/slide2vec/distributed/direct_embed_worker.py
+++ b/slide2vec/distributed/direct_embed_worker.py
@@ -48,9 +48,7 @@ def main(argv=None) -> int:
     )
     preprocessing = deserialize_preprocessing(request["preprocessing"])
     execution = deserialize_execution(request["execution"])
-    prepare_pooled_input = getattr(model, "_prepare_pooled_input", None)
-    if callable(prepare_pooled_input):
-        prepare_pooled_input(preprocessing, emit_run_info=False)
+    model._declare_encoder_input(preprocessing, emit_run_info=False)
     from slide2vec.runtime.distributed import (
         decode_work_unit,
         encode_work_unit,

--- a/slide2vec/distributed/pipeline_worker.py
+++ b/slide2vec/distributed/pipeline_worker.py
@@ -42,9 +42,7 @@ def main(argv=None) -> int:
     )
     preprocessing = deserialize_preprocessing(request["preprocessing"])
     execution = deserialize_execution(request["execution"])
-    prepare_pooled_input = getattr(model, "_prepare_pooled_input", None)
-    if callable(prepare_pooled_input):
-        prepare_pooled_input(preprocessing, emit_run_info=False)
+    model._declare_encoder_input(preprocessing, emit_run_info=False)
     tiling_input_dir = Path(request.get("tiling_input_dir", str(output_dir)))
     load_successful_tiled_slides_fn = getattr(inference, "load_successful_tiled_slides", None)
     if not callable(load_successful_tiled_slides_fn):

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -108,6 +108,18 @@ def load_model(
             f"shipped transform is the contract; got {encoder_input!r}"
         )
     name = canonicalize_model_name(name)
+    # A declared plan is resolved against ONE model's preset, patch geometry, and
+    # variable-input capability. Applying it to another model would skip exactly those
+    # checks: the constructor kwargs are name-guarded, but the normalization-only
+    # transform is not, so a mismatched contract silently reaches the encoder. Hard
+    # error rather than silent no-op.
+    if encoder_input.plan is not None and encoder_input.plan.encoder_name != name:
+        raise ValueError(
+            f"Encoder-input contract was declared for "
+            f"'{encoder_input.plan.encoder_name}' but the model being loaded is "
+            f"'{name}'. Declared geometry is validated against the encoder it names; "
+            "resolve a contract for this model instead of reusing another's."
+        )
     info = encoder_registry.info(name)
     resolved_level = info["level"]
 
@@ -491,6 +503,9 @@ def embed_patients(
                 embeddable_tiling_results,
             )
             emit_progress("embedding.started", slide_count=len(embeddable_slides))
+            # Encodes tiles through loaded.transforms below, so declare the requested
+            # geometry here too rather than trusting the Model.* wrapper to have done it.
+            model._declare_encoder_input(preprocessing, emit_run_info=False)
             loaded = model._load_backend()
 
             # Per-slide: tile encoding → slide encoding, accumulate for patient agg.
@@ -612,6 +627,10 @@ def embed_tiles(
     slide_records = [manifest.coerce_slide_spec(slide) for slide in slides]
     resolved_tiling_results = manifest.normalize_tiling_results(tiling_results, slide_records)
     resolved_preprocessing = tiling_pipeline.resolve_model_preprocessing(model, preprocessing)
+    # This route encodes tiles through loaded.transforms, so it declares its own
+    # geometry rather than relying on a Model.* wrapper having done it. Declaring is
+    # idempotent, so declaring in both places is intended.
+    model._declare_encoder_input(resolved_preprocessing, emit_run_info=False)
     loaded = model._load_backend()
     hierarchical_mode = hierarchical.is_hierarchical_preprocessing(resolved_preprocessing)
     cpu_budget.log_on_the_fly_worker_override_once(
@@ -683,7 +702,9 @@ def aggregate_tiles(
     if execution.output_dir is None:
         raise ValueError("ExecutionOptions.output_dir is required to persist slide embeddings")
 
-    loaded = model._load_backend()
+    # Aggregation only: already-computed tile features go into encode_slide, so no
+    # tile transform is selected here and no geometry has to be declared.
+    loaded = model._load_backend_without_transform()
 
     outputs: list[SlideEmbeddingArtifact] = []
     for artifact in tile_artifacts:

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -64,7 +64,7 @@ from slide2vec.encoders.registry import (
 )
 from slide2vec.runtime.model_settings import canonicalize_model_name
 from slide2vec.runtime.types import LoadedModel
-from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 from slide2vec.progress import (
     emit_progress,
     read_tiling_progress_snapshot,
@@ -89,13 +89,24 @@ from slide2vec.runtime.hierarchical import num_embedding_items
 def load_model(
     *,
     name: str,
+    encoder_input: EncoderInputContract,
     device: str = "auto",
     output_variant: str | None = None,
     allow_non_recommended_settings: bool = False,
     dynamic_img_size: bool | None = None,
     token: str | None = None,
-    pooled_input_plan: PooledEncoderInputPlan | None = None,
 ) -> LoadedModel:
+    # ``encoder_input`` is required and deliberately has no default: the transform a
+    # run encodes through is a contract the caller states, never something load_model
+    # infers from an absent argument. See EncoderInputContract for the two regimes.
+    if not isinstance(encoder_input, EncoderInputContract):
+        raise TypeError(
+            "load_model requires an explicit encoder-input contract: pass "
+            "encoder_input=EncoderInputContract.declared(...) when the caller states "
+            "the encoder input geometry it wants, or EncoderInputContract.given() "
+            "when the caller supplies pixels it never requested and the encoder's "
+            f"shipped transform is the contract; got {encoder_input!r}"
+        )
     name = canonicalize_model_name(name)
     info = encoder_registry.info(name)
     resolved_level = info["level"]
@@ -122,16 +133,16 @@ def load_model(
         extra_kwargs["dynamic_img_size"] = dynamic_img_size
     if "allow_non_recommended_settings" in ctor_params:
         extra_kwargs["allow_non_recommended_settings"] = allow_non_recommended_settings
-    if pooled_input_plan is not None and pooled_input_plan.tile_encoder_name == name:
-        missing_params = set(pooled_input_plan.model_construction_kwargs) - set(ctor_params)
+    contract_kwargs = encoder_input.construction_kwargs_for(name)
+    if contract_kwargs:
+        missing_params = set(contract_kwargs) - set(ctor_params)
         if missing_params:
             missing_text = ", ".join(sorted(missing_params))
             raise ValueError(
                 f"Encoder '{name}' requires pooled variable-input constructor "
                 f"setting(s) not accepted by its implementation: {missing_text}"
             )
-        for key, value in pooled_input_plan.model_construction_kwargs.items():
-            extra_kwargs[key] = value
+        extra_kwargs.update(contract_kwargs)
     encoder = encoder_cls(output_variant=output_variant, **extra_kwargs)
 
     # Drift guard: the static patch_size declared on @register_encoder is read
@@ -151,11 +162,7 @@ def load_model(
 
     tile_encoder = None
     if resolved_level == "tile":
-        transforms = (
-            pooled_input_plan.get_transform(encoder)
-            if pooled_input_plan is not None
-            else encoder.get_transform()
-        )
+        transforms = encoder_input.get_transform(encoder)
     else:
         # Both "slide" and "patient" declare tile_encoder for transform resolution.
         tile_enc_name = info["tile_encoder"]
@@ -165,10 +172,9 @@ def load_model(
         tile_kwargs: dict[str, Any] = {"output_variant": tile_enc_ov}
         if "allow_non_recommended_settings" in tile_ctor_params:
             tile_kwargs["allow_non_recommended_settings"] = allow_non_recommended_settings
-        if pooled_input_plan is not None and pooled_input_plan.tile_encoder_name == tile_enc_name:
-            missing_params = set(pooled_input_plan.model_construction_kwargs) - set(
-                tile_ctor_params
-            )
+        tile_contract_kwargs = encoder_input.construction_kwargs_for(tile_enc_name)
+        if tile_contract_kwargs:
+            missing_params = set(tile_contract_kwargs) - set(tile_ctor_params)
             if missing_params:
                 missing_text = ", ".join(sorted(missing_params))
                 raise ValueError(
@@ -176,14 +182,9 @@ def load_model(
                     "constructor setting(s) not accepted by its implementation: "
                     f"{missing_text}"
                 )
-            for key, value in pooled_input_plan.model_construction_kwargs.items():
-                tile_kwargs[key] = value
+            tile_kwargs.update(tile_contract_kwargs)
         tile_encoder = tile_enc_cls(**tile_kwargs)
-        transforms = (
-            pooled_input_plan.get_transform(tile_encoder)
-            if pooled_input_plan is not None
-            else tile_encoder.get_transform()
-        )
+        transforms = encoder_input.get_transform(tile_encoder)
 
     target_device = batching.resolve_device(device, encoder.device)
     encoder.to(target_device)

--- a/slide2vec/runtime/dense_stage.py
+++ b/slide2vec/runtime/dense_stage.py
@@ -190,7 +190,9 @@ def embed_regions_dense(
 
 
 def _run_dense_in_process(model, specs, *, dense, execution, out_dir) -> None:
-    loaded = model._load_backend()
+    # Dense builds its own transform from the encoder module (see dense_regions:
+    # get_normalization_transform) and never reads loaded.transforms.
+    loaded = model._load_backend_without_transform()
     run_dense_shard(
         specs,
         model=loaded.model,

--- a/slide2vec/runtime/distributed_stage.py
+++ b/slide2vec/runtime/distributed_stage.py
@@ -236,7 +236,9 @@ def embed_single_slide_distributed(
                 tile_embeddings=tile_embeddings,
                 encoder_input_size_px=encoder_input_size_px,
             )
-        loaded = model._load_backend()
+        # Aggregation only: the shards did the tile encoding, this parent-side load
+        # feeds encode_slide and never selects a tile transform.
+        loaded = model._load_backend_without_transform()
         slide_embedding, latents = aggregate_tile_embeddings_for_slide(
             loaded,
             model,

--- a/slide2vec/runtime/embedding_pipeline.py
+++ b/slide2vec/runtime/embedding_pipeline.py
@@ -356,6 +356,12 @@ def compute_embedded_slides(
     on_embedded_slide: Callable[[SlideSpec, Any, EmbeddedSlide], None] | None = None,
     collect_results: bool = True,
 ) -> list[EmbeddedSlide]:
+    # Declare the encoder input here rather than trusting the caller to have done it:
+    # this is the in-process embed route one layer below Pipeline, and a caller that
+    # reached it directly used to get the encoder's shipped transform while the very
+    # same config routed through Pipeline got the declared geometry. Declaring is
+    # idempotent, so the layers above may (and do) declare as well.
+    model._declare_encoder_input(preprocessing, emit_run_info=False)
     loaded = model._load_backend()
     embedded_slides: list[EmbeddedSlide] = []
     for slide, tiling_result in zip(slide_records, tiling_results):

--- a/slide2vec/runtime/encoder_input_contract.py
+++ b/slide2vec/runtime/encoder_input_contract.py
@@ -1,0 +1,90 @@
+"""Name the two regimes that can own an encoder run's input geometry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+
+#: Closed vocabulary for who owns the geometry handed to the encoder.
+EncoderInputRegime = Literal["declared", "given"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class EncoderInputContract:
+    """Which side of the model-load seam owns the encoder input geometry.
+
+    ``"declared"`` — the caller states the encoder input it wants and slide2vec honors
+    it exactly or raises: an off-preset request needs
+    ``allow_non_recommended_settings``, the encoder must be variable-input capable, and
+    the size must be a multiple of the patch geometry. ``plan`` carries the resolved
+    contract (see :class:`PooledEncoderInputPlan`).
+
+    ``"given"`` — the caller supplies pixels it never requested (a pre-cropped tile
+    dataset, arbitrary and often non-square). The encoder's shipped transform *is* the
+    contract; slide2vec records the observed encoder input size (see
+    ``batching._record_encoder_input_size``) rather than vetoing it.
+
+    There is deliberately no default and no "unset" state at the model-load seam:
+    ``load_model`` takes the contract as a required argument, so "the caller never
+    requested this geometry" can never be confused with "the caller forgot". That
+    confusion is not hypothetical — a downstream consumer that routed by GPU count
+    built the plan on one route and not the other, and the same config silently
+    produced two different transforms.
+    """
+
+    regime: EncoderInputRegime
+    #: Resolved declared geometry; ``None`` in the Given regime, which has none.
+    plan: PooledEncoderInputPlan | None
+
+    def __post_init__(self) -> None:
+        if self.regime == "declared" and self.plan is None:
+            raise ValueError(
+                "A declared encoder-input contract requires a resolved "
+                "PooledEncoderInputPlan; use EncoderInputContract.declared(...)."
+            )
+        if self.regime == "given" and self.plan is not None:
+            raise ValueError(
+                "A given encoder-input contract carries no plan: the caller never "
+                "requested the geometry it supplied."
+            )
+
+    @classmethod
+    def declared(
+        cls,
+        encoder_name: str,
+        *,
+        requested_tile_size_px: int,
+        allow_non_recommended_settings: bool,
+    ) -> "EncoderInputContract":
+        """Resolve the geometry the caller asked for, or raise."""
+        return cls(
+            regime="declared",
+            plan=PooledEncoderInputPlan.resolve(
+                encoder_name,
+                requested_tile_size_px=requested_tile_size_px,
+                allow_non_recommended_settings=allow_non_recommended_settings,
+            ),
+        )
+
+    @classmethod
+    def given(cls) -> "EncoderInputContract":
+        """Accept whatever pixels the caller supplies under the shipped recipe."""
+        return cls(regime="given", plan=None)
+
+    def get_transform(self, encoder) -> Callable:
+        """Return the encoder-owned transform this contract selects."""
+        if self.plan is None:
+            return encoder.get_transform()
+        return self.plan.get_transform(encoder)
+
+    def construction_kwargs_for(self, encoder_name: str) -> dict[str, bool]:
+        """Return the constructor settings this contract imposes on *encoder_name*.
+
+        Only the plan's own tile encoder is affected: a slide/patient encoder resolves
+        its geometry through the tile encoder it declares as its dependency.
+        """
+        if self.plan is None or self.plan.tile_encoder_name != encoder_name:
+            return {}
+        return dict(self.plan.model_construction_kwargs)

--- a/slide2vec/runtime/patient_pipeline.py
+++ b/slide2vec/runtime/patient_pipeline.py
@@ -44,6 +44,8 @@ def run_patient_pipeline(
     After processing all slides for a patient: aggregate slide embeddings into
     a single patient embedding via the case transformer.
     """
+    # Encodes tiles below, so this layer declares its own geometry (idempotent).
+    model._declare_encoder_input(preprocessing, emit_run_info=False)
     loaded = model._load_backend()
     tile_artifacts: list[TileEmbeddingArtifact] = []
     slide_artifacts: list[SlideEmbeddingArtifact] = []

--- a/tests/test_dense_stage.py
+++ b/tests/test_dense_stage.py
@@ -86,7 +86,7 @@ class _FakeModel:
         self._requested_device = device
         self.allow_non_recommended_settings = False
 
-    def _load_backend(self):
+    def _load_backend_without_transform(self):
         return SimpleNamespace(model=self._encoder, device=self._device)
 
     @property

--- a/tests/test_dense_worker.py
+++ b/tests/test_dense_worker.py
@@ -65,7 +65,7 @@ def test_dense_worker_encodes_only_its_rank_shard(monkeypatch, tmp_path):
     monkeypatch.setattr(
         api.Model, "from_preset",
         classmethod(lambda cls, name, **kwargs: SimpleNamespace(
-            _load_backend=lambda: SimpleNamespace(model=encoder, device="cpu"))),
+            _load_backend_without_transform=lambda: SimpleNamespace(model=encoder, device="cpu"))),
     )
 
     specs = [RegionSpec("s0", "s0.tif", i * 64, 0, 0, 64, 64, "cucim", None) for i in range(4)]

--- a/tests/test_encoder_input_contract.py
+++ b/tests/test_encoder_input_contract.py
@@ -176,6 +176,135 @@ def test_given_geometry_records_the_observed_encoder_input_instead_of_vetoing_it
     torch.testing.assert_close(indices, torch.tensor([0, 1]))
 
 
+def test_load_model_rejects_a_contract_declared_for_another_encoder(stand_in_gigapath):
+    """A declared plan is resolved against ONE encoder's preset and patch geometry."""
+    import slide2vec.inference as inference
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    # conch is fixed-input, so resolving 288px against conch would have raised outright.
+    contract = EncoderInputContract.declared(
+        "gigapath",
+        requested_tile_size_px=288,
+        allow_non_recommended_settings=True,
+    )
+
+    with pytest.raises(ValueError, match="declared for 'gigapath'"):
+        inference.load_model(
+            name="conch",
+            device="cpu",
+            allow_non_recommended_settings=True,
+            encoder_input=contract,
+        )
+
+
+def test_load_backend_raises_when_no_contract_has_been_declared(stand_in_gigapath):
+    from slide2vec.api import Model
+
+    model = Model.from_preset("gigapath", device="cpu")
+
+    with pytest.raises(ValueError, match="No encoder-input contract"):
+        model._load_backend()
+
+
+def test_transform_free_backend_load_is_not_a_declaration(stand_in_gigapath):
+    """Introspection must not leave a contract behind that an embed route inherits."""
+    from slide2vec.api import Model
+
+    model = Model.from_preset("gigapath", device="cpu")
+
+    assert model.feature_dim == 4
+
+    with pytest.raises(ValueError, match="No encoder-input contract"):
+        model._load_backend()
+
+
+def test_in_process_embed_tiles_resolves_the_same_transform_as_the_model_route(
+    stand_in_gigapath, tmp_path
+):
+    """``inference.embed_tiles`` must not select a different transform than ``Model``."""
+    import slide2vec.inference as inference
+    from slide2vec.api import ExecutionOptions, Model, PreprocessingConfig
+
+    preprocessing = PreprocessingConfig(
+        requested_spacing_um=0.5,
+        requested_tile_size_px=288,
+    )
+    execution = ExecutionOptions(output_dir=tmp_path, precision="fp32")
+
+    def fresh_model() -> Model:
+        return Model.from_preset(
+            "gigapath",
+            device="cpu",
+            allow_non_recommended_settings=True,
+        )
+
+    model_route = fresh_model()
+    model_route.embed_tiles([], [], preprocessing=preprocessing, execution=execution)
+
+    in_process_route = fresh_model()
+    inference.embed_tiles(
+        in_process_route,
+        [],
+        [],
+        preprocessing=preprocessing,
+        execution=execution,
+    )
+
+    assert in_process_route._encoder_input == model_route._encoder_input
+    assert model_route._load_backend().transforms is _StandInEncoder.normalization
+    assert in_process_route._load_backend().transforms is _StandInEncoder.normalization
+
+
+def test_in_process_embed_patients_declares_the_requested_geometry(monkeypatch, tmp_path):
+    """The patient route loads the backend too, so it must declare first."""
+    import slide2vec.inference as inference
+    from slide2vec.api import ExecutionOptions, Model, PreprocessingConfig
+    from slide2vec.runtime import process_list, tiling_pipeline
+
+    class _StandInPatientEncoder:
+        def __init__(self, *, output_variant=None):
+            self.device = torch.device("cpu")
+            self.encode_dim = 6
+
+        def to(self, device):
+            self.device = torch.device(device)
+            return self
+
+    monkeypatch.setattr(
+        inference.encoder_registry,
+        "require",
+        lambda name: _StandInPatientEncoder if name == "moozy" else _StandInEncoder,
+    )
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setattr(
+        tiling_pipeline,
+        "prepare_tiled_slides",
+        lambda *args, **kwargs: ([], [], tmp_path / "process_list.csv"),
+    )
+    monkeypatch.setattr(process_list, "emit_tiling_summary", lambda *args, **kwargs: None)
+
+    model = Model.from_preset(
+        "moozy",
+        device="cpu",
+        allow_non_recommended_settings=True,
+    )
+
+    result = inference.embed_patients(
+        model,
+        [{"sample_id": "slide-a", "image_path": tmp_path / "slide-a.tif"}],
+        preprocessing=PreprocessingConfig(
+            requested_spacing_um=0.5,
+            requested_tile_size_px=232,
+        ),
+        execution=ExecutionOptions(output_dir=tmp_path, precision="fp32"),
+    )
+
+    assert result == []
+    assert model._encoder_input.regime == "declared"
+    assert model._encoder_input.plan.expected_encoder_input_size_px == 232
+    assert model._load_backend().transforms is _StandInEncoder.normalization
+
+
 def test_pipeline_and_in_process_embed_route_resolve_the_same_transform(
     stand_in_gigapath, monkeypatch
 ):

--- a/tests/test_encoder_input_contract.py
+++ b/tests/test_encoder_input_contract.py
@@ -1,0 +1,221 @@
+"""The encoder-input contract: which side of the seam owns the tile geometry.
+
+Two named regimes, no default. ``declared`` means the caller stated the encoder input
+it wants and slide2vec honors it exactly or raises; ``given`` means the caller handed
+over pixels it never requested, so the encoder's shipped transform is the contract and
+slide2vec merely records the observed geometry.
+"""
+
+from contextlib import nullcontext
+
+import pytest
+import torch
+
+
+class _Sentinel:
+    """A callable transform that is identifiable by identity."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def __call__(self, image):
+        return image
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<transform {self.label}>"
+
+
+class _StandInEncoder:
+    """A gigapath-shaped encoder whose two transforms are distinguishable."""
+
+    # Class-level so the identity is stable across instances: the tests compare the
+    # transform two independently loaded backends selected.
+    shipped = _Sentinel("shipped")
+    normalization = _Sentinel("normalization")
+
+    def __init__(self, *, output_variant=None, allow_non_recommended_settings=False):
+        self.device = torch.device("cpu")
+        self.encode_dim = 4
+        self.patch_size = (16, 16)
+
+    def get_transform(self):
+        return self.shipped
+
+    def get_normalization_transform(self):
+        return self.normalization
+
+    def encode_tiles(self, batch):
+        return torch.zeros((int(batch.shape[0]), self.encode_dim), dtype=torch.float32)
+
+    def to(self, device):
+        self.device = torch.device(device)
+        return self
+
+
+@pytest.fixture
+def stand_in_gigapath(monkeypatch):
+    import slide2vec.inference as inference
+
+    monkeypatch.setattr(inference.encoder_registry, "require", lambda name: _StandInEncoder)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    return _StandInEncoder
+
+
+def test_load_model_refuses_to_default_the_encoder_input_contract(stand_in_gigapath):
+    import slide2vec.inference as inference
+
+    with pytest.raises(TypeError, match="encoder_input"):
+        inference.load_model(name="gigapath", device="cpu")
+
+
+def test_load_model_rejects_an_absent_contract_rather_than_falling_back(stand_in_gigapath):
+    import slide2vec.inference as inference
+
+    with pytest.raises(TypeError, match="explicit encoder-input contract"):
+        inference.load_model(name="gigapath", device="cpu", encoder_input=None)
+
+
+def test_declared_geometry_rejects_an_off_preset_request_without_permission():
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    with pytest.raises(ValueError, match="allow_non_recommended_settings=True"):
+        EncoderInputContract.declared(
+            "gigapath",
+            requested_tile_size_px=288,
+            allow_non_recommended_settings=False,
+        )
+
+
+def test_declared_geometry_rejects_an_encoder_without_variable_input_capability():
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    with pytest.raises(ValueError, match="does not support variable pooled input geometry"):
+        EncoderInputContract.declared(
+            "conch",
+            requested_tile_size_px=464,
+            allow_non_recommended_settings=True,
+        )
+
+
+def test_declared_geometry_rejects_a_non_multiple_of_the_patch_size():
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    with pytest.raises(ValueError, match="patch geometry"):
+        EncoderInputContract.declared(
+            "gigapath",
+            requested_tile_size_px=278,
+            allow_non_recommended_settings=True,
+        )
+
+
+def test_declared_geometry_keeps_normalization_only_preprocessing(stand_in_gigapath):
+    import slide2vec.inference as inference
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    contract = EncoderInputContract.declared(
+        "gigapath",
+        requested_tile_size_px=288,
+        allow_non_recommended_settings=True,
+    )
+
+    assert contract.regime == "declared"
+    assert contract.plan.preprocessing_kind == "normalization_only"
+    assert contract.plan.expected_encoder_input_size_px == 288
+
+    loaded = inference.load_model(
+        name="gigapath",
+        device="cpu",
+        allow_non_recommended_settings=True,
+        encoder_input=contract,
+    )
+
+    assert loaded.transforms is _StandInEncoder.normalization
+
+
+def test_given_geometry_applies_the_shipped_transform(stand_in_gigapath):
+    import slide2vec.inference as inference
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    contract = EncoderInputContract.given()
+
+    assert contract.regime == "given"
+    assert contract.plan is None
+
+    loaded = inference.load_model(
+        name="gigapath",
+        device="cpu",
+        encoder_input=contract,
+    )
+
+    assert loaded.transforms is _StandInEncoder.shipped
+
+
+def test_given_geometry_records_the_observed_encoder_input_instead_of_vetoing_it(
+    stand_in_gigapath,
+):
+    """224px pixels handed to a 256px-preset encoder are recorded, never rejected."""
+    import slide2vec.inference as inference
+    from slide2vec.runtime.batching import run_forward_pass
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    loaded = inference.load_model(
+        name="gigapath",
+        device="cpu",
+        encoder_input=EncoderInputContract.given(),
+    )
+    batch = torch.zeros((2, 3, 224, 224), dtype=torch.float32)
+
+    indices, embeddings = run_forward_pass(
+        [(torch.tensor([0, 1]), batch)],
+        loaded,
+        nullcontext(),
+    )
+
+    assert loaded.encoder_input_size_px == 224
+    assert tuple(embeddings.shape) == (2, 4)
+    torch.testing.assert_close(indices, torch.tensor([0, 1]))
+
+
+def test_pipeline_and_in_process_embed_route_resolve_the_same_transform(
+    stand_in_gigapath, monkeypatch
+):
+    """The divergence class this contract closes.
+
+    ``Pipeline`` used to be the only layer that built the pooled plan, so the same
+    config routed through ``compute_embedded_slides`` one layer below it silently got
+    the encoder's shipped transform instead of the declared geometry.
+    """
+    import slide2vec.inference as inference
+    from slide2vec.api import ExecutionOptions, Model, Pipeline, PreprocessingConfig
+    from slide2vec.runtime import embedding_pipeline
+
+    monkeypatch.setattr(inference, "run_pipeline", lambda *args, **kwargs: None)
+
+    preprocessing = PreprocessingConfig(
+        requested_spacing_um=0.5,
+        requested_tile_size_px=288,
+    )
+    execution = ExecutionOptions(precision="fp32")
+
+    def fresh_model() -> Model:
+        return Model.from_preset(
+            "gigapath",
+            device="cpu",
+            allow_non_recommended_settings=True,
+        )
+
+    pipeline_model = fresh_model()
+    Pipeline(pipeline_model, preprocessing, execution=execution).run([])
+
+    in_process_model = fresh_model()
+    embedding_pipeline.compute_embedded_slides(
+        in_process_model,
+        [],
+        [],
+        preprocessing=preprocessing,
+        execution=execution,
+    )
+
+    assert in_process_model._encoder_input == pipeline_model._encoder_input
+    assert pipeline_model._load_backend().transforms is _StandInEncoder.normalization
+    assert in_process_model._load_backend().transforms is _StandInEncoder.normalization

--- a/tests/test_patch_size_metadata.py
+++ b/tests/test_patch_size_metadata.py
@@ -18,6 +18,7 @@ from slide2vec.encoders.registry import (
     normalize_patch_size,
     resolve_patch_size,
 )
+from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
 
 # Every dense-capable encoder (those whose model class exposes a runtime
@@ -165,7 +166,11 @@ def test_load_model_drift_guard_rejects_patch_size_mismatch(monkeypatch):
     monkeypatch.delenv("HF_TOKEN", raising=False)
 
     with pytest.raises(ValueError, match="patch_size"):
-        inference.load_model(name="drifted-model", device="cpu")
+        inference.load_model(
+            name="drifted-model",
+            device="cpu",
+            encoder_input=EncoderInputContract.given(),
+        )
 
 
 def test_load_model_drift_guard_passes_when_consistent(monkeypatch):
@@ -195,7 +200,11 @@ def test_load_model_drift_guard_passes_when_consistent(monkeypatch):
     monkeypatch.setattr(inference.encoder_registry, "require", lambda name: _ConsistentEncoder)
     monkeypatch.delenv("HF_TOKEN", raising=False)
 
-    loaded = inference.load_model(name="consistent-model", device="cpu")
+    loaded = inference.load_model(
+        name="consistent-model",
+        device="cpu",
+        encoder_input=EncoderInputContract.given(),
+    )
     assert loaded.name == "consistent-model"
 
 
@@ -205,7 +214,11 @@ def test_static_patch_size_matches_runtime(name, expected):
     from slide2vec.inference import load_model
 
     try:
-        loaded = load_model(name=name, device="cpu")
+        loaded = load_model(
+            name=name,
+            device="cpu",
+            encoder_input=EncoderInputContract.given(),
+        )
     except (ImportError, OSError) as exc:
         # Skip ONLY on genuine unavailability, never on a contract violation:
         #   ImportError -> optional per-encoder dependency not installed

--- a/tests/test_pooled_encoder_input.py
+++ b/tests/test_pooled_encoder_input.py
@@ -172,7 +172,7 @@ def test_permitted_non_preset_plan_rejects_patch_incompatible_geometry():
 
 def test_pooled_model_loading_applies_plan_construction_and_transform(monkeypatch):
     import slide2vec.inference as inference
-    from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
     captured = {}
 
@@ -207,7 +207,7 @@ def test_pooled_model_loading_applies_plan_construction_and_transform(monkeypatc
             self.device = torch.device(device)
             return self
 
-    plan = PooledEncoderInputPlan.resolve(
+    contract = EncoderInputContract.declared(
         "h-optimus-0",
         requested_tile_size_px=280,  # 14x20 — h-optimus-0 is a genuine patch-14 model
         allow_non_recommended_settings=True,
@@ -218,7 +218,7 @@ def test_pooled_model_loading_applies_plan_construction_and_transform(monkeypatc
     loaded = inference.load_model(
         name="h-optimus-0",
         allow_non_recommended_settings=True,
-        pooled_input_plan=plan,
+        encoder_input=contract,
     )
 
     assert captured == {
@@ -241,7 +241,7 @@ def test_public_run_resolves_exact_plan_once_without_changing_batch_or_resource_
     captured = {}
 
     def embed_slides(model, slides, *, preprocessing, execution):
-        captured["plan"] = model._pooled_input_plan
+        captured["plan"] = model._encoder_input.plan
         captured["batch_size"] = execution.batch_size
         return []
 
@@ -417,14 +417,14 @@ def test_distributed_request_round_trip_resolves_same_exact_hierarchical_tar_pla
     )
     worker_preprocessing = deserialize_preprocessing(request["preprocessing"])
 
-    parent_plan = model._prepare_pooled_input(preprocessing, emit_run_info=False)
-    worker_plan = worker_model._prepare_pooled_input(
+    parent_contract = model._declare_encoder_input(preprocessing, emit_run_info=False)
+    worker_contract = worker_model._declare_encoder_input(
         worker_preprocessing,
         emit_run_info=False,
     )
 
-    assert worker_plan == parent_plan
-    assert worker_plan.expected_encoder_input_size_px == 288
+    assert worker_contract == parent_contract
+    assert worker_contract.plan.expected_encoder_input_size_px == 288
     assert worker_preprocessing.region_tile_multiple == 2
     assert worker_preprocessing.on_the_fly is False
     assert worker_preprocessing.read_tiles_from == tmp_path
@@ -460,7 +460,7 @@ def test_slide_and_patient_plans_use_tile_dependency_exact_geometry():
 
 def test_slide_model_loading_applies_plan_to_resolved_tile_dependency(monkeypatch):
     import slide2vec.inference as inference
-    from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
     captured = {}
 
@@ -490,7 +490,7 @@ def test_slide_model_loading_applies_plan_to_resolved_tile_dependency(monkeypatc
             self.device = torch.device(device)
             return self
 
-    plan = PooledEncoderInputPlan.resolve(
+    contract = EncoderInputContract.declared(
         "prism",
         requested_tile_size_px=252,
         allow_non_recommended_settings=True,
@@ -505,7 +505,7 @@ def test_slide_model_loading_applies_plan_to_resolved_tile_dependency(monkeypatc
     loaded = inference.load_model(
         name="prism",
         allow_non_recommended_settings=True,
-        pooled_input_plan=plan,
+        encoder_input=contract,
     )
 
     assert captured == {"dynamic_img_size": True, "normalization": True}

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -24,6 +24,11 @@ from slide2vec.runtime import (
     tiling_pipeline,
 )
 
+
+def _noop_declare_encoder_input(*args, **kwargs):
+    """Stand-in models declare nothing: these tests stub ``_load_backend`` outright."""
+    return None
+
 DEFAULT_PREPROCESSING = PreprocessingConfig(requested_spacing_um=0.5, requested_tile_size_px=224)
 
 
@@ -277,6 +282,7 @@ def test_run_pipeline_emits_local_progress_events_in_order(monkeypatch, tmp_path
         name="prov-gigapath",
         level="slide",
         _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=lambda: SimpleNamespace(),
     )
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -28,6 +28,7 @@ from slide2vec.artifacts import (
     write_tile_embeddings,
 )
 from slide2vec.configs.resources import config_resource, load_config
+from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 from slide2vec.runtime import (
     artifacts_collect,
     batching,
@@ -69,6 +70,11 @@ def PreprocessingConfig(*args, **kwargs):
 
 
 DEFAULT_PREPROCESSING = PreprocessingConfig()
+
+
+def _noop_declare_encoder_input(*args, **kwargs):
+    """Stand-in models declare nothing: these tests stub ``_load_backend`` outright."""
+    return None
 
 
 def make_slide(
@@ -1279,7 +1285,8 @@ def test_aggregate_tiles_uses_autocast_for_slide_encoding(monkeypatch, tmp_path:
         return SimpleNamespace(sample_id=sample_id, path=tmp_path / "slide_embeddings" / f"{sample_id}.pt")
 
     loaded = SimpleNamespace(device=torch.device("cpu"), model=SimpleNamespace(encode_slide=encode_slide))
-    model = SimpleNamespace(name="prism", level="slide", _load_backend=lambda: loaded)
+    model = SimpleNamespace(name="prism", level="slide", _declare_encoder_input=_noop_declare_encoder_input,
+        _load_backend=lambda: loaded)
     artifact = SimpleNamespace(
         sample_id="slide-a",
         path=tmp_path / "tile_embeddings" / "slide-a.pt",
@@ -1444,6 +1451,7 @@ def test_run_pipeline_skips_zero_tile_slides_and_counts_only_embeddable_slides(m
         name="prism",
         level="slide",
         _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=lambda: SimpleNamespace(),
     )
 
@@ -1651,7 +1659,8 @@ def test_compute_embedded_slides_skips_retaining_results_when_collect_results_is
     ]
     seen: list[str] = []
 
-    model = SimpleNamespace(level="tile", _load_backend=lambda: SimpleNamespace())
+    model = SimpleNamespace(level="tile", _declare_encoder_input=_noop_declare_encoder_input,
+        _load_backend=lambda: SimpleNamespace())
 
     monkeypatch.setattr(embedding_pipeline, "emit_progress", lambda *args, **kwargs: None)
     monkeypatch.setattr(hierarchical, "is_hierarchical_preprocessing", lambda preprocessing: False)
@@ -1711,7 +1720,13 @@ def test_pipeline_worker_disables_result_collection_when_streaming(monkeypatch, 
     monkeypatch.setattr(distributed, "get_local_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_size", lambda: 1)
-    monkeypatch.setattr(Model, "from_preset", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        Model,
+        "from_preset",
+        lambda *args, **kwargs: SimpleNamespace(
+            _declare_encoder_input=_noop_declare_encoder_input
+        ),
+    )
     monkeypatch.setattr(serialization, "deserialize_preprocessing", lambda payload: DEFAULT_PREPROCESSING)
     monkeypatch.setattr(
         serialization,
@@ -1775,7 +1790,13 @@ def test_pipeline_worker_filters_to_requested_sample_ids(monkeypatch, tmp_path: 
     monkeypatch.setattr(distributed, "get_local_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_size", lambda: 1)
-    monkeypatch.setattr(Model, "from_preset", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        Model,
+        "from_preset",
+        lambda *args, **kwargs: SimpleNamespace(
+            _declare_encoder_input=_noop_declare_encoder_input
+        ),
+    )
     monkeypatch.setattr(serialization, "deserialize_preprocessing", lambda payload: DEFAULT_PREPROCESSING)
     monkeypatch.setattr(
         serialization,
@@ -1837,7 +1858,13 @@ def test_direct_embed_worker_streams_payloads_without_retaining_results(monkeypa
     monkeypatch.setattr(distributed, "get_local_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_size", lambda: 1)
-    monkeypatch.setattr(Model, "from_preset", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        Model,
+        "from_preset",
+        lambda *args, **kwargs: SimpleNamespace(
+            _declare_encoder_input=_noop_declare_encoder_input
+        ),
+    )
     monkeypatch.setattr(serialization, "deserialize_preprocessing", lambda payload: DEFAULT_PREPROCESSING)
     monkeypatch.setattr(
         serialization,
@@ -1898,6 +1925,7 @@ def test_run_pipeline_local_branch_persists_completed_slides_before_later_failur
         name="virchow2",
         level="tile",
         _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=lambda: SimpleNamespace(feature_dim=2, device="cpu", model=SimpleNamespace()),
     )
 
@@ -1954,6 +1982,7 @@ def test_run_pipeline_resume_skips_successful_local_embeddings(monkeypatch, tmp_
         name="virchow2",
         level="tile",
         _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=lambda: SimpleNamespace(feature_dim=2, device="cpu", model=SimpleNamespace()),
     )
 
@@ -2050,6 +2079,7 @@ def test_run_pipeline_local_persists_completed_embeddings_before_later_slide_fai
         name="prism",
         level="slide",
         _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=lambda: SimpleNamespace(),
     )
 
@@ -2850,7 +2880,8 @@ def test_embed_single_slide_distributed_uses_shared_slide_aggregation_helper(mon
     )
 
     loaded = SimpleNamespace(device="cpu", model=SimpleNamespace())
-    model = SimpleNamespace(level="slide", _load_backend=lambda: loaded)
+    model = SimpleNamespace(level="slide", _declare_encoder_input=_noop_declare_encoder_input,
+        _load_backend=lambda: loaded)
     captured = {}
 
     def fake_aggregate(loaded_arg, model_arg, slide_arg, tiling_result_arg, tile_embeddings_arg, *, preprocessing, execution):
@@ -2924,6 +2955,7 @@ def test_embed_single_slide_distributed_skips_parent_backend_load_for_tile_model
     model = SimpleNamespace(
         name="h0-mini",
         level="tile",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=fail_if_called,
     )
     monkeypatch.setattr(distributed_stage, "aggregate_tile_embeddings_for_slide", fail_if_called)
@@ -3050,7 +3082,8 @@ def test_select_embedding_path_uses_multi_slide_distributed_when_multiple_slides
 def test_inference_embed_tiles_requires_output_dir_before_loading_runtime(monkeypatch):
     import slide2vec.inference as inference
 
-    model = SimpleNamespace(_load_backend=lambda: (_ for _ in ()).throw(AssertionError("should fail before loading model")))
+    model = SimpleNamespace(_declare_encoder_input=_noop_declare_encoder_input,
+        _load_backend=lambda: (_ for _ in ()).throw(AssertionError("should fail before loading model")))
 
     with pytest.raises(ValueError, match="ExecutionOptions.output_dir is required to persist tile embeddings"):
         inference.embed_tiles(
@@ -3223,6 +3256,7 @@ def test_direct_embed_slides_allows_no_output_dir_and_optional_persistence(monke
         name="prism",
         level="slide",
         _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=lambda: SimpleNamespace(),
     )
     in_memory = inference.embed_slides(
@@ -3299,6 +3333,7 @@ def test_direct_embed_slides_persists_completed_embeddings_before_later_slide_fa
         name="prism",
         level="slide",
         _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=lambda: SimpleNamespace(),
     )
 
@@ -3371,6 +3406,7 @@ def test_direct_embed_slides_single_gpu_reconciles_batched_tile_status_on_clean_
         name="uni2",
         level="tile",
         _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
         _load_backend=lambda: SimpleNamespace(),
     )
 
@@ -5011,7 +5047,11 @@ def test_load_model_auto_prefers_cuda_when_available(monkeypatch):
     monkeypatch.setattr(base.timm, "create_model", lambda *args, **kwargs: FakeModel())
     monkeypatch.delenv("HF_TOKEN", raising=False)
 
-    loaded = inference.load_model(name="h0-mini", device="auto")
+    loaded = inference.load_model(
+        name="h0-mini",
+        device="auto",
+        encoder_input=EncoderInputContract.given(),
+    )
 
     assert loaded.device == torch.device("cuda")
 
@@ -5046,6 +5086,7 @@ def test_load_model_accepts_allow_non_recommended_settings_without_forwarding(mo
     loaded = inference.load_model(
         name="dummy-model",
         allow_non_recommended_settings=True,
+        encoder_input=EncoderInputContract.given(),
     )
 
     assert loaded.name == "dummy-model"
@@ -6093,7 +6134,13 @@ def test_direct_embed_worker_slide_shard_writes_per_class_payloads_without_colli
     monkeypatch.setattr(distributed, "get_local_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_size", lambda: 1)
-    monkeypatch.setattr(Model, "from_preset", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        Model,
+        "from_preset",
+        lambda *args, **kwargs: SimpleNamespace(
+            _declare_encoder_input=_noop_declare_encoder_input
+        ),
+    )
     monkeypatch.setattr(serialization, "deserialize_preprocessing", lambda payload: DEFAULT_PREPROCESSING)
     monkeypatch.setattr(serialization, "deserialize_execution", lambda payload: ExecutionOptions(output_dir=tmp_path))
     monkeypatch.setattr(direct_embed_worker, "_to_cpu_payload", lambda value: value)
@@ -6140,7 +6187,8 @@ def test_compute_embedded_slides_finished_event_carries_annotation(monkeypatch):
     tiling_result = SimpleNamespace(x=np.array([0]), y=np.array([1]), tile_size_lv0=224, annotation="tumor")
 
     loaded = SimpleNamespace()
-    model = SimpleNamespace(level="tile", _load_backend=lambda: loaded)
+    model = SimpleNamespace(level="tile", _declare_encoder_input=_noop_declare_encoder_input,
+        _load_backend=lambda: loaded)
 
     monkeypatch.setattr(
         embedding_pipeline,
@@ -6205,7 +6253,13 @@ def test_pipeline_worker_embeds_every_class_of_a_multi_class_slide(monkeypatch, 
     monkeypatch.setattr(distributed, "get_local_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_rank", lambda: 0)
     monkeypatch.setattr(distributed, "get_global_size", lambda: 1)
-    monkeypatch.setattr(Model, "from_preset", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        Model,
+        "from_preset",
+        lambda *args, **kwargs: SimpleNamespace(
+            _declare_encoder_input=_noop_declare_encoder_input
+        ),
+    )
     monkeypatch.setattr(serialization, "deserialize_preprocessing", lambda payload: DEFAULT_PREPROCESSING)
     monkeypatch.setattr(serialization, "deserialize_execution", lambda payload: ExecutionOptions(output_dir=tmp_path))
     monkeypatch.setattr(

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1285,8 +1285,11 @@ def test_aggregate_tiles_uses_autocast_for_slide_encoding(monkeypatch, tmp_path:
         return SimpleNamespace(sample_id=sample_id, path=tmp_path / "slide_embeddings" / f"{sample_id}.pt")
 
     loaded = SimpleNamespace(device=torch.device("cpu"), model=SimpleNamespace(encode_slide=encode_slide))
-    model = SimpleNamespace(name="prism", level="slide", _declare_encoder_input=_noop_declare_encoder_input,
-        _load_backend=lambda: loaded)
+    model = SimpleNamespace(
+        name="prism",
+        level="slide",
+        _load_backend_without_transform=lambda: loaded,
+    )
     artifact = SimpleNamespace(
         sample_id="slide-a",
         path=tmp_path / "tile_embeddings" / "slide-a.pt",
@@ -2880,8 +2883,7 @@ def test_embed_single_slide_distributed_uses_shared_slide_aggregation_helper(mon
     )
 
     loaded = SimpleNamespace(device="cpu", model=SimpleNamespace())
-    model = SimpleNamespace(level="slide", _declare_encoder_input=_noop_declare_encoder_input,
-        _load_backend=lambda: loaded)
+    model = SimpleNamespace(level="slide", _load_backend_without_transform=lambda: loaded)
     captured = {}
 
     def fake_aggregate(loaded_arg, model_arg, slide_arg, tiling_result_arg, tile_embeddings_arg, *, preprocessing, execution):
@@ -2955,8 +2957,7 @@ def test_embed_single_slide_distributed_skips_parent_backend_load_for_tile_model
     model = SimpleNamespace(
         name="h0-mini",
         level="tile",
-        _declare_encoder_input=_noop_declare_encoder_input,
-        _load_backend=fail_if_called,
+        _load_backend_without_transform=fail_if_called,
     )
     monkeypatch.setattr(distributed_stage, "aggregate_tile_embeddings_for_slide", fail_if_called)
 


### PR DESCRIPTION
Closes #232

## What

`load_model` chose the tile transform by testing whether a pooled input plan was passed. `None` was overloaded: it legitimately meant *"the caller supplied pixels it never requested, so the shipped transform is the contract"* (pre-cropped tile datasets), and it also meant *"the caller forgot"*. Nothing distinguished them, and that overload already produced a silent divergence downstream — `soma` routes pooled extraction by GPU count, `Pipeline` built the plan, the in-process `compute_embedded_slides` route did not, so one config yielded different features on 1 GPU vs 2 with no test failing.

This replaces the nullable plan with a required, non-defaultable `encoder_input: EncoderInputContract` argument at the model-load seam, naming two regimes:

- **declared** — the caller states the encoder input it wants; slide2vec honors it exactly or raises. Unchanged `PooledEncoderInputPlan` semantics: off-preset without `allow_non_recommended_settings` raises, a non-variable-input encoder raises, a non-multiple of the patch size raises, otherwise `preprocessing_kind="normalization_only"`.
- **given** — the caller supplies pixels it never requested; the encoder's shipped transform is the contract and the observed encoder input size is *recorded* (via the existing `_record_encoder_input_size`) rather than vetoed.

Omitting the contract raises rather than silently selecting the shipped recipe: the parameter has no default, and a non-contract value (including `None`) is rejected with an instructive `TypeError`.

`compute_embedded_slides` now resolves the contract itself, so the in-process embed route cannot bypass geometry canonicalization by calling one layer below `Pipeline`. Declaring is idempotent, so the layers above still declare too (and keep the run-info log).

## Changes

- New `slide2vec/runtime/encoder_input_contract.py`: `EncoderInputContract` (frozen dataclass, `regime: Literal["declared", "given"]`, `declared(...)` / `given()` constructors, `get_transform`, `construction_kwargs_for`).
- `load_model(*, name, encoder_input, ...)` — required, no default; the two plan-vs-None branches collapse into contract methods.
- `Model._prepare_pooled_input` → `Model._declare_encoder_input`, returning the contract; `Model._pooled_input_plan` → `Model._encoder_input`.
- The distributed pipeline/direct-embed workers declare via the same method (their defensive `getattr` probe is gone).
- Docs: the pooled tile geometry section now names the two regimes.

No deprecation path or dual code path — this is a breaking change for direct `load_model` callers, which must now pass `encoder_input=`.

## Tests

New `tests/test_encoder_input_contract.py`, including a regression test asserting `Pipeline` and the in-process embed route resolve to the *same* transform for the same config — the divergence class above. Full suite: `560 passed, 26 deselected` (`-m 'not heavy'`, matching CI).