### PR TITLE
State the encoder-input contract over the effective encoder input

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -223,6 +223,28 @@ a ``(K, grid_h, grid_w)`` CLS-attention grid, with ``attention_blocks`` and
 ``attention_include_registers`` forwarded to that call. Both feature kinds share
 the same read / pad / window path.
 
+Variable encoder input for dense runs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A dense run states a *supervision* geometry — the ROI ``target_size`` the token
+grid registers to, plus an optional ``window_size`` — not an encoder input.
+``Model.embed_regions_dense`` derives the **effective encoder input** from it,
+i.e. the geometry of the tensor handed to ``encode_tiles_dense``:
+
+- whole-tile (``window_size=None``): the ROI padded up to the patch multiple;
+- sliding: the ``window_size`` rounded to the patch multiple and clamped to that
+  padded extent.
+
+That size then goes through the same check as a pooled
+``requested_tile_size_px``: when it differs from the encoder's registered input
+size, the encoder must declare ``supports_variable_input_size=True``, and its
+``variable_input_model_kwargs`` (e.g. ``dynamic_img_size=True``) are applied at
+construction. Whole-tile dense at a non-native size on a fixed-input encoder
+(e.g. ``phikon``) therefore fails before any region is read, instead of feeding
+the backbone a size it cannot accept; sliding at the native window passes the
+check trivially. Callers never pass ``dynamic_img_size`` — it is derived from the
+declared geometry plus the registry metadata.
+
 Dense Attention Map Extraction
 ------------------------------
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -231,7 +231,10 @@ Notes:
 - ``musk`` dense extraction currently requires its native 384 x 384 input size.
 - H-Optimus dense extraction at non-native input sizes requires
   ``dynamic_img_size=True`` and ``allow_non_recommended_settings=True`` when
-  constructing the encoder.
+  constructing the encoder directly. Through ``Model.embed_regions_dense`` the
+  ``dynamic_img_size`` half is derived from the declared geometry, so only
+  ``allow_non_recommended_settings=True`` (the H-Optimus model card advises
+  against variable input) has to be passed to ``Model.from_preset``.
 - ``genbio-pathfm`` is a single-channel ViT: its dense grid (via
   ``forward_with_patches``) concatenates the three per-colour-channel patch grids
   along the feature dim, so ``d`` = 4608 matches the pooled output dimension.

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -73,6 +73,14 @@ Omitting the contract is an error, not a silent fallback to the shipped recipe:
 "the caller never requested this geometry" and "the caller forgot" must not look
 alike at the seam where the transform is chosen.
 
+The declared regime covers dense extraction too. Pooled and dense derive the
+**effective encoder input** — the geometry of the tensor immediately before
+``encode_tiles`` / ``encode_tiles_dense`` — differently (``requested_tile_size_px``
+for pooled; the padded ROI or the patch-aligned window for dense, see
+:doc:`api`), but both then ask the same thing of it: whether the encoder is
+registered as variable-input capable, and which constructor settings activate
+that. There is no separate ``dynamic_img_size`` knob for dense; it is derived.
+
 This reader convergence intentionally changes pooled embeddings for runs where
 ``read_tile_size_px != requested_tile_size_px``: older runs could pass the raw
 pyramid read directly to the model transform. There is no legacy compatibility

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -352,6 +352,9 @@ class DenseOptions:
     image_pad_value: float | None = None
     #: Encoder field-of-view chunk fed through the backbone per forward. ``None`` (default)
     #: is one whole-tile forward; a smaller value slides the encoder and blends token grids.
+    #: Together with ``target_size`` this fixes the *effective encoder input*, from which the
+    #: variable-input constructor settings are derived — hence no ``dynamic_img_size`` knob
+    #: here (see :meth:`Model._declare_dense_encoder_input`).
     window_size: int | None = None
     #: Fractional window overlap in ``[0, 1)`` for the sliding path (ignored when
     #: ``window_size is None``).
@@ -685,6 +688,12 @@ class Model:
         (``execution.num_gpus``); ``num_gpus=1`` encodes fully in-process. Resume is
         automatic — ROIs whose sidecar already exists are skipped. Returns one
         :class:`~slide2vec.artifacts.DenseRegionArtifact` per input ROI.
+
+        The effective encoder input — the padded ROI for a whole-tile run, one
+        patch-aligned window for a sliding one — is declared before any region is read, so
+        a geometry the encoder cannot accept raises here rather than at the first forward
+        pass. Variable-input capable encoders get their registry-declared constructor
+        settings applied automatically; there is nothing for the caller to pass.
         """
         from slide2vec.runtime.dense_stage import embed_regions_dense
 
@@ -699,7 +708,7 @@ class Model:
         *,
         emit_run_info: bool,
     ) -> EncoderInputContract:
-        """Declare the encoder input geometry this run requested, or raise.
+        """Declare the pooled encoder input geometry this run requested, or raise.
 
         Idempotent: resolving the same preprocessing twice yields an equal contract, so
         every layer that reaches the encoder may declare for itself rather than trust
@@ -710,7 +719,7 @@ class Model:
                 "requested_tile_size_px must be resolved before declaring the encoder "
                 "input geometry; a pooled run reads tiles at a size it requested."
             )
-        contract = EncoderInputContract.declared(
+        contract = EncoderInputContract.declared_pooled(
             self.name,
             requested_tile_size_px=int(preprocessing.requested_tile_size_px),
             allow_non_recommended_settings=self.allow_non_recommended_settings,
@@ -728,6 +737,42 @@ class Model:
             )
         return contract
 
+    def _declare_dense_encoder_input(
+        self,
+        dense: "DenseOptions",
+        *,
+        emit_run_info: bool,
+    ) -> EncoderInputContract:
+        """Declare the dense encoder input geometry this run requested, or raise.
+
+        Dense states a supervision geometry (ROI ``target_size``, optional ``window_size``)
+        rather than an encoder input; the contract derives the tensor the backbone will
+        actually see and validates it exactly as the pooled path's is validated. Like the
+        pooled declaration this is idempotent, so each layer that reaches the encoder — the
+        parent stage and every torchrun rank — declares for itself.
+        """
+        contract = EncoderInputContract.declared_dense(
+            self.name,
+            target_size_px=int(dense.target_size),
+            window_size=None if dense.window_size is None else int(dense.window_size),
+        )
+        self._encoder_input = contract
+        plan = contract.plan
+        if emit_run_info and plan.requires_variable_model_input:
+            logging.getLogger("slide2vec").info(
+                "Dense encoder input for '%s': native %dpx, effective encoder input "
+                "%dx%dpx (target_size=%dpx, window_size=%s); enabling variable input "
+                "size via %s.",
+                self.name,
+                plan.preset_input_size_px,
+                plan.effective_encoder_input_size_px[0],
+                plan.effective_encoder_input_size_px[1],
+                plan.target_size_px,
+                plan.window_size_px,
+                plan.model_construction_kwargs or "no constructor setting",
+            )
+        return contract
+
     def _load_backend(self) -> LoadedModel:
         """Load the backend under this run's declared encoder-input contract.
 
@@ -740,21 +785,26 @@ class Model:
                 f"No encoder-input contract has been declared for model '{self.name}'. "
                 "A route that encodes pixels must state its geometry before the "
                 "backend is loaded: call _declare_encoder_input(preprocessing, ...) "
-                "for a run that requested a tile size. Callers that never read "
-                "loaded.transforms use _load_backend_without_transform() instead."
+                "for a pooled run, or _declare_dense_encoder_input(dense, ...) for a "
+                "dense one. Callers that never read loaded.transforms use "
+                "_load_backend_without_transform() instead."
             )
         return self._load_backend_under(self._encoder_input)
 
     def _load_backend_without_transform(self) -> LoadedModel:
         """Load the backend for callers that never read ``loaded.transforms``.
 
-        Three kinds of caller need the constructed encoder module without ever
-        selecting a tile transform: the ``device``/``feature_dim`` properties (pure
-        construction facts), tile→slide/patient aggregation (``encode_slide`` /
-        ``encode_patient`` consume already-computed features), and dense extraction
-        (which builds its own normalization transform from the module — dense gets its
-        own contract separately). They cannot observe, let alone encode through, the
-        transform the backend happens to carry.
+        Two kinds of caller need the constructed encoder module without ever selecting a
+        tile transform: the ``device``/``feature_dim`` properties (pure construction
+        facts) and tile→slide/patient aggregation (``encode_slide`` / ``encode_patient``
+        consume already-computed features). They cannot observe, let alone encode
+        through, the transform the backend happens to carry.
+
+        Dense extraction is deliberately NOT in this set. It builds its own normalization
+        transform and never reads ``loaded.transforms``, but it does need the
+        variable-input constructor settings its geometry implies — which is exactly what
+        an encoder-input contract carries — so it declares (see
+        ``_declare_dense_encoder_input``) and loads through ``_load_backend``.
 
         A declared contract is honored when one exists so the cached backend is shared;
         otherwise an explicit Given contract is used for this load only. This never

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -29,6 +29,7 @@ from slide2vec.runtime.model_settings import (
 )
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.types import LoadedModel
+from slide2vec.runtime.effective_encoder_input import format_input_size
 from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 from slide2vec.utils.utils import cpu_worker_limit, slurm_cpu_limit
 
@@ -352,9 +353,9 @@ class DenseOptions:
     image_pad_value: float | None = None
     #: Encoder field-of-view chunk fed through the backbone per forward. ``None`` (default)
     #: is one whole-tile forward; a smaller value slides the encoder and blends token grids.
-    #: Together with ``target_size`` this fixes the *effective encoder input*, from which the
-    #: variable-input constructor settings are derived — hence no ``dynamic_img_size`` knob
-    #: here (see :meth:`Model._declare_dense_encoder_input`).
+    #: Together with ``target_size`` this fixes the *effective encoder input* — the geometry
+    #: handed to ``encode_tiles_dense`` — from which the encoder's variable-input constructor
+    #: settings are derived; hence no ``dynamic_img_size`` knob here.
     window_size: int | None = None
     #: Fractional window overlap in ``[0, 1)`` for the sliding path (ignored when
     #: ``window_size is None``).
@@ -760,13 +761,11 @@ class Model:
         plan = contract.plan
         if emit_run_info and plan.requires_variable_model_input:
             logging.getLogger("slide2vec").info(
-                "Dense encoder input for '%s': native %dpx, effective encoder input "
-                "%dx%dpx (target_size=%dpx, window_size=%s); enabling variable input "
-                "size via %s.",
+                "Dense encoder input for '%s': native %dpx, effective encoder input %s "
+                "(target_size=%dpx, window_size=%s); enabling variable input size via %s.",
                 self.name,
                 plan.preset_input_size_px,
-                plan.effective_encoder_input_size_px[0],
-                plan.effective_encoder_input_size_px[1],
+                format_input_size(plan.effective_encoder_input_size_px),
                 plan.target_size_px,
                 plan.window_size_px,
                 plan.model_construction_kwargs or "no constructor setting",

--- a/slide2vec/distributed/dense_worker.py
+++ b/slide2vec/distributed/dense_worker.py
@@ -63,9 +63,12 @@ def main(argv=None) -> int:
     )
     dense = deserialize_dense_options(request["dense"])
     execution = deserialize_execution(request["execution"])
-    # Dense builds its own transform from the encoder module (see dense_regions:
-    # get_normalization_transform) and never reads loaded.transforms.
-    loaded = model._load_backend_without_transform()
+    # Each rank declares its own dense encoder-input contract rather than trusting the
+    # parent to have done it (the declaration is idempotent): that is what supplies the
+    # variable-input constructor settings this ROI geometry implies. emit_run_info=False —
+    # the run-info line is logged once by the parent, not once per rank.
+    model._declare_dense_encoder_input(dense, emit_run_info=False)
+    loaded = model._load_backend()
 
     progress_events_path = request.get("progress_events_path")
     reporter = (

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -93,17 +93,22 @@ def load_model(
     device: str = "auto",
     output_variant: str | None = None,
     allow_non_recommended_settings: bool = False,
-    dynamic_img_size: bool | None = None,
     token: str | None = None,
 ) -> LoadedModel:
+    # There is deliberately no ``dynamic_img_size`` parameter: variable encoder input is a
+    # *derived* fact of the declared geometry (see EncoderInputContract), not something a
+    # caller hand-passes. Hand-passing it was unverified in both directions — silently
+    # dropped by encoders whose constructor lacks the parameter, and never checked against
+    # the size actually fed to the encoder.
     # ``encoder_input`` is required and deliberately has no default: the transform a
     # run encodes through is a contract the caller states, never something load_model
     # infers from an absent argument. See EncoderInputContract for the two regimes.
     if not isinstance(encoder_input, EncoderInputContract):
         raise TypeError(
             "load_model requires an explicit encoder-input contract: pass "
-            "encoder_input=EncoderInputContract.declared(...) when the caller states "
-            "the encoder input geometry it wants, or EncoderInputContract.given() "
+            "encoder_input=EncoderInputContract.declared_pooled(...) / "
+            ".declared_dense(...) when the caller states the encoder input geometry it "
+            "wants, or EncoderInputContract.given() "
             "when the caller supplies pixels it never requested and the encoder's "
             f"shipped transform is the contract; got {encoder_input!r}"
         )
@@ -132,17 +137,15 @@ def load_model(
         hf_login(token=token, add_to_git_credential=False)
 
     encoder_cls = encoder_registry.require(name)
-    # Pass dynamic_img_size / allow_non_recommended_settings ONLY to encoders whose
-    # constructor accepts them (e.g. H-optimus needs both to opt into variable input
-    # size for dense extraction; most others hardcode dynamic_img_size=True and take
-    # neither). Limited to these two named params on purpose — not a generic kwargs
-    # passthrough — so load_model stays a narrow construction contract.
+    # Pass allow_non_recommended_settings ONLY to encoders whose constructor accepts it
+    # (e.g. H-optimus needs it to opt into the variable input size its model card advises
+    # against; most encoders take no such parameter). Limited to that one named param on
+    # purpose — not a generic kwargs passthrough — so load_model stays a narrow
+    # construction contract; every other setting comes from the encoder-input contract.
     import inspect
 
     ctor_params = inspect.signature(encoder_cls.__init__).parameters
     extra_kwargs: dict = {}
-    if dynamic_img_size is not None and "dynamic_img_size" in ctor_params:
-        extra_kwargs["dynamic_img_size"] = dynamic_img_size
     if "allow_non_recommended_settings" in ctor_params:
         extra_kwargs["allow_non_recommended_settings"] = allow_non_recommended_settings
     contract_kwargs = encoder_input.construction_kwargs_for(name)
@@ -151,7 +154,7 @@ def load_model(
         if missing_params:
             missing_text = ", ".join(sorted(missing_params))
             raise ValueError(
-                f"Encoder '{name}' requires pooled variable-input constructor "
+                f"Encoder '{name}' requires variable-input constructor "
                 f"setting(s) not accepted by its implementation: {missing_text}"
             )
         extra_kwargs.update(contract_kwargs)
@@ -190,7 +193,7 @@ def load_model(
             if missing_params:
                 missing_text = ", ".join(sorted(missing_params))
                 raise ValueError(
-                    f"Encoder '{tile_enc_name}' requires pooled variable-input "
+                    f"Encoder '{tile_enc_name}' requires variable-input "
                     "constructor setting(s) not accepted by its implementation: "
                     f"{missing_text}"
                 )

--- a/slide2vec/runtime/dense_encoder_input.py
+++ b/slide2vec/runtime/dense_encoder_input.py
@@ -1,0 +1,111 @@
+"""Resolve dense grid geometry into the encoder input the backbone actually sees.
+
+The dense counterpart of :mod:`slide2vec.runtime.pooled_encoder_input`. A dense run states
+a *supervision* geometry — the ROI ``target_size`` the token grid registers to, and
+optionally a ``window_size`` the encoder's field is slid over — neither of which is the
+tensor the backbone receives. Two rules turn one into the other:
+
+* **whole-tile** (``window_size is None``): the ROI is padded up to the encoder's patch
+  multiple, so the effective encoder input is ``encoded_size``;
+* **sliding**: the encoder only ever sees one patch-aligned window, so the effective
+  encoder input is ``window_size`` rounded to the patch multiple and clamped to the
+  encoded extent (a window at least as large as the tile *is* the whole-tile case).
+
+Both then go through the one shared capability check
+(:class:`~slide2vec.runtime.effective_encoder_input.EffectiveEncoderInput`), which is what
+makes ``dynamic_img_size`` a derived fact rather than a knob a caller hand-passes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from slide2vec.encoders.registry import (
+    resolve_patch_size,
+    resolve_preprocessing_requirements,
+)
+from slide2vec.runtime.effective_encoder_input import EffectiveEncoderInput
+
+
+@dataclass(frozen=True, kw_only=True)
+class DenseEncoderInputPlan:
+    """One dense run's effective encoder input and the construction it implies."""
+
+    encoder_name: str
+    tile_encoder_name: str
+    preset_input_size_px: int
+    #: Supervision tile side length the dense grid registers to (``DenseOptions.target_size``).
+    target_size_px: int
+    #: Requested encoder field-of-view chunk; ``None`` is one whole-tile forward.
+    window_size_px: int | None
+    #: ``target_size_px`` padded up to the patch multiple — the padded tensor's geometry.
+    encoded_size_px: tuple[int, int]
+    #: The geometry handed to ``encode_tiles_dense``: the padded tile, or one window of it.
+    effective_encoder_input_size_px: tuple[int, int]
+    requires_variable_model_input: bool
+    model_construction_kwargs: dict[str, bool]
+
+    @classmethod
+    def resolve(
+        cls,
+        encoder_name: str,
+        *,
+        target_size_px: int,
+        window_size: int | None,
+    ) -> "DenseEncoderInputPlan":
+        # Imported here, not at module scope: the dense geometry kernels live next to the
+        # dense read/encode loop, which pulls in torch/PIL/hs2p. This module is imported by
+        # the encoder-input contract, which every model load goes through.
+        from slide2vec.runtime.dense_regions import compute_dense_geometry
+        from slide2vec.runtime.dense_sliding import resolve_window_geometry
+
+        requirements = resolve_preprocessing_requirements(encoder_name)
+        preset_size = int(requirements["tile_size_px"])
+        tile_encoder_name = str(requirements["source_encoder"])
+        # The static registry patch size, not the loaded module's: the declaration is
+        # resolved *before* the encoder is constructed. ``load_model`` asserts the two
+        # agree, so the geometry resolved here is the geometry that gets encoded.
+        patch_size = resolve_patch_size(tile_encoder_name)
+        geometry = compute_dense_geometry(
+            target_size=int(target_size_px), patch_size=patch_size
+        )
+        if window_size is None:
+            effective_size = geometry.encoded_size
+            origin = (
+                f"dense whole-tile target_size={int(target_size_px)} padded to the "
+                "patch multiple"
+            )
+        else:
+            # Ask the sliding kernel itself, so the declaration cannot drift from the
+            # window the encode loop will actually cut (rounding + clamping included).
+            effective_size, _stride, _starts_h, _starts_w = resolve_window_geometry(
+                geometry, window_size=int(window_size), overlap=0.0
+            )
+            origin = (
+                f"dense window_size={int(window_size)} aligned to the patch multiple"
+            )
+        effective = EffectiveEncoderInput.resolve(
+            encoder_name, size_px=effective_size, origin=origin
+        )
+        return cls(
+            encoder_name=encoder_name,
+            tile_encoder_name=effective.tile_encoder_name,
+            preset_input_size_px=preset_size,
+            target_size_px=int(target_size_px),
+            window_size_px=None if window_size is None else int(window_size),
+            encoded_size_px=geometry.encoded_size,
+            effective_encoder_input_size_px=effective.size_px,
+            requires_variable_model_input=effective.requires_variable_model_input,
+            model_construction_kwargs=effective.model_construction_kwargs,
+        )
+
+    def get_transform(self, tile_encoder) -> Callable:
+        """Dense always encodes through the normalization-only transform.
+
+        Unconditionally, unlike the pooled plan: the shipped pooled transform resizes and
+        center-crops, which would destroy the ROI geometry the token grid registers to.
+        This is the same transform the dense read loop builds for itself, so a backend
+        loaded under a dense contract carries the transform dense actually uses.
+        """
+        return tile_encoder.get_normalization_transform()

--- a/slide2vec/runtime/dense_encoder_input.py
+++ b/slide2vec/runtime/dense_encoder_input.py
@@ -60,9 +60,9 @@ class DenseEncoderInputPlan:
         from slide2vec.runtime.dense_regions import compute_dense_geometry
         from slide2vec.runtime.dense_sliding import resolve_window_geometry
 
-        requirements = resolve_preprocessing_requirements(encoder_name)
-        preset_size = int(requirements["tile_size_px"])
-        tile_encoder_name = str(requirements["source_encoder"])
+        tile_encoder_name = str(
+            resolve_preprocessing_requirements(encoder_name)["source_encoder"]
+        )
         # The static registry patch size, not the loaded module's: the declaration is
         # resolved *before* the encoder is constructed. ``load_model`` asserts the two
         # agree, so the geometry resolved here is the geometry that gets encoded.
@@ -79,6 +79,9 @@ class DenseEncoderInputPlan:
         else:
             # Ask the sliding kernel itself, so the declaration cannot drift from the
             # window the encode loop will actually cut (rounding + clamping included).
+            # ``overlap`` is irrelevant to the *window* — it only sets the stride and the
+            # start offsets — so a fixed 0.0 here yields the run's actual window whatever
+            # ``DenseOptions.overlap`` is.
             effective_size, _stride, _starts_h, _starts_w = resolve_window_geometry(
                 geometry, window_size=int(window_size), overlap=0.0
             )
@@ -90,8 +93,8 @@ class DenseEncoderInputPlan:
         )
         return cls(
             encoder_name=encoder_name,
-            tile_encoder_name=effective.tile_encoder_name,
-            preset_input_size_px=preset_size,
+            tile_encoder_name=tile_encoder_name,
+            preset_input_size_px=effective.preset_input_size_px,
             target_size_px=int(target_size_px),
             window_size_px=None if window_size is None else int(window_size),
             encoded_size_px=geometry.encoded_size,

--- a/slide2vec/runtime/dense_stage.py
+++ b/slide2vec/runtime/dense_stage.py
@@ -162,6 +162,10 @@ def embed_regions_dense(
     execution,
 ) -> list[DenseRegionArtifact]:
     """Extract + persist a dense grid per ROI across all visible GPUs (the D8 entry point)."""
+    # Declare the effective encoder input before anything is read, sharded or launched: a
+    # ROI geometry this encoder cannot accept must fail here, not on the first forward pass
+    # of a torchrun rank. Idempotent, so every rank re-declares for itself (dense_worker).
+    model._declare_dense_encoder_input(dense, emit_run_info=True)
     out_dir = Path(execution.output_dir).expanduser().resolve()
     execution = execution.with_output_dir(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
@@ -190,9 +194,11 @@ def embed_regions_dense(
 
 
 def _run_dense_in_process(model, specs, *, dense, execution, out_dir) -> None:
-    # Dense builds its own transform from the encoder module (see dense_regions:
-    # get_normalization_transform) and never reads loaded.transforms.
-    loaded = model._load_backend_without_transform()
+    # Loaded under the dense contract declared by embed_regions_dense, which supplies the
+    # variable-input constructor settings this geometry needs. Dense builds its own
+    # normalization transform (see dense_regions) and never reads loaded.transforms — but
+    # the contract selects that same transform, so the backend is not carrying a different one.
+    loaded = model._load_backend()
     run_dense_shard(
         specs,
         model=loaded.model,

--- a/slide2vec/runtime/effective_encoder_input.py
+++ b/slide2vec/runtime/effective_encoder_input.py
@@ -1,0 +1,123 @@
+"""The one place the variable-input question is asked — for pooled and dense alike.
+
+The **effective encoder input** is the geometry of the tensor handed to ``encode_tiles`` /
+``encode_tiles_dense``: after preprocessing, after padding, after windowing. Every
+extraction path resolves it differently, but every extraction path then asks the *same* two
+questions of it — is this a size the encoder can accept, and which constructor settings
+activate that? Those questions are answered here, once:
+
+===================  ====================================================================
+path                 effective encoder input
+===================  ====================================================================
+pooled, declared     ``requested_tile_size_px``
+dense, whole-tile    the padded ``encoded_size`` (target rounded to the patch multiple)
+dense, sliding       the patch-aligned ``window_size`` (native ⇒ the check passes trivially)
+given                not declared — observed after the encoder's shipped transform
+===================  ====================================================================
+
+Before this existed the dense path answered them by a different, unchecked route: the
+caller hand-passed ``dynamic_img_size`` to ``load_model``, which applied it only when the
+encoder's constructor happened to accept the parameter. For a fixed-input encoder such as
+phikon that silently swallowed the request and the run went on to feed the backbone a size
+it cannot accept. Same question, two mechanisms, one of them unverified.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from slide2vec.encoders.registry import (
+    encoder_registry,
+    resolve_patch_size,
+    resolve_preprocessing_requirements,
+    resolve_variable_input_capability,
+)
+
+
+def format_input_size(size_px: tuple[int, int]) -> str:
+    """Render an effective input size for error messages (``518px`` / ``518x504px``)."""
+    height, width = size_px
+    return f"{height}px" if height == width else f"{height}x{width}px"
+
+
+@dataclass(frozen=True, kw_only=True)
+class EffectiveEncoderInput:
+    """One resolved effective encoder input and the construction it implies.
+
+    ``requires_variable_model_input`` is simply "this is not the encoder's registered
+    input size", and ``model_construction_kwargs`` is the registry's
+    ``variable_input_model_kwargs`` for the tile encoder that will actually see the tensor
+    (empty for encoders that hardcode the setting, or that need none).
+    """
+
+    encoder_name: str
+    #: The encoder that actually sees the tensor: a slide/patient model resolves through
+    #: the tile encoder it declares as its dependency.
+    tile_encoder_name: str
+    preset_input_size_px: int
+    size_px: tuple[int, int]
+    requires_variable_model_input: bool
+    model_construction_kwargs: dict[str, bool]
+
+    @classmethod
+    def resolve(
+        cls,
+        encoder_name: str,
+        *,
+        size_px: int | tuple[int, int],
+        origin: str,
+    ) -> "EffectiveEncoderInput":
+        """Resolve an effective encoder input, or raise naming *origin*.
+
+        *origin* is a short phrase describing where the size came from (e.g.
+        ``"requested_tile_size_px=278"``); it only shapes the error messages, so each path
+        keeps its own actionable vocabulary while sharing this one check.
+        """
+        requirements = resolve_preprocessing_requirements(encoder_name)
+        preset_size = int(requirements["tile_size_px"])
+        tile_encoder_name = str(requirements["source_encoder"])
+        size = (
+            (int(size_px), int(size_px))
+            if isinstance(size_px, int)
+            else (int(size_px[0]), int(size_px[1]))
+        )
+        if size[0] <= 0 or size[1] <= 0:
+            raise ValueError(
+                f"The effective encoder input must be positive; got "
+                f"{format_input_size(size)} ({origin})."
+            )
+        if size == (preset_size, preset_size):
+            # The encoder's own registered geometry: no capability is being asked for, and
+            # no constructor setting has to be activated.
+            return cls(
+                encoder_name=encoder_name,
+                tile_encoder_name=tile_encoder_name,
+                preset_input_size_px=preset_size,
+                size_px=size,
+                requires_variable_model_input=False,
+                model_construction_kwargs={},
+            )
+        if not resolve_variable_input_capability(encoder_name):
+            raise ValueError(
+                f"Encoder '{encoder_name}' does not support a variable encoder input; its "
+                f"registered input size is {preset_size}px, so an effective encoder input "
+                f"of {format_input_size(size)} ({origin}) is unsupported."
+            )
+        patch_h, patch_w = resolve_patch_size(tile_encoder_name)
+        if size[0] % patch_h != 0 or size[1] % patch_w != 0:
+            raise ValueError(
+                f"Encoder '{tile_encoder_name}' requires an encoder input divisible by its "
+                f"{patch_h}x{patch_w} patch geometry; got an effective encoder input of "
+                f"{format_input_size(size)} ({origin})."
+            )
+        tile_info = encoder_registry.info(tile_encoder_name)
+        return cls(
+            encoder_name=encoder_name,
+            tile_encoder_name=tile_encoder_name,
+            preset_input_size_px=preset_size,
+            size_px=size,
+            requires_variable_model_input=True,
+            model_construction_kwargs=dict(
+                tile_info.get("variable_input_model_kwargs") or {}
+            ),
+        )

--- a/slide2vec/runtime/effective_encoder_input.py
+++ b/slide2vec/runtime/effective_encoder_input.py
@@ -35,7 +35,11 @@ from slide2vec.encoders.registry import (
 
 
 def format_input_size(size_px: tuple[int, int]) -> str:
-    """Render an effective input size for error messages (``518px`` / ``518x504px``)."""
+    """Render an effective input size for messages (``518px`` / ``518x504px``).
+
+    Shared with the run-info logging in :meth:`slide2vec.api.Model` so an effective
+    encoder input reads the same wherever it is reported.
+    """
     height, width = size_px
     return f"{height}px" if height == width else f"{height}x{width}px"
 
@@ -50,7 +54,6 @@ class EffectiveEncoderInput:
     (empty for encoders that hardcode the setting, or that need none).
     """
 
-    encoder_name: str
     #: The encoder that actually sees the tensor: a slide/patient model resolves through
     #: the tile encoder it declares as its dependency.
     tile_encoder_name: str
@@ -90,7 +93,6 @@ class EffectiveEncoderInput:
             # The encoder's own registered geometry: no capability is being asked for, and
             # no constructor setting has to be activated.
             return cls(
-                encoder_name=encoder_name,
                 tile_encoder_name=tile_encoder_name,
                 preset_input_size_px=preset_size,
                 size_px=size,
@@ -112,7 +114,6 @@ class EffectiveEncoderInput:
             )
         tile_info = encoder_registry.info(tile_encoder_name)
         return cls(
-            encoder_name=encoder_name,
             tile_encoder_name=tile_encoder_name,
             preset_input_size_px=preset_size,
             size_px=size,

--- a/slide2vec/runtime/encoder_input_contract.py
+++ b/slide2vec/runtime/encoder_input_contract.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Literal
 
+from slide2vec.runtime.dense_encoder_input import DenseEncoderInputPlan
 from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
 
 #: Closed vocabulary for who owns the geometry handed to the encoder.
 EncoderInputRegime = Literal["declared", "given"]
+
+#: A resolved declared geometry: pooled or dense, both stated over the *effective encoder
+#: input* — the geometry of the tensor immediately before ``encode_tiles`` /
+#: ``encode_tiles_dense`` — and both validated by the same capability check.
+EncoderInputPlan = PooledEncoderInputPlan | DenseEncoderInputPlan
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -16,10 +22,12 @@ class EncoderInputContract:
     """Which side of the model-load seam owns the encoder input geometry.
 
     ``"declared"`` — the caller states the encoder input it wants and slide2vec honors
-    it exactly or raises: an off-preset request needs
-    ``allow_non_recommended_settings``, the encoder must be variable-input capable, and
-    the size must be a multiple of the patch geometry. ``plan`` carries the resolved
-    contract (see :class:`PooledEncoderInputPlan`).
+    it exactly or raises: the encoder must be variable-input capable and the size must be
+    a multiple of the patch geometry (and, for a pooled off-preset request,
+    ``allow_non_recommended_settings`` must be set). ``plan`` carries the resolved
+    contract — :class:`PooledEncoderInputPlan` for a pooled run,
+    :class:`DenseEncoderInputPlan` for a dense one. The two differ only in how the
+    effective encoder input is *derived*; what is checked about it is shared.
 
     ``"given"`` — the caller supplies pixels it never requested (a pre-cropped tile
     dataset, arbitrary and often non-square). The encoder's shipped transform *is* the
@@ -36,13 +44,14 @@ class EncoderInputContract:
 
     regime: EncoderInputRegime
     #: Resolved declared geometry; ``None`` in the Given regime, which has none.
-    plan: PooledEncoderInputPlan | None
+    plan: EncoderInputPlan | None
 
     def __post_init__(self) -> None:
         if self.regime == "declared" and self.plan is None:
             raise ValueError(
-                "A declared encoder-input contract requires a resolved "
-                "PooledEncoderInputPlan; use EncoderInputContract.declared(...)."
+                "A declared encoder-input contract requires a resolved encoder-input "
+                "plan; use EncoderInputContract.declared_pooled(...) or "
+                "EncoderInputContract.declared_dense(...)."
             )
         if self.regime == "given" and self.plan is not None:
             raise ValueError(
@@ -51,20 +60,43 @@ class EncoderInputContract:
             )
 
     @classmethod
-    def declared(
+    def declared_pooled(
         cls,
         encoder_name: str,
         *,
         requested_tile_size_px: int,
         allow_non_recommended_settings: bool,
     ) -> "EncoderInputContract":
-        """Resolve the geometry the caller asked for, or raise."""
+        """Resolve the pooled tile geometry the caller asked for, or raise."""
         return cls(
             regime="declared",
             plan=PooledEncoderInputPlan.resolve(
                 encoder_name,
                 requested_tile_size_px=requested_tile_size_px,
                 allow_non_recommended_settings=allow_non_recommended_settings,
+            ),
+        )
+
+    @classmethod
+    def declared_dense(
+        cls,
+        encoder_name: str,
+        *,
+        target_size_px: int,
+        window_size: int | None,
+    ) -> "EncoderInputContract":
+        """Resolve the dense ROI geometry the caller asked for, or raise.
+
+        Dense states a supervision geometry rather than an encoder input, so the effective
+        encoder input is derived from it (padded tile, or one patch-aligned window) before
+        the shared capability check runs.
+        """
+        return cls(
+            regime="declared",
+            plan=DenseEncoderInputPlan.resolve(
+                encoder_name,
+                target_size_px=target_size_px,
+                window_size=window_size,
             ),
         )
 

--- a/slide2vec/runtime/pooled_encoder_input.py
+++ b/slide2vec/runtime/pooled_encoder_input.py
@@ -3,19 +3,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Literal
 
-from slide2vec.encoders.registry import (
-    encoder_registry,
-    resolve_preprocessing_requirements,
-    resolve_patch_size,
-    resolve_variable_input_capability,
-)
+from slide2vec.encoders.registry import resolve_preprocessing_requirements
+from slide2vec.runtime.effective_encoder_input import EffectiveEncoderInput
+
+#: Closed vocabulary for which encoder-owned preprocessing a pooled run applies.
+PooledPreprocessingKind = Literal["shipped", "normalization_only"]
 
 
 @dataclass(frozen=True, kw_only=True)
 class PooledEncoderInputPlan:
     """One pooled run's encoder-input and preprocessing contract.
+
+    The pooled **effective encoder input** is ``requested_tile_size_px``: the exact square
+    the normalization-only recipe hands to ``encode_tiles``. Whether the encoder can accept
+    it is not decided here — that question is shared with dense extraction and is answered
+    by :class:`~slide2vec.runtime.effective_encoder_input.EffectiveEncoderInput`.
 
     ``expected_encoder_input_size_px`` is intentionally nullable for a shipped
     preset recipe: the factual size is observed from the transformed batch just
@@ -26,7 +30,7 @@ class PooledEncoderInputPlan:
     tile_encoder_name: str
     preset_input_size_px: int
     requested_tile_size_px: int
-    preprocessing_kind: str
+    preprocessing_kind: PooledPreprocessingKind
     requires_variable_model_input: bool
     expected_encoder_input_size_px: int | None
     model_construction_kwargs: dict[str, bool]
@@ -42,57 +46,43 @@ class PooledEncoderInputPlan:
         requirements = resolve_preprocessing_requirements(encoder_name)
         preset_size = int(requirements["tile_size_px"])
         requested_size = int(requested_tile_size_px)
+        # The permission gate is pooled-specific and stays here: a non-preset pooled tile
+        # size deviates from the *model card's tiling recipe* (a different field of view at
+        # the same spacing), which is a scientific choice the caller must opt into. Dense
+        # extraction has no such recipe to deviate from — the ROI size is the caller's
+        # supervision geometry, not a tiling recommendation — so it shares the capability
+        # check below without inheriting this gate.
         if requested_size != preset_size and not allow_non_recommended_settings:
             raise ValueError(
                 f"Encoder '{encoder_name}' was requested at {requested_size}px instead "
                 f"of its {preset_size}px preset. Set allow_non_recommended_settings=True "
                 "to request an exact non-preset encoder input."
             )
-        if requested_size != preset_size and not resolve_variable_input_capability(
-            encoder_name
-        ):
-            raise ValueError(
-                f"Encoder '{encoder_name}' does not support variable pooled input "
-                f"geometry; its registered preset is {preset_size}px, so "
-                f"requested_tile_size_px={requested_size} is unsupported."
-            )
-        if requested_size != preset_size and requested_size <= 0:
-            raise ValueError(
-                "requested_tile_size_px must be a positive square size; "
-                f"got {requested_size}px"
-            )
-        if requested_size != preset_size:
-            patch_h, patch_w = resolve_patch_size(str(requirements["source_encoder"]))
-            if requested_size % patch_h != 0 or requested_size % patch_w != 0:
-                raise ValueError(
-                    f"Encoder '{requirements['source_encoder']}' requires exact pooled "
-                    f"inputs divisible by its {patch_h}x{patch_w} patch geometry; got "
-                    f"requested_tile_size_px={requested_size}."
-                )
-        is_exact = requested_size != preset_size
-        if is_exact:
-            tile_info = encoder_registry.info(str(requirements["source_encoder"]))
+        effective = EffectiveEncoderInput.resolve(
+            encoder_name,
+            size_px=requested_size,
+            origin=f"requested_tile_size_px={requested_size}",
+        )
+        if effective.requires_variable_model_input:
             return cls(
                 encoder_name=encoder_name,
-                tile_encoder_name=str(requirements["source_encoder"]),
+                tile_encoder_name=effective.tile_encoder_name,
                 preset_input_size_px=preset_size,
                 requested_tile_size_px=requested_size,
                 preprocessing_kind="normalization_only",
                 requires_variable_model_input=True,
                 expected_encoder_input_size_px=requested_size,
-                model_construction_kwargs=dict(
-                    tile_info.get("variable_input_model_kwargs") or {}
-                ),
+                model_construction_kwargs=effective.model_construction_kwargs,
             )
         return cls(
             encoder_name=encoder_name,
-            tile_encoder_name=str(requirements["source_encoder"]),
+            tile_encoder_name=effective.tile_encoder_name,
             preset_input_size_px=preset_size,
             requested_tile_size_px=requested_size,
             preprocessing_kind="shipped",
             requires_variable_model_input=False,
             expected_encoder_input_size_px=None,
-            model_construction_kwargs={},
+            model_construction_kwargs=effective.model_construction_kwargs,
         )
 
     def get_transform(self, tile_encoder) -> Callable:

--- a/slide2vec/runtime/pooled_encoder_input.py
+++ b/slide2vec/runtime/pooled_encoder_input.py
@@ -63,25 +63,18 @@ class PooledEncoderInputPlan:
             size_px=requested_size,
             origin=f"requested_tile_size_px={requested_size}",
         )
-        if effective.requires_variable_model_input:
-            return cls(
-                encoder_name=encoder_name,
-                tile_encoder_name=effective.tile_encoder_name,
-                preset_input_size_px=preset_size,
-                requested_tile_size_px=requested_size,
-                preprocessing_kind="normalization_only",
-                requires_variable_model_input=True,
-                expected_encoder_input_size_px=requested_size,
-                model_construction_kwargs=effective.model_construction_kwargs,
-            )
+        # An exact request is one the shipped recipe would not produce: it applies
+        # normalization only, and its final size is therefore known up front rather than
+        # observed from the transformed batch.
+        is_exact = effective.requires_variable_model_input
         return cls(
             encoder_name=encoder_name,
             tile_encoder_name=effective.tile_encoder_name,
-            preset_input_size_px=preset_size,
+            preset_input_size_px=effective.preset_input_size_px,
             requested_tile_size_px=requested_size,
-            preprocessing_kind="shipped",
-            requires_variable_model_input=False,
-            expected_encoder_input_size_px=None,
+            preprocessing_kind="normalization_only" if is_exact else "shipped",
+            requires_variable_model_input=is_exact,
+            expected_encoder_input_size_px=requested_size if is_exact else None,
             model_construction_kwargs=effective.model_construction_kwargs,
         )
 

--- a/tests/test_dense_encoder_input.py
+++ b/tests/test_dense_encoder_input.py
@@ -137,6 +137,27 @@ def test_derived_kwargs_match_what_the_hand_passed_path_produced(
     assert contract.construction_kwargs_for(encoder_name) == hand_passed
 
 
+def test_derived_kwargs_still_meet_an_encoder_card_gate(monkeypatch):
+    """Deriving the setting does not smuggle it past an encoder's own model-card gate.
+
+    H-Optimus' card loads with ``dynamic_img_size=False``, so its constructor refuses the
+    deviation unless ``allow_non_recommended_settings=True``. The contract supplies the
+    ``True``; the encoder still demands the deliberate override. The guard fires while the
+    constructor arguments are evaluated, so no weights are downloaded.
+    """
+    import slide2vec.inference as inference
+
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    contract = EncoderInputContract.declared_dense(
+        "h-optimus-0", target_size_px=518, window_size=None
+    )
+
+    assert contract.construction_kwargs_for("h-optimus-0") == {"dynamic_img_size": True}
+
+    with pytest.raises(ValueError, match="recommends dynamic_img_size=False"):
+        inference.load_model(name="h-optimus-0", device="cpu", encoder_input=contract)
+
+
 def test_dense_options_carries_no_dynamic_img_size_knob():
     """The variable-input setting is derived from the declaration + registry metadata."""
     assert "dynamic_img_size" not in {field.name for field in fields(DenseOptions)}

--- a/tests/test_dense_encoder_input.py
+++ b/tests/test_dense_encoder_input.py
@@ -1,0 +1,294 @@
+"""The encoder-input contract stated over the **effective encoder input** (issue #233).
+
+The effective encoder input is the geometry of the tensor handed to ``encode_tiles`` /
+``encode_tiles_dense``. Pooled and dense resolve it differently — ``requested_tile_size_px``
+vs the padded ``encoded_size`` or the patch-aligned ``window_size`` — but both then ask the
+*same* question of it: is this a size the encoder can accept, and what constructor settings
+activate it? These tests pin that the question is asked once, and that dense no longer
+answers it by hand-passing ``dynamic_img_size`` past an unchecked seam.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import fields
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from torchvision.transforms import v2  # noqa: E402
+
+from slide2vec.api import DenseOptions, ExecutionOptions, Model, SlideRegions  # noqa: E402
+from slide2vec.data import tile_reader  # noqa: E402
+from slide2vec.runtime import dense_stage  # noqa: E402
+from slide2vec.runtime.encoder_input_contract import EncoderInputContract  # noqa: E402
+
+
+# --------------------------------------------------------------------------------------
+# Resolution: which size is the effective encoder input, and is it accepted?
+# --------------------------------------------------------------------------------------
+
+
+def test_dense_whole_tile_at_a_non_native_size_is_rejected_without_the_capability():
+    """phikon declares supports_variable_input_size=False; a 512px whole tile must raise.
+
+    The old route hand-passed ``dynamic_img_size=True`` to ``load_model``, which silently
+    dropped it because phikon's constructor takes no such parameter — the run proceeded to
+    feed the encoder a size it cannot accept.
+    """
+    with pytest.raises(ValueError, match="does not support a variable encoder input"):
+        EncoderInputContract.declared_dense("phikon", target_size_px=512, window_size=None)
+
+
+def test_dense_whole_tile_derives_the_registry_variable_input_kwargs():
+    contract = EncoderInputContract.declared_dense(
+        "virchow2", target_size_px=518, window_size=None
+    )
+
+    assert contract.regime == "declared"
+    assert contract.plan.effective_encoder_input_size_px == (518, 518)
+    assert contract.plan.requires_variable_model_input is True
+    assert contract.construction_kwargs_for("virchow2") == {"dynamic_img_size": True}
+
+
+def test_dense_whole_tile_effective_input_is_the_padded_encoded_size():
+    """512 is not a multiple of virchow2's 14px patch: the encoder sees the padded 518."""
+    contract = EncoderInputContract.declared_dense(
+        "virchow2", target_size_px=512, window_size=None
+    )
+
+    assert contract.plan.target_size_px == 512
+    assert contract.plan.encoded_size_px == (518, 518)
+    assert contract.plan.effective_encoder_input_size_px == (518, 518)
+
+
+def test_dense_sliding_at_the_native_window_needs_no_variable_input():
+    """The sliding path only ever feeds the encoder its own native window."""
+    contract = EncoderInputContract.declared_dense(
+        "phikon", target_size_px=512, window_size=224
+    )
+
+    assert contract.plan.effective_encoder_input_size_px == (224, 224)
+    assert contract.plan.requires_variable_model_input is False
+    assert contract.construction_kwargs_for("phikon") == {}
+
+
+def test_dense_sliding_above_the_native_window_still_asks_the_capability_question():
+    """A 256px window on a 224px fixed-input encoder is as unsupported as a 512px tile."""
+    with pytest.raises(ValueError, match="does not support a variable encoder input"):
+        EncoderInputContract.declared_dense("phikon", target_size_px=512, window_size=256)
+
+
+def test_dense_sliding_window_is_clamped_to_the_encoded_extent():
+    """A window at least as large as the tile is the whole-tile case, not a sliding one."""
+    contract = EncoderInputContract.declared_dense(
+        "virchow2", target_size_px=224, window_size=512
+    )
+
+    assert contract.plan.effective_encoder_input_size_px == (224, 224)
+    assert contract.plan.requires_variable_model_input is False
+
+
+def test_dense_contract_selects_the_normalization_only_transform():
+    """Dense never uses the shipped pooled transform: it would resize/crop the ROI."""
+
+    class _Encoder:
+        def get_transform(self):
+            raise AssertionError("dense must not select the shipped pooled transform")
+
+        def get_normalization_transform(self):
+            return "normalization"
+
+    contract = EncoderInputContract.declared_dense(
+        "virchow2", target_size_px=518, window_size=None
+    )
+
+    assert contract.get_transform(_Encoder()) == "normalization"
+
+
+@pytest.mark.parametrize(
+    "encoder_name, target_size_px, window_size",
+    [
+        pytest.param("virchow2", 518, None, id="whole-tile-at-a-non-native-size"),
+        pytest.param("phikon", 512, 224, id="sliding-at-the-native-window"),
+    ],
+)
+def test_derived_kwargs_match_what_the_hand_passed_path_produced(
+    encoder_name, target_size_px, window_size
+):
+    """Output-preserving pin: the derived kwargs equal the hand-passed path's outcome.
+
+    The old dense route passed ``dynamic_img_size=True`` to ``load_model``, which applied
+    it only when the encoder's constructor accepted the parameter. Re-derive that rule here
+    and require the contract to reach the same construction.
+    """
+    from slide2vec.encoders.registry import encoder_registry
+
+    encoder_cls = encoder_registry.require(encoder_name)
+    ctor_params = inspect.signature(encoder_cls.__init__).parameters
+    hand_passed = {"dynamic_img_size": True} if "dynamic_img_size" in ctor_params else {}
+
+    contract = EncoderInputContract.declared_dense(
+        encoder_name, target_size_px=target_size_px, window_size=window_size
+    )
+
+    assert contract.construction_kwargs_for(encoder_name) == hand_passed
+
+
+def test_dense_options_carries_no_dynamic_img_size_knob():
+    """The variable-input setting is derived from the declaration + registry metadata."""
+    assert "dynamic_img_size" not in {field.name for field in fields(DenseOptions)}
+
+
+def test_load_model_no_longer_accepts_a_hand_passed_dynamic_img_size(stand_in_virchow2):
+    import slide2vec.inference as inference
+
+    with pytest.raises(TypeError, match="dynamic_img_size"):
+        inference.load_model(
+            name="virchow2",
+            device="cpu",
+            encoder_input=EncoderInputContract.given(),
+            dynamic_img_size=True,
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Reachability: whole-tile dense at a non-native size through the public API
+# --------------------------------------------------------------------------------------
+
+
+class _StandInVirchow2:
+    """A patch-14 stand-in that records the constructor settings it was built with."""
+
+    constructed: list[dict] = []
+
+    def __init__(self, *, output_variant=None, dynamic_img_size=False):
+        type(self).constructed.append({"dynamic_img_size": dynamic_img_size})
+        self.device = torch.device("cpu")
+        self.encode_dim = 8
+
+    @property
+    def patch_size(self):
+        return (14, 14)
+
+    def get_transform(self):
+        raise AssertionError("dense must not select the shipped pooled transform")
+
+    def get_normalization_transform(self):
+        return v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])
+
+    def encode_tiles_dense(self, batch):
+        height, width = int(batch.shape[-2]), int(batch.shape[-1])
+        return torch.zeros(
+            (int(batch.shape[0]), self.encode_dim, height // 14, width // 14),
+            dtype=torch.float32,
+        )
+
+    def to(self, device):
+        self.device = torch.device(device)
+        return self
+
+
+def _canned_region(location, size) -> np.ndarray:
+    width, height = int(size[0]), int(size[1])
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+class _FakeBackend:
+    def read_regions(self, locations, level, size, num_workers):
+        return [_canned_region(location, size) for location in locations]
+
+    def read_region(self, location, level, size):
+        return _canned_region(location, size)
+
+
+@pytest.fixture
+def stand_in_virchow2(monkeypatch):
+    import slide2vec.inference as inference
+
+    _StandInVirchow2.constructed = []
+    monkeypatch.setattr(
+        inference.encoder_registry, "require", lambda name: _StandInVirchow2
+    )
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setattr(
+        tile_reader, "_open_wsi_backend",
+        lambda image_path, backend, gpu_decode: _FakeBackend(),
+    )
+    monkeypatch.setattr(
+        dense_stage, "resolve_slide_read_plan",
+        lambda image_path, dense: (0, int(dense.target_size), "cucim"),
+    )
+    return _StandInVirchow2
+
+
+def test_public_api_reaches_whole_tile_dense_at_a_non_native_size(
+    stand_in_virchow2, tmp_path
+):
+    """``Model.from_preset`` → ``embed_regions_dense`` at 518px on a 224px-native encoder.
+
+    The caller passes no ``dynamic_img_size``: the declaration plus the registry's
+    ``variable_input_model_kwargs`` supply it. This was unreachable through the public API.
+    """
+    model = Model.from_preset("virchow2", device="cpu")
+    regions = SlideRegions(
+        sample_id="s0",
+        image_path="s0.tif",
+        coordinates=np.asarray([[0, 0]], dtype=np.int64),
+    )
+
+    artifacts = model.embed_regions_dense(
+        [regions],
+        dense=DenseOptions(spacing_um=0.5, target_size=518),
+        execution=ExecutionOptions(
+            output_dir=tmp_path, num_gpus=1, batch_size=1, precision="fp32"
+        ),
+    )
+
+    assert [artifact.grid_shape for artifact in artifacts] == [(37, 37)]
+    assert _StandInVirchow2.constructed == [{"dynamic_img_size": True}]
+    assert model._encoder_input.plan.effective_encoder_input_size_px == (518, 518)
+
+
+def test_public_api_refuses_whole_tile_dense_the_encoder_cannot_accept(
+    stand_in_virchow2, tmp_path, monkeypatch
+):
+    """phikon at 512px whole-tile raises before a single region is read."""
+    import slide2vec.inference as inference
+
+    monkeypatch.setattr(
+        inference.encoder_registry, "require",
+        lambda name: pytest.fail("the model must not be constructed"),
+    )
+    model = Model.from_preset("phikon", device="cpu")
+    regions = SlideRegions(
+        sample_id="s0",
+        image_path="s0.tif",
+        coordinates=np.asarray([[0, 0]], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match="does not support a variable encoder input"):
+        model.embed_regions_dense(
+            [regions],
+            dense=DenseOptions(spacing_um=0.5, target_size=512),
+            execution=ExecutionOptions(
+                output_dir=tmp_path, num_gpus=1, batch_size=1, precision="fp32"
+            ),
+        )
+
+
+def test_dense_declaration_is_what_unlocks_the_backend_load(stand_in_virchow2):
+    """Dense declares like every other encoding route: no declaration, no backend."""
+    model = Model.from_preset("virchow2", device="cpu")
+
+    with pytest.raises(ValueError, match="No encoder-input contract"):
+        model._load_backend()
+
+    model._declare_dense_encoder_input(
+        DenseOptions(spacing_um=0.5, target_size=518), emit_run_info=False
+    )
+
+    assert model._load_backend().transforms is not None
+    assert _StandInVirchow2.constructed == [{"dynamic_img_size": True}]

--- a/tests/test_dense_stage.py
+++ b/tests/test_dense_stage.py
@@ -76,7 +76,12 @@ def stub_read_plan(monkeypatch):
 
 
 class _FakeModel:
-    """Minimal Model stand-in exposing what the in-process dense path reads."""
+    """Minimal Model stand-in exposing what the in-process dense path reads.
+
+    ``_load_backend`` refuses to hand out a backend until the dense encoder-input contract
+    has been declared, mirroring the real ``Model``: dense declares its effective encoder
+    input like every other route that reaches the encoder.
+    """
 
     def __init__(self, encoder, device="cpu") -> None:
         self._encoder = encoder
@@ -85,8 +90,14 @@ class _FakeModel:
         self._output_variant = None
         self._requested_device = device
         self.allow_non_recommended_settings = False
+        self.declared_dense = None
 
-    def _load_backend_without_transform(self):
+    def _declare_dense_encoder_input(self, dense, *, emit_run_info):
+        self.declared_dense = dense
+        return dense
+
+    def _load_backend(self):
+        assert self.declared_dense is not None, "dense must declare before it loads"
         return SimpleNamespace(model=self._encoder, device=self._device)
 
     @property

--- a/tests/test_dense_worker.py
+++ b/tests/test_dense_worker.py
@@ -62,10 +62,22 @@ def test_dense_worker_encodes_only_its_rank_shard(monkeypatch, tmp_path):
 
     encoder = TimmTileEncoder("vit_tiny_patch16_224", pretrained=False, num_classes=0,
                               dynamic_img_size=True)
+    declared: list = []
+
+    def _load_backend():
+        # A rank declares its own dense encoder-input contract before loading, so that the
+        # variable-input constructor settings its ROI geometry implies are applied.
+        assert declared, "the rank must declare its dense contract before it loads"
+        return SimpleNamespace(model=encoder, device="cpu")
+
     monkeypatch.setattr(
         api.Model, "from_preset",
         classmethod(lambda cls, name, **kwargs: SimpleNamespace(
-            _load_backend_without_transform=lambda: SimpleNamespace(model=encoder, device="cpu"))),
+            _declare_dense_encoder_input=(
+                lambda dense, *, emit_run_info: declared.append(dense)
+            ),
+            _load_backend=_load_backend,
+        )),
     )
 
     specs = [RegionSpec("s0", "s0.tif", i * 64, 0, 0, 64, 64, "cucim", None) for i in range(4)]

--- a/tests/test_encoder_input_contract.py
+++ b/tests/test_encoder_input_contract.py
@@ -79,7 +79,7 @@ def test_declared_geometry_rejects_an_off_preset_request_without_permission():
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
     with pytest.raises(ValueError, match="allow_non_recommended_settings=True"):
-        EncoderInputContract.declared(
+        EncoderInputContract.declared_pooled(
             "gigapath",
             requested_tile_size_px=288,
             allow_non_recommended_settings=False,
@@ -89,8 +89,8 @@ def test_declared_geometry_rejects_an_off_preset_request_without_permission():
 def test_declared_geometry_rejects_an_encoder_without_variable_input_capability():
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
-    with pytest.raises(ValueError, match="does not support variable pooled input geometry"):
-        EncoderInputContract.declared(
+    with pytest.raises(ValueError, match="does not support a variable encoder input"):
+        EncoderInputContract.declared_pooled(
             "conch",
             requested_tile_size_px=464,
             allow_non_recommended_settings=True,
@@ -101,7 +101,7 @@ def test_declared_geometry_rejects_a_non_multiple_of_the_patch_size():
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
     with pytest.raises(ValueError, match="patch geometry"):
-        EncoderInputContract.declared(
+        EncoderInputContract.declared_pooled(
             "gigapath",
             requested_tile_size_px=278,
             allow_non_recommended_settings=True,
@@ -112,7 +112,7 @@ def test_declared_geometry_keeps_normalization_only_preprocessing(stand_in_gigap
     import slide2vec.inference as inference
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
-    contract = EncoderInputContract.declared(
+    contract = EncoderInputContract.declared_pooled(
         "gigapath",
         requested_tile_size_px=288,
         allow_non_recommended_settings=True,
@@ -182,7 +182,7 @@ def test_load_model_rejects_a_contract_declared_for_another_encoder(stand_in_gig
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
     # conch is fixed-input, so resolving 288px against conch would have raised outright.
-    contract = EncoderInputContract.declared(
+    contract = EncoderInputContract.declared_pooled(
         "gigapath",
         requested_tile_size_px=288,
         allow_non_recommended_settings=True,

--- a/tests/test_pooled_encoder_input.py
+++ b/tests/test_pooled_encoder_input.py
@@ -87,8 +87,9 @@ def test_fixed_size_encoder_rejects_permitted_non_preset_request():
         )
 
     assert str(error.value) == (
-        "Encoder 'conch' does not support variable pooled input geometry; its "
-        "registered preset is 448px, so requested_tile_size_px=464 is unsupported."
+        "Encoder 'conch' does not support a variable encoder input; its registered "
+        "input size is 448px, so an effective encoder input of 464px "
+        "(requested_tile_size_px=464) is unsupported."
     )
 
 
@@ -149,7 +150,10 @@ def test_permitted_non_preset_plan_rejects_non_positive_geometry():
             allow_non_recommended_settings=True,
         )
 
-    assert str(error.value) == "requested_tile_size_px must be a positive square size; got 0px"
+    assert str(error.value) == (
+        "The effective encoder input must be positive; got 0px "
+        "(requested_tile_size_px=0)."
+    )
 
 
 def test_permitted_non_preset_plan_rejects_patch_incompatible_geometry():
@@ -165,8 +169,9 @@ def test_permitted_non_preset_plan_rejects_patch_incompatible_geometry():
         )
 
     assert str(error.value) == (
-        "Encoder 'gigapath' requires exact pooled inputs divisible by its 16x16 "
-        "patch geometry; got requested_tile_size_px=278."
+        "Encoder 'gigapath' requires an encoder input divisible by its 16x16 patch "
+        "geometry; got an effective encoder input of 278px "
+        "(requested_tile_size_px=278)."
     )
 
 
@@ -207,7 +212,7 @@ def test_pooled_model_loading_applies_plan_construction_and_transform(monkeypatc
             self.device = torch.device(device)
             return self
 
-    contract = EncoderInputContract.declared(
+    contract = EncoderInputContract.declared_pooled(
         "h-optimus-0",
         requested_tile_size_px=280,  # 14x20 — h-optimus-0 is a genuine patch-14 model
         allow_non_recommended_settings=True,
@@ -490,7 +495,7 @@ def test_slide_model_loading_applies_plan_to_resolved_tile_dependency(monkeypatc
             self.device = torch.device(device)
             return self
 
-    contract = EncoderInputContract.declared(
+    contract = EncoderInputContract.declared_pooled(
         "prism",
         requested_tile_size_px=252,
         allow_non_recommended_settings=True,


### PR DESCRIPTION
Closes #233

## Summary

The variable-input capability the registry declares (`supports_variable_input_size`, `variable_input_model_kwargs`) was wired only into the pooled plan. Dense extraction asked the identical question by a different, unchecked route: the caller hand-passed `dynamic_img_size` to `load_model`, which applied it only when the encoder's constructor happened to accept the parameter — so for phikon the request was silently swallowed, and nothing checked the size actually fed to `encode_tiles_dense`.

This restates the contract over the **effective encoder input** — the geometry of the tensor immediately before `encode_tiles` / `encode_tiles_dense` — so one capability check and one application of `variable_input_model_kwargs` serve both paths:

| path | effective encoder input |
|---|---|
| pooled, declared | `requested_tile_size_px` |
| dense, whole-tile | the ROI padded up to the patch multiple |
| dense, sliding | the patch-aligned, extent-clamped `window_size` |
| given | not declared; observed after the shipped transform |

## What changed

- **`runtime/effective_encoder_input.py`** (new) — `EffectiveEncoderInput.resolve(...)` is now the single place that asks "can this encoder accept this tensor, and which constructor settings activate it?": positivity, `supports_variable_input_size`, patch-multiple, and the registry's `variable_input_model_kwargs`.
- **`runtime/dense_encoder_input.py`** (new) — `DenseEncoderInputPlan` derives the effective input from the dense geometry kernels themselves (`compute_dense_geometry` / `resolve_window_geometry`), so a declaration cannot drift from the window the encode loop cuts. Its transform is unconditionally the normalization-only one.
- **`PooledEncoderInputPlan`** keeps only what is genuinely pooled: the `allow_non_recommended_settings` gate. That gate is about deviating from the model card's *tiling recipe*; dense has no such recipe to deviate from (the ROI size is the caller's supervision geometry), so it shares the capability check without inheriting the permission gate. An encoder that objects on model-card grounds still enforces its own gate — H-Optimus dense at a non-native size raises without `allow_non_recommended_settings=True` (pinned by a test).
- **Dense declares through the normal path.** `dense_stage.embed_regions_dense` and the torchrun `dense_worker` now call `_declare_dense_encoder_input(...)` + `_load_backend()` instead of `_load_backend_without_transform()`. Dense still builds its own normalization transform and never reads `loaded.transforms`, but it *does* need the variable-input constructor settings, which is exactly what a contract carries — and a dense contract selects that same normalization transform, so the backend is not carrying a different one. The declaration runs before anything is read, sharded or launched, so an unacceptable ROI geometry fails in the parent rather than on a rank's first forward pass.
- **`load_model` loses its `dynamic_img_size` parameter.** The setting is derived from the declaration plus registry metadata; hand-passing it was unverified in both directions.
- `EncoderInputContract.declared` → `declared_pooled`, alongside the new `declared_dense`.

## Why it matters

Whole-tile dense at a non-native size (e.g. 518 px ROIs through a 224-native ViT) is now reachable through the public API — `Model.from_preset(...)` → `embed_regions_dense(...)` — with nothing for the caller to pass. It was previously impossible without dropping to the internal `iter_regions_dense`. Conversely, the same request on phikon now raises instead of proceeding with a swallowed kwarg.

## Verification

- `tests/test_dense_encoder_input.py` (new, 15 tests) covers resolution per path, the phikon rejection, reachability through the public API, and the declaration-before-load guard.
- Output-preserving: derived kwargs are pinned against a re-derivation of exactly what the hand-passed path produced, for both a whole-tile-at-non-native-size case (virchow2, `{"dynamic_img_size": True}`) and a sliding-at-native-window case (phikon, `{}` — the hand-passed value was swallowed there anyway). Existing dense assertions are untouched; only the two `Model` stand-in fixtures moved from `_load_backend_without_transform` to `_declare_dense_encoder_input` + `_load_backend`.
- `580 passed, 26 deselected` locally (`-m 'not heavy'`); the heavy tests whose weights are cached (`-k "phikon or lunit"`) pass. CI runs the full suite including heavy.