### PR TITLE
Add a public images-to-embeddings API for given-geometry inputs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -87,6 +87,55 @@ ordered by first appearance.
    :members:
    :undoc-members:
 
+Images to Embeddings
+--------------------
+
+When the images already exist as files — a public patch benchmark (BACH, CRC,
+Gleason, BreakHis, MHIST, PCam), an exported ROI set — there is no slide to tile
+and no geometry to request. :meth:`Model.embed_images` takes those images
+directly and writes one embedding artifact per image:
+
+.. code-block:: python
+
+   from slide2vec import ExecutionOptions, ImageSpec, Model
+
+   model = Model.from_preset("virchow2")
+   artifacts = model.embed_images(
+       [
+           ImageSpec(sample_id="bach-001", image_path="/data/bach/001.tif"),
+           ImageSpec(sample_id="bach-002", image_path="/data/bach/002.tif"),
+       ],
+       execution=ExecutionOptions(output_dir="outputs/bach", num_gpus=2),
+   )
+
+   print(artifacts[0].path)         # outputs/bach/image_embeddings/bach-001.pt
+   print(artifacts[0].feature_dim)  # 2560
+
+The run splits its images across all visible GPUs (``num_gpus=1`` encodes
+in-process) and is resume-aware: an image whose ``.meta.json`` sidecar already
+exists is skipped, so an interrupted run is restarted by re-issuing the same
+call. ``sample_id`` is the artifact's whole identity and must be unique within a
+run — slide2vec never derives it from the filename, because two directories can
+hold the same one.
+
+**Given geometry.** This is the one path where the caller supplies pixels it
+never requested, so the encoder's *shipped* transform is the contract (Resize,
+CenterCrop, Normalize — exactly what the model card prescribes), and slide2vec
+records the resulting encoder input size in each sidecar as provenance instead of
+validating it against a request. That also fixes how preprocessing runs: given
+images are heterogeneously sized (2048x1536 beside 96x96) and cannot be stacked
+into one uint8 batch before being resized, so the transform is applied **itemwise
+in the dataloader workers** and only the transformed items are stacked. The
+batched transform spec used by the pooled path stays exclusive to it.
+
+.. autoclass:: slide2vec.ImageSpec
+   :members:
+   :undoc-members:
+
+.. autoclass:: slide2vec.ImageEmbeddingArtifact
+   :members:
+   :undoc-members:
+
 Hierarchical Feature Extraction
 ---------------------------------
 

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -189,6 +189,49 @@ Same fields as ``tile_embeddings`` (except  ``"artifact_type": "hierarchical_emb
    }
 
 
+Image Embeddings
+----------------
+
+:meth:`~slide2vec.Model.embed_images` (see :doc:`api`) writes one flat directory,
+one payload plus one sidecar per input image, named by the caller's
+``sample_id``:
+
+.. code-block:: text
+
+   <output_dir>/
+   └── image_embeddings/
+       ├── <sample_id>.pt          ← Tensor of shape (D,)
+       └── <sample_id>.meta.json
+
+There is no per-annotation namespacing here: a given-geometry image has no slide,
+no coordinate and no sampled class. The sidecar is written **last**, after the
+payload has been published atomically, so a payload without its sidecar
+unambiguously means an interrupted image — which is exactly what makes the run
+resumable at image granularity across GPUs.
+
+**image_embeddings**
+
+.. code-block:: text
+
+   {
+     "sample_id": "bach-001",
+     "artifact_type": "image_embeddings",
+     "encoder_name": "virchow2",
+     "encoder_level": "tile",
+     "encoder_input_regime": "given",
+     "encoder_input_size_px": 224,
+     "feature_dim": 2560,
+     "feature_dtype": "fp32",
+     "format": "pt",
+     "image_path": "/data/bach/001.tif",
+   }
+
+``encoder_input_size_px`` is the factual side length of the tensor the encoder
+saw, after its shipped transform ran on that image. In the Given regime it is
+recorded, never validated: the caller supplied pixels it never requested, so
+there is no request to check it against.
+
+
 Coordinate Files
 ----------------
 

--- a/slide2vec/__init__.py
+++ b/slide2vec/__init__.py
@@ -3,6 +3,7 @@ from slide2vec.api import (
     EmbeddedPatient,
     EmbeddedSlide,
     ExecutionOptions,
+    ImageSpec,
     Model,
     Pipeline,
     PreprocessingConfig,
@@ -13,6 +14,7 @@ from slide2vec.api import (
 from slide2vec.artifacts import (
     DenseRegionArtifact,
     HierarchicalEmbeddingArtifact,
+    ImageEmbeddingArtifact,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
 )
@@ -27,6 +29,7 @@ __all__ = [
     "PreprocessingConfig",
     "DenseOptions",
     "SlideRegions",
+    "ImageSpec",
     "ExecutionOptions",
     "RunResult",
     "EmbeddedPatient",
@@ -35,5 +38,6 @@ __all__ = [
     "HierarchicalEmbeddingArtifact",
     "TileEmbeddingArtifact",
     "DenseRegionArtifact",
+    "ImageEmbeddingArtifact",
     "__version__",
 ]

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -13,6 +13,7 @@ from hs2p import SlideSpec
 from slide2vec.artifacts import (
     DenseRegionArtifact,
     HierarchicalEmbeddingArtifact,
+    ImageEmbeddingArtifact,
     PatientEmbeddingArtifact,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
@@ -387,6 +388,22 @@ class SlideRegions:
 
 
 @dataclass(frozen=True, kw_only=True)
+class ImageSpec:
+    """One pre-cropped image to embed: ``(sample_id, image_path)``.
+
+    The input unit of :meth:`Model.embed_images` — the Given-geometry counterpart of
+    :class:`SlideRegions`. There is no slide, no coordinate and no spacing here: the caller
+    holds an image file it never asked slide2vec to produce (a public patch benchmark
+    sample), and names it. ``sample_id`` is the artifact's whole identity, so it must be
+    unique within a run and a valid filename component; slide2vec never derives it from the
+    path, because two directories can hold the same filename.
+    """
+
+    sample_id: str
+    image_path: PathLike
+
+
+@dataclass(frozen=True, kw_only=True)
 class RunResult:
     """Return value of :meth:`Pipeline.run`."""
 
@@ -703,6 +720,38 @@ class Model:
         with _auto_progress_reporting(output_dir=resolved.output_dir):
             return embed_regions_dense(self, regions, dense=dense, execution=resolved)
 
+    def embed_images(
+        self,
+        images: "Sequence[ImageSpec]",
+        *,
+        execution: ExecutionOptions | None = None,
+    ) -> list[ImageEmbeddingArtifact]:
+        """Embed + persist one embedding per caller-supplied image.
+
+        The Given-geometry entry point: the caller already holds pre-cropped images — a
+        public patch benchmark (BACH, CRC, Gleason, BreakHis, MHIST, PCam), an exported ROI
+        set — and slide2vec neither tiles nor reads a slide. Each :class:`ImageSpec` is
+        decoded, preprocessed with the encoder's **shipped** transform, encoded, and written
+        to ``image_embeddings/<sample_id>.pt`` plus a provenance sidecar. The run splits its
+        images across all visible GPUs (``execution.num_gpus``); ``num_gpus=1`` encodes
+        fully in-process. Resume is automatic — images whose sidecar already exists are
+        skipped. Returns one :class:`~slide2vec.artifacts.ImageEmbeddingArtifact` per input
+        image, in input order.
+
+        Unlike the pooled and dense paths there is no geometry to declare: the images are
+        heterogeneously sized (2048x1536 beside 96x96) and were never requested, so the
+        encoder's shipped transform is the contract and slide2vec *records* the resulting
+        encoder input size as run provenance rather than validating it. That also means
+        preprocessing runs itemwise in the loader workers — differently sized images cannot
+        be stacked before they are resized.
+        """
+        from slide2vec.runtime.image_stage import embed_images
+
+        resolved = _coerce_execution_options(execution, model=self)
+        _require_output_dir_for_persistence(resolved, method_name="Model.embed_images(...)")
+        with _auto_progress_reporting(output_dir=resolved.output_dir):
+            return embed_images(self, images, execution=resolved)
+
     def _declare_encoder_input(
         self,
         preprocessing: PreprocessingConfig,
@@ -769,6 +818,24 @@ class Model:
                 plan.target_size_px,
                 plan.window_size_px,
                 plan.model_construction_kwargs or "no constructor setting",
+            )
+        return contract
+
+    def _declare_given_encoder_input(self, *, emit_run_info: bool) -> EncoderInputContract:
+        """Declare that this run's encoder input is whatever the caller handed over.
+
+        The Given regime's affirmative statement. It is deliberately not the same thing as
+        leaving ``_encoder_input`` unset: an absent contract means "this route forgot", and
+        the contract refuses to guess between the two. Like the declared variants this is
+        idempotent, so the parent stage and every torchrun rank declare for themselves.
+        """
+        contract = EncoderInputContract.given()
+        self._encoder_input = contract
+        if emit_run_info:
+            logging.getLogger("slide2vec").info(
+                "Given encoder input for '%s': using the encoder's shipped preprocessing; "
+                "the observed encoder input size is recorded per artifact, not validated.",
+                self.name,
             )
         return contract
 

--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import json
 import os
 from pathlib import Path, PureWindowsPath
-from typing import Any
+from typing import Any, Callable
 from uuid import uuid4
 
 import numpy as np
@@ -95,6 +95,27 @@ class DenseRegionArtifact:
         return load_metadata(self.metadata_path)
 
 
+@dataclass(frozen=True, kw_only=True)
+class ImageEmbeddingArtifact:
+    """One persisted given-geometry image embedding: the ``(D,)`` payload + its sidecar.
+
+    The unit of :meth:`slide2vec.api.Model.embed_images`: a caller holding pre-cropped tile
+    images (a public patch benchmark) gets one artifact per image, named by the ``sample_id``
+    it supplied. Unlike a tile artifact this holds a single vector, not a bag — the image
+    *is* the sample.
+    """
+
+    sample_id: str
+    path: Path
+    metadata_path: Path
+    format: str
+    feature_dim: int
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return load_metadata(self.metadata_path)
+
+
 def _validate_output_format(output_format: str) -> str:
     normalized = output_format.lower()
     if normalized not in {"pt", "npz"}:
@@ -136,17 +157,34 @@ def _ensure_tensor(data: Any):
     return torch.as_tensor(data)
 
 
-def _write_metadata(path: Path, metadata: dict[str, Any]) -> None:
+def write_atomically(path: Path, write: Callable[[Path], None]) -> None:
+    """Publish ``path`` in one step: *write* a hidden temp sibling, then ``os.replace``.
+
+    ``os.replace`` is atomic within a filesystem, so a concurrent reader (another rank, a
+    resume check, a downstream consumer) sees either the previous file or the complete new
+    one — never a half-written payload. The temp name carries the pid plus a uuid so two
+    ranks writing the same destination cannot collide on it, starts with a dot so it is
+    invisible to the artifact globs, and keeps the destination suffix because some writers
+    (``numpy.savez``) choose their format from it. Any temp left behind by a failed write
+    is removed rather than published.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_name(f".{path.name}.tmp-{os.getpid()}-{uuid4().hex}")
+    tmp_path = path.with_name(f".{path.name}.tmp-{os.getpid()}-{uuid4().hex}{path.suffix}")
     try:
-        tmp_path.write_text(
-            json.dumps(metadata, indent=2, sort_keys=True),
-            encoding="utf-8",
-        )
+        write(tmp_path)
         os.replace(tmp_path, path)
     finally:
         tmp_path.unlink(missing_ok=True)
+
+
+def _write_metadata(path: Path, metadata: dict[str, Any]) -> None:
+    write_atomically(
+        path,
+        lambda tmp_path: tmp_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True),
+            encoding="utf-8",
+        ),
+    )
 
 
 def tile_embeddings_subdir(annotation: str | None) -> str:
@@ -261,11 +299,8 @@ def write_dense_region(
     payload_path, metadata_path = region_dense_paths(
         output_dir, sample_id=sample_id, annotation=annotation, x=x, y=y
     )
-    payload_path.parent.mkdir(parents=True, exist_ok=True)
     grid_array = _ensure_array(grid)
-    tmp_path = payload_path.with_name(f"{payload_path.name}.tmp-{os.getpid()}")
-    torch.save(_ensure_tensor(grid), tmp_path)
-    os.replace(tmp_path, payload_path)
+    write_atomically(payload_path, lambda tmp_path: torch.save(_ensure_tensor(grid), tmp_path))
     _write_metadata(metadata_path, metadata)
     return DenseRegionArtifact(
         sample_id=sample_id,
@@ -276,6 +311,67 @@ def write_dense_region(
         feature_dim=int(grid_array.shape[0]),
         grid_shape=(int(grid_array.shape[1]), int(grid_array.shape[2])),
         annotation=annotation,
+    )
+
+
+def image_embedding_paths(
+    output_dir: str | Path, *, sample_id: str, output_format: str
+) -> tuple[Path, Path]:
+    """``(payload_path, sidecar_path)`` for one given-geometry image.
+
+    ``image_embeddings/<sample_id>.{pt,npz}`` plus ``image_embeddings/<sample_id>.meta.json``.
+    A given-geometry run has no slide, no coordinate and no annotation class — the caller's
+    ``sample_id`` is the whole identity — so the layout is flat and the resume check needs
+    nothing but the sample id.
+    """
+    output_root = Path(output_dir).expanduser().resolve()
+    sample_component = _validate_path_component(sample_id, field="sample_id")
+    embeddings_dir = (output_root / "image_embeddings").resolve()
+    if not embeddings_dir.is_relative_to(output_root):
+        raise ValueError("Image artifact path must stay within output_dir")
+    return (
+        embeddings_dir / f"{sample_component}.{_validate_output_format(output_format)}",
+        embeddings_dir / f"{sample_component}.meta.json",
+    )
+
+
+def write_image_embedding(
+    embedding,
+    *,
+    output_dir: str | Path,
+    sample_id: str,
+    output_format: str = "pt",
+    metadata: dict[str, Any],
+) -> ImageEmbeddingArtifact:
+    """Persist one image's ``(D,)`` embedding + its sidecar, atomically and sidecar-last.
+
+    Write order: payload through :func:`write_atomically`, then the ``.meta.json`` sidecar.
+    A payload present without its sidecar therefore unambiguously means an interrupted
+    image, and resume treats the sidecar as the done-marker — the same contract the dense
+    ROI write follows (:func:`write_dense_region`), and the reason a rank can be killed
+    mid-shard without poisoning the output.
+    """
+    output_format = _validate_output_format(output_format)
+    payload_path, metadata_path = image_embedding_paths(
+        output_dir, sample_id=sample_id, output_format=output_format
+    )
+    embedding_array = _ensure_array(embedding)
+    if output_format == "pt":
+        write_atomically(
+            payload_path, lambda tmp_path: torch.save(_ensure_tensor(embedding), tmp_path)
+        )
+    else:
+        write_atomically(
+            payload_path, lambda tmp_path: np.savez_compressed(tmp_path, features=embedding_array)
+        )
+    feature_dim = int(embedding_array.shape[-1]) if embedding_array.ndim else 1
+    _write_metadata(metadata_path, {**metadata, "feature_dim": feature_dim})
+    return ImageEmbeddingArtifact(
+        sample_id=sample_id,
+        path=payload_path,
+        metadata_path=metadata_path,
+        format=output_format,
+        feature_dim=feature_dim,
     )
 
 

--- a/slide2vec/data/dataset.py
+++ b/slide2vec/data/dataset.py
@@ -7,8 +7,6 @@ from PIL import Image
 
 from hs2p import TilingResult
 
-from slide2vec.runtime.preprocessing import apply_transforms_itemwise
-
 from .tile_store import TarTileReader
 
 
@@ -24,20 +22,23 @@ class TileIndexDataset(torch.utils.data.Dataset):
 
 
 class ImageFileDataset(torch.utils.data.Dataset):
-    """Decode one given-geometry image and apply the encoder's shipped transform, per item.
+    """Decode one given-geometry image and preprocess it, per item, in the loader worker.
 
     The preprocessing seam of :meth:`slide2vec.api.Model.embed_images`. Given-geometry
     inputs are heterogeneously sized (a 2048x1536 BACH image beside a 96x96 PCam patch), so
     they cannot be stacked into one ``(B, 3, H, W)`` uint8 tensor and resized as a batch the
     way the declared paths do — the batched transform spec is structurally inapplicable
-    here. Instead each item is decoded and transformed on its own, inside the dataloader
-    worker, and only the *transformed* items (all at the encoder's own input size) are
-    stacked by :class:`StackedImageCollator`.
+    here. Instead each item is decoded and transformed on its own, and only the
+    *transformed* items (all at the encoder's own input size) are stacked by
+    :class:`StackedImageCollator`.
+
+    ``preprocess`` is the whole per-item recipe, supplied by the caller: this dataset knows
+    how to read an image file and nothing about which transform an encoder ships.
     """
 
-    def __init__(self, image_paths, transforms):
+    def __init__(self, image_paths, preprocess):
         self.image_paths = [str(path) for path in image_paths]
-        self.transforms = transforms
+        self.preprocess = preprocess
 
     def __len__(self) -> int:
         return len(self.image_paths)
@@ -47,7 +48,7 @@ class ImageFileDataset(torch.utils.data.Dataset):
             # RGB up front: the shipped transforms expect three channels, and public patch
             # datasets ship a mix of RGB, RGBA (alpha) and palette PNGs.
             rgb = image.convert("RGB")
-        return int(idx), apply_transforms_itemwise(rgb, self.transforms)
+        return int(idx), self.preprocess(rgb)
 
 
 class StackedImageCollator:

--- a/slide2vec/data/dataset.py
+++ b/slide2vec/data/dataset.py
@@ -3,8 +3,11 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from PIL import Image
 
 from hs2p import TilingResult
+
+from slide2vec.runtime.preprocessing import apply_transforms_itemwise
 
 from .tile_store import TarTileReader
 
@@ -18,6 +21,56 @@ class TileIndexDataset(torch.utils.data.Dataset):
 
     def __getitem__(self, idx):
         return int(self.tile_indices[idx])
+
+
+class ImageFileDataset(torch.utils.data.Dataset):
+    """Decode one given-geometry image and apply the encoder's shipped transform, per item.
+
+    The preprocessing seam of :meth:`slide2vec.api.Model.embed_images`. Given-geometry
+    inputs are heterogeneously sized (a 2048x1536 BACH image beside a 96x96 PCam patch), so
+    they cannot be stacked into one ``(B, 3, H, W)`` uint8 tensor and resized as a batch the
+    way the declared paths do — the batched transform spec is structurally inapplicable
+    here. Instead each item is decoded and transformed on its own, inside the dataloader
+    worker, and only the *transformed* items (all at the encoder's own input size) are
+    stacked by :class:`StackedImageCollator`.
+    """
+
+    def __init__(self, image_paths, transforms):
+        self.image_paths = [str(path) for path in image_paths]
+        self.transforms = transforms
+
+    def __len__(self) -> int:
+        return len(self.image_paths)
+
+    def __getitem__(self, idx: int):
+        with Image.open(self.image_paths[idx]) as image:
+            # RGB up front: the shipped transforms expect three channels, and public patch
+            # datasets ship a mix of RGB, RGBA (alpha) and palette PNGs.
+            rgb = image.convert("RGB")
+        return int(idx), apply_transforms_itemwise(rgb, self.transforms)
+
+
+class StackedImageCollator:
+    """Stack itemwise-preprocessed images into the ``(B, C, H, W)`` batch the encoder takes."""
+
+    def __call__(self, batch):
+        worker_start = time.perf_counter()
+        indices = torch.as_tensor([int(index) for index, _ in batch], dtype=torch.long)
+        images = [torch.as_tensor(image) for _, image in batch]
+        shapes = {tuple(image.shape) for image in images}
+        if len(shapes) > 1:
+            # Only reachable when an encoder's shipped transform does not normalize
+            # geometry, in which case the encoder cannot consume a mixed batch either.
+            raise ValueError(
+                "The encoder's shipped transform produced differently shaped images in one "
+                f"batch ({sorted(shapes)}); given-geometry inputs can only be batched when "
+                "preprocessing maps them onto a common encoder input size."
+            )
+        return (
+            indices,
+            torch.stack(images, dim=0),
+            {"worker_batch_ms": (time.perf_counter() - worker_start) * 1000.0},
+        )
 
 
 class BatchTileCollator:

--- a/slide2vec/distributed/dense_worker.py
+++ b/slide2vec/distributed/dense_worker.py
@@ -1,35 +1,31 @@
 """torchrun entry point for distributed dense feature extraction (issue #217).
 
 One of these runs per GPU under ``torch.distributed.run``. It is deliberately near
-logic-free (D10): it reads ``RANK`` / ``WORLD_SIZE`` / ``LOCAL_RANK`` straight from the env
-torchrun exports — **no NCCL / process-group init**, because dense extraction needs no
-collectives (each rank writes its own artifacts and nobody gathers) — loads the JSON request
-plus the coordinates npz the parent staged, then calls the two pure/CPU-tested layers:
+logic-free (D10): the rank, the model and the progress wiring all come from
+:mod:`slide2vec.distributed.worker_entry`; what is left here is dense-specific — declare
+the dense encoder-input contract, rebuild the flat ROI list the parent staged (request JSON
+plus coordinates npz), then call the two pure/CPU-tested layers:
 :func:`~slide2vec.runtime.sharding.plan_contiguous_shards` to pick this rank's shard
 and :func:`~slide2vec.runtime.dense_shard.run_dense_shard` to encode + persist it.
 """
 
-import argparse
 import json
-import os
-from contextlib import nullcontext
 from pathlib import Path
 
+from slide2vec.distributed.worker_entry import (
+    model_from_request,
+    resolve_worker_rank,
+    worker_args_parser,
+    worker_progress_context,
+)
 
-def get_args_parser(add_help: bool = True) -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser("slide2vec.distributed.dense_worker", add_help=add_help)
-    parser.add_argument("--output-dir", required=True, help="Directory dense artifacts are written to")
-    parser.add_argument("--request-path", required=True, help="JSON request produced by the parent process")
-    return parser
+
+def get_args_parser(add_help: bool = True):
+    return worker_args_parser("slide2vec.distributed.dense_worker", add_help=add_help)
 
 
 def main(argv=None) -> int:
-    from slide2vec.api import Model
-    from slide2vec.progress import (
-        JsonlProgressReporter,
-        activate_progress_reporter,
-        emit_progress,
-    )
+    from slide2vec.progress import emit_progress
     from slide2vec.runtime.dense_shard import run_dense_shard
     from slide2vec.runtime.dense_stage import (
         region_specs_from_request,
@@ -44,24 +40,14 @@ def main(argv=None) -> int:
     args = get_args_parser(add_help=True).parse_args(argv)
     request = json.loads(Path(args.request_path).read_text(encoding="utf-8"))
     output_dir = Path(args.output_dir)
-
-    # torchrun exports these; default to a single in-process rank if launched bare.
-    global_rank = int(os.environ.get("RANK", "0"))
-    world_size = int(os.environ.get("WORLD_SIZE", "1"))
-    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    rank = resolve_worker_rank()
 
     specs = region_specs_from_request(request)
-    shard = plan_contiguous_shards(specs, world_size)[global_rank]
+    shard = plan_contiguous_shards(specs, rank.world_size)[rank.global_rank]
     if not shard:
         return 0
 
-    model_spec = dict(request["model"])
-    model = Model.from_preset(
-        model_spec["name"],
-        device=f"cuda:{local_rank}",
-        output_variant=model_spec.get("output_variant"),
-        allow_non_recommended_settings=bool(model_spec.get("allow_non_recommended_settings", False)),
-    )
+    model = model_from_request(request, rank=rank)
     dense = deserialize_dense_options(request["dense"])
     execution = deserialize_execution(request["execution"])
     # Each rank declares its own dense encoder-input contract rather than trusting the
@@ -71,19 +57,9 @@ def main(argv=None) -> int:
     model._declare_dense_encoder_input(dense, emit_run_info=False)
     loaded = model._load_backend()
 
-    progress_events_path = request.get("progress_events_path")
-    reporter = (
-        JsonlProgressReporter(
-            progress_events_path, rank=global_rank, progress_label=f"cuda:{local_rank}"
-        )
-        if progress_events_path
-        else None
-    )
-    context = activate_progress_reporter(reporter) if reporter is not None else nullcontext()
-
-    with context:
+    with worker_progress_context(request, rank=rank):
         def _on_batch(count: int) -> None:
-            emit_progress("dense.batch.finished", rank=global_rank, regions=int(count))
+            emit_progress("dense.batch.finished", rank=rank.global_rank, regions=int(count))
 
         run_dense_shard(
             shard,

--- a/slide2vec/distributed/image_worker.py
+++ b/slide2vec/distributed/image_worker.py
@@ -1,12 +1,12 @@
-"""torchrun entry point for distributed dense feature extraction (issue #217).
+"""torchrun entry point for distributed given-image feature extraction (issue #234).
 
-One of these runs per GPU under ``torch.distributed.run``. It is deliberately near
-logic-free (D10): it reads ``RANK`` / ``WORLD_SIZE`` / ``LOCAL_RANK`` straight from the env
-torchrun exports — **no NCCL / process-group init**, because dense extraction needs no
-collectives (each rank writes its own artifacts and nobody gathers) — loads the JSON request
-plus the coordinates npz the parent staged, then calls the two pure/CPU-tested layers:
-:func:`~slide2vec.runtime.sharding.plan_contiguous_shards` to pick this rank's shard
-and :func:`~slide2vec.runtime.dense_shard.run_dense_shard` to encode + persist it.
+One of these runs per GPU under ``torch.distributed.run``. Like its dense sibling it is
+deliberately near logic-free: it reads ``RANK`` / ``WORLD_SIZE`` / ``LOCAL_RANK`` straight
+from the env torchrun exports — **no NCCL / process-group init**, because there are no
+collectives to run (each rank writes its own artifacts and nobody gathers) — loads the JSON
+request the parent staged, then calls the two CPU-tested layers:
+:func:`~slide2vec.runtime.sharding.plan_contiguous_shards` to pick this rank's contiguous
+shard and :func:`~slide2vec.runtime.image_shard.run_image_shard` to encode + persist it.
 """
 
 import argparse
@@ -17,8 +17,8 @@ from pathlib import Path
 
 
 def get_args_parser(add_help: bool = True) -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser("slide2vec.distributed.dense_worker", add_help=add_help)
-    parser.add_argument("--output-dir", required=True, help="Directory dense artifacts are written to")
+    parser = argparse.ArgumentParser("slide2vec.distributed.image_worker", add_help=add_help)
+    parser.add_argument("--output-dir", required=True, help="Directory image artifacts are written to")
     parser.add_argument("--request-path", required=True, help="JSON request produced by the parent process")
     return parser
 
@@ -30,15 +30,10 @@ def main(argv=None) -> int:
         activate_progress_reporter,
         emit_progress,
     )
-    from slide2vec.runtime.dense_shard import run_dense_shard
-    from slide2vec.runtime.dense_stage import (
-        region_specs_from_request,
-        resolve_output_torch_dtype,
-    )
-    from slide2vec.runtime.serialization import (
-        deserialize_dense_options,
-        deserialize_execution,
-    )
+    from slide2vec.runtime.image_shard import run_image_shard
+    from slide2vec.runtime.image_stage import image_specs_from_request
+    from slide2vec.runtime.model_settings import resolve_output_precision
+    from slide2vec.runtime.serialization import deserialize_execution
     from slide2vec.runtime.sharding import plan_contiguous_shards
 
     args = get_args_parser(add_help=True).parse_args(argv)
@@ -50,7 +45,7 @@ def main(argv=None) -> int:
     world_size = int(os.environ.get("WORLD_SIZE", "1"))
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
 
-    specs = region_specs_from_request(request)
+    specs = image_specs_from_request(request)
     shard = plan_contiguous_shards(specs, world_size)[global_rank]
     if not shard:
         return 0
@@ -62,13 +57,11 @@ def main(argv=None) -> int:
         output_variant=model_spec.get("output_variant"),
         allow_non_recommended_settings=bool(model_spec.get("allow_non_recommended_settings", False)),
     )
-    dense = deserialize_dense_options(request["dense"])
     execution = deserialize_execution(request["execution"])
-    # Each rank declares its own dense encoder-input contract rather than trusting the
-    # parent to have done it (the declaration is idempotent): that is what supplies the
-    # variable-input constructor settings this ROI geometry implies. emit_run_info=False —
-    # the run-info line is logged once by the parent, not once per rank.
-    model._declare_dense_encoder_input(dense, emit_run_info=False)
+    # Each rank declares Given for itself rather than trusting the parent to have done it
+    # (the declaration is idempotent): a backend is never handed out without a stated
+    # contract. emit_run_info=False — the run-info line is logged once by the parent.
+    model._declare_given_encoder_input(emit_run_info=False)
     loaded = model._load_backend()
 
     progress_events_path = request.get("progress_events_path")
@@ -83,18 +76,18 @@ def main(argv=None) -> int:
 
     with context:
         def _on_batch(count: int) -> None:
-            emit_progress("dense.batch.finished", rank=global_rank, regions=int(count))
+            emit_progress("images.batch.finished", rank=global_rank, images=int(count))
 
-        run_dense_shard(
+        run_image_shard(
             shard,
-            model=loaded.model,
+            loaded=loaded,
             out_dir=output_dir,
-            dense=dense,
             batch_size=int(execution.batch_size),
-            device=loaded.device,
+            output_precision=resolve_output_precision(execution.output_dtype, execution.precision),
+            output_format=execution.output_format,
             precision=execution.precision,
-            output_dtype=resolve_output_torch_dtype(execution),
             num_workers=execution.resolved_num_workers_per_gpu(),
+            prefetch_factor=int(execution.prefetch_factor),
             on_batch=_on_batch,
         )
     return 0

--- a/slide2vec/distributed/image_worker.py
+++ b/slide2vec/distributed/image_worker.py
@@ -1,35 +1,31 @@
 """torchrun entry point for distributed given-image feature extraction (issue #234).
 
 One of these runs per GPU under ``torch.distributed.run``. Like its dense sibling it is
-deliberately near logic-free: it reads ``RANK`` / ``WORLD_SIZE`` / ``LOCAL_RANK`` straight
-from the env torchrun exports — **no NCCL / process-group init**, because there are no
-collectives to run (each rank writes its own artifacts and nobody gathers) — loads the JSON
-request the parent staged, then calls the two CPU-tested layers:
-:func:`~slide2vec.runtime.sharding.plan_contiguous_shards` to pick this rank's contiguous
-shard and :func:`~slide2vec.runtime.image_shard.run_image_shard` to encode + persist it.
+near logic-free: the rank, the model and the progress wiring come from
+:mod:`slide2vec.distributed.worker_entry`; what is left here is Given-specific — declare
+the Given encoder-input contract, rebuild the image list the parent staged, then call the
+two CPU-tested layers: :func:`~slide2vec.runtime.sharding.plan_contiguous_shards` to pick
+this rank's contiguous shard and :func:`~slide2vec.runtime.image_shard.run_image_shard` to
+encode + persist it.
 """
 
-import argparse
 import json
-import os
-from contextlib import nullcontext
 from pathlib import Path
 
+from slide2vec.distributed.worker_entry import (
+    model_from_request,
+    resolve_worker_rank,
+    worker_args_parser,
+    worker_progress_context,
+)
 
-def get_args_parser(add_help: bool = True) -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser("slide2vec.distributed.image_worker", add_help=add_help)
-    parser.add_argument("--output-dir", required=True, help="Directory image artifacts are written to")
-    parser.add_argument("--request-path", required=True, help="JSON request produced by the parent process")
-    return parser
+
+def get_args_parser(add_help: bool = True):
+    return worker_args_parser("slide2vec.distributed.image_worker", add_help=add_help)
 
 
 def main(argv=None) -> int:
-    from slide2vec.api import Model
-    from slide2vec.progress import (
-        JsonlProgressReporter,
-        activate_progress_reporter,
-        emit_progress,
-    )
+    from slide2vec.progress import emit_progress
     from slide2vec.runtime.image_shard import run_image_shard
     from slide2vec.runtime.image_stage import image_specs_from_request
     from slide2vec.runtime.model_settings import resolve_output_precision
@@ -39,24 +35,14 @@ def main(argv=None) -> int:
     args = get_args_parser(add_help=True).parse_args(argv)
     request = json.loads(Path(args.request_path).read_text(encoding="utf-8"))
     output_dir = Path(args.output_dir)
-
-    # torchrun exports these; default to a single in-process rank if launched bare.
-    global_rank = int(os.environ.get("RANK", "0"))
-    world_size = int(os.environ.get("WORLD_SIZE", "1"))
-    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    rank = resolve_worker_rank()
 
     specs = image_specs_from_request(request)
-    shard = plan_contiguous_shards(specs, world_size)[global_rank]
+    shard = plan_contiguous_shards(specs, rank.world_size)[rank.global_rank]
     if not shard:
         return 0
 
-    model_spec = dict(request["model"])
-    model = Model.from_preset(
-        model_spec["name"],
-        device=f"cuda:{local_rank}",
-        output_variant=model_spec.get("output_variant"),
-        allow_non_recommended_settings=bool(model_spec.get("allow_non_recommended_settings", False)),
-    )
+    model = model_from_request(request, rank=rank)
     execution = deserialize_execution(request["execution"])
     # Each rank declares Given for itself rather than trusting the parent to have done it
     # (the declaration is idempotent): a backend is never handed out without a stated
@@ -64,19 +50,9 @@ def main(argv=None) -> int:
     model._declare_given_encoder_input(emit_run_info=False)
     loaded = model._load_backend()
 
-    progress_events_path = request.get("progress_events_path")
-    reporter = (
-        JsonlProgressReporter(
-            progress_events_path, rank=global_rank, progress_label=f"cuda:{local_rank}"
-        )
-        if progress_events_path
-        else None
-    )
-    context = activate_progress_reporter(reporter) if reporter is not None else nullcontext()
-
-    with context:
+    with worker_progress_context(request, rank=rank):
         def _on_batch(count: int) -> None:
-            emit_progress("images.batch.finished", rank=global_rank, images=int(count))
+            emit_progress("images.batch.finished", rank=rank.global_rank, images=int(count))
 
         run_image_shard(
             shard,

--- a/slide2vec/distributed/worker_entry.py
+++ b/slide2vec/distributed/worker_entry.py
@@ -1,0 +1,87 @@
+"""What every torchrun worker does before it starts encoding.
+
+A slide2vec worker module is deliberately near logic-free — read the rank torchrun handed
+it, rebuild the model the parent named, wire progress back to the parent, encode its shard.
+Only the last step differs between the dense and given-image workers, so the first three
+live here rather than being copied per extraction path.
+
+There is no NCCL / process-group init anywhere in this file: these workers run no
+collectives. Each rank derives its own shard from the same ordered work list and writes its
+own artifacts, so the only thing they share is the filesystem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from contextlib import nullcontext
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class WorkerRank:
+    """This process's place in the torchrun world: which shard, and which GPU."""
+
+    #: Index into the shard list — which slice of the work this process owns.
+    global_rank: int
+    #: Number of shards the work list is cut into.
+    world_size: int
+    #: Local device ordinal, i.e. ``cuda:<local_rank>``.
+    local_rank: int
+
+    @property
+    def device(self) -> str:
+        return f"cuda:{self.local_rank}"
+
+
+def worker_args_parser(module: str, *, add_help: bool = True) -> argparse.ArgumentParser:
+    """The two arguments the parent passes to every worker module."""
+    parser = argparse.ArgumentParser(module, add_help=add_help)
+    parser.add_argument("--output-dir", required=True, help="Directory artifacts are written to")
+    parser.add_argument("--request-path", required=True, help="JSON request produced by the parent process")
+    return parser
+
+
+def resolve_worker_rank() -> WorkerRank:
+    """Read this process's rank from the env torchrun exports.
+
+    Defaults to a single in-process rank when the module is launched bare, so a worker can
+    be run by hand (or in a test) without a torchrun agent.
+    """
+    return WorkerRank(
+        global_rank=int(os.environ.get("RANK", "0")),
+        world_size=int(os.environ.get("WORLD_SIZE", "1")),
+        local_rank=int(os.environ.get("LOCAL_RANK", "0")),
+    )
+
+
+def model_from_request(request: dict, *, rank: WorkerRank):
+    """Rebuild the parent's ``Model`` on this rank's GPU (weights load on first backend use).
+
+    Note this returns a model with **no encoder-input contract declared**: which regime
+    applies is the caller's own statement, and each worker makes it explicitly before it
+    asks for a backend.
+    """
+    from slide2vec.api import Model
+
+    model_spec = dict(request["model"])
+    return Model.from_preset(
+        model_spec["name"],
+        device=rank.device,
+        output_variant=model_spec.get("output_variant"),
+        allow_non_recommended_settings=bool(model_spec.get("allow_non_recommended_settings", False)),
+    )
+
+
+def worker_progress_context(request: dict, *, rank: WorkerRank):
+    """Route this rank's progress events into the jsonl the parent process tails."""
+    from slide2vec.progress import JsonlProgressReporter, activate_progress_reporter
+
+    progress_events_path = request.get("progress_events_path")
+    if not progress_events_path:
+        return nullcontext()
+    return activate_progress_reporter(
+        JsonlProgressReporter(
+            progress_events_path, rank=rank.global_rank, progress_label=rank.device
+        )
+    )

--- a/slide2vec/runtime/batching.py
+++ b/slide2vec/runtime/batching.py
@@ -82,14 +82,26 @@ def build_batch_preprocessor_for_tile_images(
     return preprocess
 
 
-def embedding_dataloader_kwargs(loaded: LoadedModel, execution) -> dict[str, Any]:
-    num_workers = execution.resolved_num_workers_per_gpu()
-    kwargs: dict[str, Any] = {"num_workers": num_workers}
-    if num_workers > 0:
-        kwargs["prefetch_factor"] = execution.prefetch_factor
-    if uses_cuda_runtime(loaded.device):
+def dataloader_kwargs(*, device, num_workers: int, prefetch_factor: int) -> dict[str, Any]:
+    """The DataLoader knobs every embedding route sets, from the values it already holds.
+
+    ``prefetch_factor`` is only legal with worker processes, and pinned host memory only
+    buys anything when the copy is to a CUDA device.
+    """
+    kwargs: dict[str, Any] = {"num_workers": int(num_workers)}
+    if int(num_workers) > 0:
+        kwargs["prefetch_factor"] = int(prefetch_factor)
+    if uses_cuda_runtime(device):
         kwargs["pin_memory"] = True
     return kwargs
+
+
+def embedding_dataloader_kwargs(loaded: LoadedModel, execution) -> dict[str, Any]:
+    return dataloader_kwargs(
+        device=loaded.device,
+        num_workers=execution.resolved_num_workers_per_gpu(),
+        prefetch_factor=execution.prefetch_factor,
+    )
 
 
 class BatchPrefetcher:

--- a/slide2vec/runtime/batching.py
+++ b/slide2vec/runtime/batching.py
@@ -1,19 +1,32 @@
+"""Feeding an encoder: prefetch batches, preprocess them, run the forward pass.
+
+The library's single encode loop lives here (:func:`iter_forward_batches`), along with the
+prefetcher that overlaps host→device copies with compute. How the pixels are turned into a
+tensor is :mod:`slide2vec.runtime.preprocessing`'s job; what is done with each batch's
+embeddings is the calling route's.
+"""
+
 from __future__ import annotations
 
 import logging
 import time
 from contextlib import nullcontext
-from typing import Any
+from typing import Any, Iterator
 
 import torch
-from transformers.image_processing_utils import BaseImageProcessor
-from torchvision.transforms.functional import to_pil_image
 
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.types import LoadedModel
 from slide2vec.utils.log_utils import suppress_c_stderr
 
-from .types import BatchTransformSpec, PreparedBatch
+from .preprocessing import (
+    apply_batch_transform_spec,
+    apply_transforms_itemwise,
+    build_batch_transform_spec,
+    prepare_batch_tensor,
+    resize_image_batch,
+)
+from .types import PreparedBatch
 
 
 def uses_cuda_runtime(device) -> bool:
@@ -77,180 +90,6 @@ def embedding_dataloader_kwargs(loaded: LoadedModel, execution) -> dict[str, Any
     if uses_cuda_runtime(loaded.device):
         kwargs["pin_memory"] = True
     return kwargs
-
-
-def build_batch_transform_spec(transforms) -> BatchTransformSpec | None:
-    if isinstance(transforms, BaseImageProcessor):
-        crop_size = transforms.crop_size if hasattr(transforms, "crop_size") else None
-        size = transforms.size if hasattr(transforms, "size") else None
-        resize_size = normalize_hw(crop_size or size)
-        if resize_size is None:
-            return None
-        mean = transforms.image_mean if hasattr(transforms, "image_mean") else None
-        std = transforms.image_std if hasattr(transforms, "image_std") else None
-        return BatchTransformSpec(
-            resize_size=resize_size,
-            center_crop_size=None,
-            mean=tuple(float(value) for value in mean) if mean is not None else None,
-            std=tuple(float(value) for value in std) if std is not None else None,
-        )
-
-    transform_steps = iter_transform_steps(transforms)
-    if transform_steps is None:
-        return None
-
-    resize_size = None
-    resize_interpolation = "bilinear"
-    center_crop_size = None
-    mean = None
-    std = None
-    supported_step_names = {
-        "Resize",
-        "CenterCrop",
-        "Normalize",
-        "ToTensor",
-        "MaybeToTensor",
-        "ToImage",
-        "ToDtype",
-        "ConvertImageDtype",
-    }
-    for step in transform_steps:
-        step_name = type(step).__name__
-        if step_name not in supported_step_names:
-            return None
-        if step_name == "Resize":
-            resize_size = normalize_hw(step.size if hasattr(step, "size") else None)
-            resize_interpolation = interp_mode_to_str(step.interpolation if hasattr(step, "interpolation") else None)
-        elif step_name == "CenterCrop":
-            center_crop_size = normalize_hw(step.size if hasattr(step, "size") else None)
-        elif step_name == "ToDtype":
-            if (
-                getattr(step, "dtype", None) != torch.float32
-                or getattr(step, "scale", None) is not True
-            ):
-                return None
-        elif step_name == "Normalize":
-            mean = tuple(float(value) for value in step.mean)
-            std = tuple(float(value) for value in step.std)
-    return BatchTransformSpec(
-        resize_size=resize_size,
-        center_crop_size=center_crop_size,
-        mean=mean,
-        std=std,
-        resize_interpolation=resize_interpolation,
-    )
-
-
-def iter_transform_steps(transforms):
-    transform_steps = transforms.transforms if hasattr(transforms, "transforms") else None
-    if transform_steps is None:
-        return None
-    flattened = []
-    for step in transform_steps:
-        nested = iter_transform_steps(step)
-        if nested is not None:
-            flattened.extend(nested)
-        else:
-            flattened.append(step)
-    return flattened
-
-
-def prepare_batch_tensor(image):
-    if image.dtype == torch.uint8:
-        return image.float().div(255.0)
-    return image.float()
-
-
-def _apply_transform_sample(sample, transforms):
-    if not torch.is_tensor(sample):
-        return transforms(sample)
-    try:
-        return transforms(sample)
-    except AttributeError as exc:
-        message = str(exc)
-        if "convert" not in message and "Tensor" not in message:
-            raise
-        return transforms(to_pil_image(sample.cpu()))
-
-
-def apply_transforms_itemwise(image, transforms):
-    if not torch.is_tensor(image) or image.ndim <= 3:
-        return _apply_transform_sample(image, transforms)
-
-    transformed_items = [_apply_transform_sample(sample, transforms) for sample in image.cpu()]
-    if not transformed_items:
-        return image.new_empty((0,), dtype=torch.float32)
-    if not all(torch.is_tensor(item) for item in transformed_items):
-        transformed_items = [torch.as_tensor(item) for item in transformed_items]
-    return torch.stack(transformed_items, dim=0)
-
-
-def interp_mode_to_str(interp_mode) -> str:
-    if interp_mode is None:
-        return "bilinear"
-    name = str(interp_mode).upper()
-    if "BICUBIC" in name:
-        return "bicubic"
-    if "NEAREST" in name:
-        return "nearest"
-    return "bilinear"
-
-
-def resize_image_batch(image, size: tuple[int, int], *, mode: str = "bilinear"):
-    if tuple(int(dim) for dim in image.shape[-2:]) == size:
-        return image
-
-    align_corners = False if mode in ("bilinear", "bicubic") else None
-    kwargs = {"antialias": True} if mode in ("bilinear", "bicubic") else {}
-    return torch.nn.functional.interpolate(
-        image,
-        size=size,
-        mode=mode,
-        **({"align_corners": align_corners} if align_corners is not None else {}),
-        **kwargs,
-    )
-
-
-def apply_batch_transform_spec(image, spec: BatchTransformSpec):
-    if spec.resize_size is not None:
-        image = resize_image_batch(image, spec.resize_size, mode=spec.resize_interpolation)
-    if spec.center_crop_size is not None:
-        image = center_crop_batch(image, spec.center_crop_size)
-    if spec.mean is not None and spec.std is not None:
-        mean = torch.tensor(spec.mean, dtype=image.dtype, device=image.device).view(1, -1, 1, 1)
-        std = torch.tensor(spec.std, dtype=image.dtype, device=image.device).view(1, -1, 1, 1)
-        image = (image - mean) / std
-    return image
-
-
-def normalize_hw(value) -> tuple[int, int] | None:
-    if value is None:
-        return None
-    if isinstance(value, int):
-        return (int(value), int(value))
-    if isinstance(value, (tuple, list)):
-        if len(value) == 1:
-            return (int(value[0]), int(value[0]))
-        if len(value) >= 2:
-            return (int(value[0]), int(value[1]))
-        return None
-    if isinstance(value, dict):
-        if "height" in value and "width" in value:
-            return (int(value["height"]), int(value["width"]))
-        if "shortest_edge" in value:
-            edge = int(value["shortest_edge"])
-            return (edge, edge)
-    return None
-
-
-def center_crop_batch(image, size: tuple[int, int]):
-    target_h, target_w = size
-    height, width = int(image.shape[-2]), int(image.shape[-1])
-    crop_h = min(target_h, height)
-    crop_w = min(target_w, width)
-    top = max((height - crop_h) // 2, 0)
-    left = max((width - crop_w) // 2, 0)
-    return image[..., top : top + crop_h, left : left + crop_w]
 
 
 class BatchPrefetcher:
@@ -367,7 +206,7 @@ class BatchPrefetcher:
         return current
 
 
-def run_forward_pass(
+def iter_forward_batches(
     dataloader,
     loaded: LoadedModel,
     autocast_context,
@@ -376,12 +215,21 @@ def run_forward_pass(
     sample_id: str | None = None,
     total_items: int | None = None,
     unit_label: str = "tile",
-):
-    embeddings = None
-    batch_indices = None
-    buffer_capacity = max(0, int(total_items)) if total_items is not None else 0
-    processed = 0
+) -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
+    """Yield ``(indices, embeddings)`` for each batch the dataloader produces.
+
+    The single encode loop of the library: prefetch → preprocess → record the factual
+    encoder input geometry → ``encode_tiles`` → emit per-batch timing/progress. What the
+    caller does with each batch is the only thing that differs between routes — the pooled
+    routes accumulate the whole slide into one tensor (:func:`run_forward_pass`), while the
+    given-image route persists each batch's embeddings as it goes, since there its work
+    unit is the individual image rather than the bag.
+
+    The ``torch.inference_mode()`` / autocast contexts stay entered across the yield, so a
+    consumer's per-batch work runs under the same regime the accumulating caller always did.
+    """
     batch_index = 0
+    processed = 0
     prefetcher_context = (
         suppress_c_stderr()
         if should_suppress_cucim_dataloader_stderr(dataloader)
@@ -396,33 +244,7 @@ def run_forward_pass(
             forward_start = time.perf_counter()
             embedding = loaded.model.encode_tiles(image).detach().cpu()
             forward_ms = (time.perf_counter() - forward_start) * 1000.0
-            batch_size = int(embedding.shape[0])
             current_indices = torch.as_tensor(prepared_batch.indices, dtype=torch.long).detach().cpu()
-            required_capacity = processed + batch_size
-            if embeddings is None:
-                buffer_capacity = max(buffer_capacity, required_capacity)
-                embeddings = torch.empty(
-                    (buffer_capacity, int(embedding.shape[-1])),
-                    dtype=embedding.dtype,
-                )
-                batch_indices = torch.empty((buffer_capacity,), dtype=torch.long)
-            elif required_capacity > buffer_capacity:
-                new_capacity = max(required_capacity, max(1, buffer_capacity * 2))
-                grown_embeddings = torch.empty(
-                    (new_capacity, int(embeddings.shape[-1])),
-                    dtype=embeddings.dtype,
-                )
-                if processed > 0:
-                    grown_embeddings[:processed] = embeddings[:processed]
-                embeddings = grown_embeddings
-                grown_indices = torch.empty((new_capacity,), dtype=torch.long)
-                if processed > 0:
-                    grown_indices[:processed] = batch_indices[:processed]
-                batch_indices = grown_indices
-                buffer_capacity = new_capacity
-
-            embeddings[processed:required_capacity] = embedding
-            batch_indices[processed:required_capacity] = current_indices
             processed += int(embedding.shape[0])
             batch_index += 1
             batch_total_ms = (
@@ -459,6 +281,60 @@ def run_forward_pass(
                     total=int(total_items or processed),
                     unit=unit_label,
                 )
+            yield current_indices, embedding
+
+
+def run_forward_pass(
+    dataloader,
+    loaded: LoadedModel,
+    autocast_context,
+    *,
+    batch_preprocessor=None,
+    sample_id: str | None = None,
+    total_items: int | None = None,
+    unit_label: str = "tile",
+):
+    """Encode every batch and gather the result into one ``(N, D)`` tensor + index vector."""
+    embeddings = None
+    batch_indices = None
+    buffer_capacity = max(0, int(total_items)) if total_items is not None else 0
+    processed = 0
+    for current_indices, embedding in iter_forward_batches(
+        dataloader,
+        loaded,
+        autocast_context,
+        batch_preprocessor=batch_preprocessor,
+        sample_id=sample_id,
+        total_items=total_items,
+        unit_label=unit_label,
+    ):
+        batch_size = int(embedding.shape[0])
+        required_capacity = processed + batch_size
+        if embeddings is None:
+            buffer_capacity = max(buffer_capacity, required_capacity)
+            embeddings = torch.empty(
+                (buffer_capacity, int(embedding.shape[-1])),
+                dtype=embedding.dtype,
+            )
+            batch_indices = torch.empty((buffer_capacity,), dtype=torch.long)
+        elif required_capacity > buffer_capacity:
+            new_capacity = max(required_capacity, max(1, buffer_capacity * 2))
+            grown_embeddings = torch.empty(
+                (new_capacity, int(embeddings.shape[-1])),
+                dtype=embeddings.dtype,
+            )
+            if processed > 0:
+                grown_embeddings[:processed] = embeddings[:processed]
+            embeddings = grown_embeddings
+            grown_indices = torch.empty((new_capacity,), dtype=torch.long)
+            if processed > 0:
+                grown_indices[:processed] = batch_indices[:processed]
+            batch_indices = grown_indices
+            buffer_capacity = new_capacity
+
+        embeddings[processed:required_capacity] = embedding
+        batch_indices[processed:required_capacity] = current_indices
+        processed += batch_size
     if embeddings is None:
         feature_dim = loaded.tile_feature_dim if loaded.tile_feature_dim is not None else loaded.feature_dim
         empty = torch.empty((0, int(feature_dim)), dtype=torch.float32)

--- a/slide2vec/runtime/dense_shard.py
+++ b/slide2vec/runtime/dense_shard.py
@@ -1,13 +1,12 @@
-"""ROI-granularity sharding + the device-agnostic dense encode/write loop (issue #217).
+"""The device-agnostic dense encode/write loop (issue #217).
 
-The two CPU-testable layers of distributed dense extraction (D12):
+Sharding itself is not here: the slide-ordered flat ROI list is split by the shared
+:func:`~slide2vec.runtime.sharding.plan_contiguous_shards`. Splitting at ROI granularity
+minimizes WSI re-opens — only the slides straddling a shard boundary are opened twice —
+and, because dense features depend only on the batch size ``B`` and never on batch
+*composition* (docs/adr/0002), needs no batch-alignment or bin-packing.
 
-* :func:`plan_dense_shards` — pure. Splits the slide-ordered flat ROI list into
-  ``world_size`` contiguous shards with :func:`numpy.array_split` (balanced to ±1 ROI,
-  deterministic, an exact partition). Sharding at ROI granularity minimizes WSI re-opens —
-  only the slides straddling a shard boundary are opened twice — and, because dense
-  features depend only on the batch size ``B`` and never on batch *composition*
-  (docs/adr/0002), needs no batch-alignment or bin-packing.
+What this module owns is the CPU-testable encode/write layer (D12):
 
 * :func:`run_dense_shard` — the encode+write loop each rank runs over its shard. It groups
   the shard's ROIs by slide (contiguous runs), builds a minimal hs2p ``TilingResult`` per
@@ -67,24 +66,6 @@ class RegionSpec:
     requested_tile_size_px: int
     backend: str
     annotation: str | None = None
-
-
-def plan_dense_shards(
-    regions: Sequence[RegionSpec], world_size: int
-) -> list[list[RegionSpec]]:
-    """Partition the slide-ordered flat ROI list into ``world_size`` contiguous shards.
-
-    Contiguous ``numpy.array_split`` over the ROI index range: exactly ``world_size``
-    shards, balanced to within one ROI, deterministic, and an exact ordered partition of
-    the input (union preserves order, shards are pairwise disjoint). Contiguity keeps ROIs
-    of a slide together so only boundary slides are opened twice. Shards may be empty when
-    ``world_size`` exceeds the ROI count.
-    """
-    if world_size < 1:
-        raise ValueError(f"world_size must be at least 1, got {world_size}")
-    regions = list(regions)
-    index_shards = np.array_split(np.arange(len(regions)), world_size)
-    return [[regions[int(i)] for i in shard] for shard in index_shards]
 
 
 def _slide_key(spec: RegionSpec) -> tuple:

--- a/slide2vec/runtime/dense_stage.py
+++ b/slide2vec/runtime/dense_stage.py
@@ -33,7 +33,6 @@ from slide2vec.progress import emit_progress
 from slide2vec.runtime.dense_shard import (
     RegionSpec,
     dense_artifact_from_disk,
-    plan_dense_shards,
     region_needs_encode,
     run_dense_shard,
 )

--- a/slide2vec/runtime/image_shard.py
+++ b/slide2vec/runtime/image_shard.py
@@ -20,11 +20,20 @@ Two things distinguish it from the pooled tile loop it otherwise reuses wholesal
 Writes are atomic and sidecar-last (see :func:`~slide2vec.artifacts.write_image_embedding`),
 so a payload without a sidecar unambiguously means an interrupted image and resume trusts
 the sidecar as the done-marker.
+
+One property of the Given regime is worth stating explicitly, because it is what makes
+batching possible at all: the encoder's shipped transform maps *every* input onto one fixed
+square geometry (every registered encoder's recipe ends in a Resize/CenterCrop to its
+registered input size). Heterogeneous inputs therefore leave preprocessing uniform, which is
+why they can be stacked — and why the shared recorder
+(``batching._record_encoder_input_size``) can hold one observed size for the run. A
+transform that did not normalize geometry would fail at the stack, before the recorder.
 """
 
 from __future__ import annotations
 
 from contextlib import nullcontext
+from functools import partial
 from typing import TYPE_CHECKING, Callable, Sequence
 
 import torch
@@ -37,7 +46,13 @@ from slide2vec.artifacts import (
     write_image_embedding,
 )
 from slide2vec.data.dataset import ImageFileDataset, StackedImageCollator
-from slide2vec.runtime.batching import autocast_dtype, iter_forward_batches, uses_cuda_runtime
+from slide2vec.runtime.batching import (
+    autocast_dtype,
+    dataloader_kwargs,
+    iter_forward_batches,
+    uses_cuda_runtime,
+)
+from slide2vec.runtime.preprocessing import apply_transforms_itemwise
 
 if TYPE_CHECKING:
     from slide2vec.api import ImageSpec
@@ -45,15 +60,18 @@ if TYPE_CHECKING:
 
 
 def image_needs_encode(out_dir, spec: "ImageSpec", *, output_format: str) -> bool:
-    """Resume predicate: an image needs encoding iff its sidecar is absent.
+    """Resume predicate: an image is done iff its sidecar *and* this run's payload exist.
 
     The sidecar is written last, so its presence is the done-marker; a payload with no
-    sidecar is an interrupted write and is re-encoded.
+    sidecar is an interrupted write and is re-encoded. The payload is checked too because
+    the sidecar name carries no format: a rerun that switches ``output_format`` would
+    otherwise see the previous run's sidecar, skip every image, and hand back artifacts
+    pointing at payloads that were never written.
     """
-    _, sidecar_path = image_embedding_paths(
+    payload_path, sidecar_path = image_embedding_paths(
         out_dir, sample_id=spec.sample_id, output_format=output_format
     )
-    return not sidecar_path.exists()
+    return not (sidecar_path.exists() and payload_path.exists())
 
 
 def image_artifact_from_disk(
@@ -134,9 +152,9 @@ def run_image_shard(
 ) -> list[ImageEmbeddingArtifact]:
     """Encode + persist one shard's images, one payload + one sidecar per image.
 
-    Skips any image whose sidecar already exists (resume), encodes the rest through the
-    shared forward loop, and writes each batch's embeddings before the next batch is
-    encoded. Returns one :class:`~slide2vec.artifacts.ImageEmbeddingArtifact` per input
+    Skips any image already complete on disk (see :func:`image_needs_encode`), encodes the
+    rest through the shared forward loop, and writes each batch's embeddings before the
+    next batch is encoded. Returns one :class:`~slide2vec.artifacts.ImageEmbeddingArtifact` per input
     image in input order — freshly written or (when skipped) read back off disk.
     ``on_batch`` is invoked with each encoded batch's image count for per-batch progress.
     """
@@ -148,18 +166,21 @@ def run_image_shard(
     if pending:
         # The observed encoder input is a fact of this run, not of a previous one.
         loaded.encoder_input_size_px = None
-        dataset = ImageFileDataset([spec.image_path for spec in pending], loaded.transforms)
-        loader_kwargs: dict = {"num_workers": int(num_workers)}
-        if int(num_workers) > 0:
-            loader_kwargs["prefetch_factor"] = int(prefetch_factor)
-        if uses_cuda_runtime(loaded.device):
-            loader_kwargs["pin_memory"] = True
+        dataset = ImageFileDataset(
+            [spec.image_path for spec in pending],
+            # partial, not a closure: the recipe is pickled into the loader workers.
+            partial(apply_transforms_itemwise, transforms=loaded.transforms),
+        )
         dataloader = torch.utils.data.DataLoader(
             dataset,
             batch_size=max(1, int(batch_size)),
             shuffle=False,
             collate_fn=StackedImageCollator(),
-            **loader_kwargs,
+            **dataloader_kwargs(
+                device=loaded.device,
+                num_workers=int(num_workers),
+                prefetch_factor=int(prefetch_factor),
+            ),
         )
         cast_dtype = autocast_dtype(torch, precision)
         autocast_context = (

--- a/slide2vec/runtime/image_shard.py
+++ b/slide2vec/runtime/image_shard.py
@@ -1,0 +1,201 @@
+"""The device-agnostic encode/write loop for given-geometry images (issue #234).
+
+The Given-regime counterpart of :mod:`slide2vec.runtime.dense_shard`: each rank runs this
+identical loop over its own contiguous shard (cut by the shared
+:func:`~slide2vec.runtime.sharding.plan_contiguous_shards`), and writes one embedding
+artifact per image. It is device-agnostic and ``RANK``-free, so the very same code path runs
+in-process for ``num_gpus=1`` and on every torchrun rank — and is exercised on CPU.
+
+Two things distinguish it from the pooled tile loop it otherwise reuses wholesale
+(:func:`~slide2vec.runtime.batching.iter_forward_batches`):
+
+* **Preprocessing is itemwise.** The images are heterogeneously sized, so the batched
+  transform spec cannot apply; the shipped transform runs per item inside the loader
+  workers (:class:`~slide2vec.data.dataset.ImageFileDataset`) and only the transformed
+  items are stacked.
+* **Persistence is write-through.** The work unit is the individual image, not a bag, so
+  each batch's embeddings are persisted as they are produced — which is what makes a
+  killed rank resumable at image granularity rather than losing the whole shard.
+
+Writes are atomic and sidecar-last (see :func:`~slide2vec.artifacts.write_image_embedding`),
+so a payload without a sidecar unambiguously means an interrupted image and resume trusts
+the sidecar as the done-marker.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import TYPE_CHECKING, Callable, Sequence
+
+import torch
+
+from slide2vec.artifacts import (
+    ImageEmbeddingArtifact,
+    cast_feature_dtype,
+    image_embedding_paths,
+    load_metadata,
+    write_image_embedding,
+)
+from slide2vec.data.dataset import ImageFileDataset, StackedImageCollator
+from slide2vec.runtime.batching import autocast_dtype, iter_forward_batches, uses_cuda_runtime
+
+if TYPE_CHECKING:
+    from slide2vec.api import ImageSpec
+    from slide2vec.runtime.types import LoadedModel
+
+
+def image_needs_encode(out_dir, spec: "ImageSpec", *, output_format: str) -> bool:
+    """Resume predicate: an image needs encoding iff its sidecar is absent.
+
+    The sidecar is written last, so its presence is the done-marker; a payload with no
+    sidecar is an interrupted write and is re-encoded.
+    """
+    _, sidecar_path = image_embedding_paths(
+        out_dir, sample_id=spec.sample_id, output_format=output_format
+    )
+    return not sidecar_path.exists()
+
+
+def image_artifact_from_disk(
+    out_dir, spec: "ImageSpec", *, output_format: str
+) -> ImageEmbeddingArtifact:
+    """Rebuild the artifact record for an image already on disk (skipped, or final collect)."""
+    payload_path, sidecar_path = image_embedding_paths(
+        out_dir, sample_id=spec.sample_id, output_format=output_format
+    )
+    metadata = load_metadata(sidecar_path)
+    return ImageEmbeddingArtifact(
+        sample_id=spec.sample_id,
+        path=payload_path,
+        metadata_path=sidecar_path,
+        format=output_format,
+        feature_dim=int(metadata["feature_dim"]),
+    )
+
+
+def image_embedding_metadata(
+    spec: "ImageSpec",
+    *,
+    loaded: "LoadedModel",
+    output_precision: str,
+    output_format: str,
+) -> dict:
+    """The provenance sidecar: who encoded this image, and what geometry the encoder saw.
+
+    ``encoder_input_size_px`` is the Given regime's obligation from the encoder-input
+    contract — the factual square side length of the tensor handed to ``encode_tiles``,
+    observed rather than declared, because the caller supplied pixels it never requested and
+    the encoder's shipped transform decided the geometry.
+    """
+    return {
+        "artifact_type": "image_embeddings",
+        "sample_id": spec.sample_id,
+        "image_path": str(spec.image_path),
+        "format": output_format,
+        "encoder_name": loaded.name,
+        "encoder_level": loaded.level,
+        "encoder_input_regime": "given",
+        "encoder_input_size_px": (
+            int(loaded.encoder_input_size_px)
+            if loaded.encoder_input_size_px is not None
+            else None
+        ),
+        "feature_dtype": output_precision,
+    }
+
+
+def _move_batch_to_device(loaded: "LoadedModel") -> Callable:
+    """Batch 'preprocessing' for this path: the transform already ran, so only move.
+
+    Passing this rather than ``None`` is what keeps the prefetcher from applying
+    ``loaded.transforms`` a second time — here the loader workers already did, per item.
+    """
+
+    def move(image):
+        if torch.is_tensor(image) and image.device != loaded.device:
+            return image.to(loaded.device, non_blocking=uses_cuda_runtime(loaded.device))
+        return image
+
+    return move
+
+
+def run_image_shard(
+    images: Sequence["ImageSpec"],
+    *,
+    loaded: "LoadedModel",
+    out_dir,
+    batch_size: int,
+    output_precision: str,
+    output_format: str = "pt",
+    precision: str = "fp32",
+    num_workers: int = 4,
+    prefetch_factor: int = 4,
+    on_batch: Callable[[int], None] | None = None,
+) -> list[ImageEmbeddingArtifact]:
+    """Encode + persist one shard's images, one payload + one sidecar per image.
+
+    Skips any image whose sidecar already exists (resume), encodes the rest through the
+    shared forward loop, and writes each batch's embeddings before the next batch is
+    encoded. Returns one :class:`~slide2vec.artifacts.ImageEmbeddingArtifact` per input
+    image in input order — freshly written or (when skipped) read back off disk.
+    ``on_batch`` is invoked with each encoded batch's image count for per-batch progress.
+    """
+    images = list(images)
+    pending = [
+        spec for spec in images if image_needs_encode(out_dir, spec, output_format=output_format)
+    ]
+    written: dict[str, ImageEmbeddingArtifact] = {}
+    if pending:
+        # The observed encoder input is a fact of this run, not of a previous one.
+        loaded.encoder_input_size_px = None
+        dataset = ImageFileDataset([spec.image_path for spec in pending], loaded.transforms)
+        loader_kwargs: dict = {"num_workers": int(num_workers)}
+        if int(num_workers) > 0:
+            loader_kwargs["prefetch_factor"] = int(prefetch_factor)
+        if uses_cuda_runtime(loaded.device):
+            loader_kwargs["pin_memory"] = True
+        dataloader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=max(1, int(batch_size)),
+            shuffle=False,
+            collate_fn=StackedImageCollator(),
+            **loader_kwargs,
+        )
+        cast_dtype = autocast_dtype(torch, precision)
+        autocast_context = (
+            torch.autocast(device_type="cuda", dtype=cast_dtype)
+            if cast_dtype is not None and uses_cuda_runtime(loaded.device)
+            else nullcontext()
+        )
+        for indices, embeddings in iter_forward_batches(
+            dataloader,
+            loaded,
+            autocast_context,
+            batch_preprocessor=_move_batch_to_device(loaded),
+            total_items=len(dataset),
+            unit_label="image",
+        ):
+            for index, embedding in zip(indices.tolist(), embeddings):
+                spec = pending[int(index)]
+                # ``clone`` before persisting: each row is a view onto the whole batch's
+                # storage, and torch.save serializes a tensor's *storage*, so saving the
+                # view unclipped would write the entire batch into every artifact.
+                written[spec.sample_id] = write_image_embedding(
+                    cast_feature_dtype(embedding.clone(), output_precision),
+                    output_dir=out_dir,
+                    sample_id=spec.sample_id,
+                    output_format=output_format,
+                    metadata=image_embedding_metadata(
+                        spec,
+                        loaded=loaded,
+                        output_precision=output_precision,
+                        output_format=output_format,
+                    ),
+                )
+            if on_batch is not None:
+                on_batch(int(indices.numel()))
+    return [
+        written.get(spec.sample_id)
+        or image_artifact_from_disk(out_dir, spec, output_format=output_format)
+        for spec in images
+    ]

--- a/slide2vec/runtime/image_stage.py
+++ b/slide2vec/runtime/image_stage.py
@@ -150,9 +150,16 @@ def _run_images_in_process(model, specs, *, execution, out_dir) -> None:
     # Loaded under the Given contract declared by embed_images, so the backend carries the
     # encoder's shipped transform — which the loader workers then apply itemwise.
     loaded = model._load_backend()
+
+    def _on_batch(count: int) -> None:
+        # Same per-batch event the ranks emit, so a single-GPU run reports progress the
+        # same way a distributed one does.
+        emit_progress("images.batch.finished", rank=0, images=int(count))
+
     run_image_shard(
         specs,
         loaded=loaded,
+        on_batch=_on_batch,
         out_dir=out_dir,
         batch_size=int(execution.batch_size),
         output_precision=resolve_output_precision(execution.output_dtype, execution.precision),

--- a/slide2vec/runtime/image_stage.py
+++ b/slide2vec/runtime/image_stage.py
@@ -1,0 +1,188 @@
+"""Parent-side orchestration for given-geometry image extraction (issue #234).
+
+The glue that turns a caller's :class:`~slide2vec.api.ImageSpec` list into persisted
+embeddings. It is deliberately the same five steps as the dense stage, over the same
+machinery, because the only thing that differs is the work unit:
+
+1. **declare** the Given encoder-input contract — the caller supplies pixels it never
+   requested, so the encoder's shipped transform *is* the contract (see
+   :class:`~slide2vec.runtime.encoder_input_contract.EncoderInputContract`);
+2. **normalize** the images into resolved, uniquely-named specs;
+3. **resume-filter** them — drop images whose sidecar already exists, before sharding, so
+   no rank draws an all-done shard and idles; the skip count is logged;
+4. **dispatch**: ``num_gpus=1`` runs :func:`~slide2vec.runtime.image_shard.run_image_shard`
+   fully in-process (no torchrun); ``num_gpus>1`` writes a JSON request and launches
+   :mod:`slide2vec.distributed.image_worker` under torchrun, which splits the list with the
+   shared :func:`~slide2vec.runtime.sharding.plan_contiguous_shards`;
+5. **collect** one :class:`~slide2vec.artifacts.ImageEmbeddingArtifact` per input image by
+   reading the sidecars back off disk (the ranks already persisted them; nobody gathers).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from pathlib import Path
+from subprocess import Popen
+from typing import Sequence
+
+from slide2vec.api import ImageSpec
+from slide2vec.artifacts import ImageEmbeddingArtifact
+from slide2vec.progress import emit_progress
+from slide2vec.runtime.distributed import (
+    distributed_coordination_dir,
+    reset_progress_event_logs,
+    run_torchrun_worker,
+)
+from slide2vec.runtime.distributed_stage import validate_multi_gpu_execution
+from slide2vec.runtime.image_shard import (
+    image_artifact_from_disk,
+    image_needs_encode,
+    run_image_shard,
+)
+from slide2vec.runtime.model_settings import resolve_output_precision
+from slide2vec.runtime.serialization import serialize_execution, serialize_model
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_image_specs(images: Sequence[ImageSpec]) -> list[ImageSpec]:
+    """Resolve each image path and guarantee the sample ids can name distinct artifacts.
+
+    ``sample_id`` is the artifact's whole identity on this path, so a duplicate would make
+    two images silently overwrite one another — and, worse, make the second look already
+    done to resume. That is a hard error, not a warning.
+    """
+    specs = [
+        ImageSpec(
+            sample_id=str(image.sample_id),
+            image_path=str(Path(image.image_path).expanduser().resolve()),
+        )
+        for image in images
+    ]
+    if not specs:
+        raise ValueError("At least one image is required")
+    duplicates = sorted(
+        sample_id
+        for sample_id, count in Counter(spec.sample_id for spec in specs).items()
+        if count > 1
+    )
+    if duplicates:
+        raise ValueError(
+            f"embed_images() received duplicate sample_id values: {duplicates}. Each image "
+            "is persisted as image_embeddings/<sample_id>, so sample ids must be unique."
+        )
+    return specs
+
+
+def partition_images_by_resume(
+    specs: Sequence[ImageSpec], out_dir, *, output_format: str
+) -> tuple[list[ImageSpec], int]:
+    """Split the spec list into (needs-encode, already-on-disk-count) by sidecar existence."""
+    remaining = [
+        spec for spec in specs if image_needs_encode(out_dir, spec, output_format=output_format)
+    ]
+    return remaining, len(specs) - len(remaining)
+
+
+def build_image_worker_request(specs: Sequence[ImageSpec]) -> dict:
+    """The flat image list crossing to the torchrun ranks, in the order the parent fixed.
+
+    Order is the payload: every rank rebuilds this exact list and derives its own contiguous
+    shard from it, so the ordering *is* the work assignment. Unlike the dense request there
+    is no side-car npz — the units are two strings each, not numeric coordinate arrays.
+    """
+    return {
+        "images": [
+            {"sample_id": spec.sample_id, "image_path": str(spec.image_path)} for spec in specs
+        ]
+    }
+
+
+def image_specs_from_request(request: dict) -> list[ImageSpec]:
+    """Inverse of :func:`build_image_worker_request`: request → flat spec list."""
+    return [
+        ImageSpec(sample_id=str(image["sample_id"]), image_path=str(image["image_path"]))
+        for image in request["images"]
+    ]
+
+
+def embed_images(model, images: Sequence[ImageSpec], *, execution) -> list[ImageEmbeddingArtifact]:
+    """Embed + persist one artifact per caller-supplied image across all visible GPUs."""
+    # Declare Given before anything is read or launched. This is the affirmative statement
+    # that the caller supplied geometry it never requested — not the absence of a
+    # declaration, which the contract deliberately refuses to interpret. Idempotent, so
+    # every torchrun rank re-declares for itself (image_worker).
+    model._declare_given_encoder_input(emit_run_info=True)
+    specs = normalize_image_specs(images)
+    out_dir = Path(execution.output_dir).expanduser().resolve()
+    execution = execution.with_output_dir(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
+    remaining, skipped = partition_images_by_resume(
+        specs, out_dir, output_format=execution.output_format
+    )
+    if skipped:
+        logger.info(
+            "resume: %s/%s images already on disk, encoding %s",
+            f"{skipped:,}", f"{len(specs):,}", f"{len(remaining):,}",
+        )
+    emit_progress(
+        "images.started",
+        total=len(specs),
+        skipped=skipped,
+        encoding=len(remaining),
+        num_gpus=execution.num_gpus,
+    )
+    if remaining:
+        if execution.num_gpus == 1:
+            _run_images_in_process(model, remaining, execution=execution, out_dir=out_dir)
+        else:
+            _run_images_distributed(model, remaining, execution=execution, out_dir=out_dir)
+    emit_progress("images.finished", total=len(specs))
+    return [
+        image_artifact_from_disk(out_dir, spec, output_format=execution.output_format)
+        for spec in specs
+    ]
+
+
+def _run_images_in_process(model, specs, *, execution, out_dir) -> None:
+    # Loaded under the Given contract declared by embed_images, so the backend carries the
+    # encoder's shipped transform — which the loader workers then apply itemwise.
+    loaded = model._load_backend()
+    run_image_shard(
+        specs,
+        loaded=loaded,
+        out_dir=out_dir,
+        batch_size=int(execution.batch_size),
+        output_precision=resolve_output_precision(execution.output_dtype, execution.precision),
+        output_format=execution.output_format,
+        precision=execution.precision,
+        num_workers=execution.resolved_num_workers_per_gpu(),
+        prefetch_factor=int(execution.prefetch_factor),
+    )
+
+
+def _run_images_distributed(model, specs, *, execution, out_dir) -> None:
+    validate_multi_gpu_execution(model, execution)
+    progress_events_path = out_dir / "logs" / "image_worker.progress.jsonl"
+    reset_progress_event_logs(progress_events_path)
+    with distributed_coordination_dir(out_dir) as coordination_dir:
+        request_path = coordination_dir / "image_request.json"
+        request = {
+            "model": serialize_model(model),
+            "execution": serialize_execution(execution),
+            "output_dir": str(out_dir),
+            "progress_events_path": str(progress_events_path),
+            **build_image_worker_request(specs),
+        }
+        request_path.write_text(json.dumps(request, indent=2, sort_keys=True), encoding="utf-8")
+        run_torchrun_worker(
+            module="slide2vec.distributed.image_worker",
+            num_gpus=execution.num_gpus,
+            output_dir=out_dir,
+            request_path=request_path,
+            failure_title="Distributed image feature extraction failed",
+            progress_events_path=progress_events_path,
+            popen_factory=Popen,
+        )

--- a/slide2vec/runtime/preprocessing.py
+++ b/slide2vec/runtime/preprocessing.py
@@ -1,0 +1,196 @@
+"""Turning images into the tensor an encoder consumes — batched, or one item at a time.
+
+Two preprocessing regimes live here, and which one applies is a property of the input:
+
+* **Batched** (:func:`build_batch_transform_spec` + :func:`apply_batch_transform_spec`) —
+  the declared paths tile a slide at one ``read_tile_size_px``, so a whole batch arrives as
+  a single uniform ``(B, 3, H, W)`` uint8 tensor and the encoder's Resize / CenterCrop /
+  Normalize recipe can be replayed once over the batch on the GPU. This is a fast path, and
+  it is only sound because the geometry is uniform by construction.
+* **Itemwise** (:func:`apply_transforms_itemwise`) — the encoder's shipped transform applied
+  per sample. This is the fallback when a transform stack cannot be replayed as a spec, and
+  it is the *only* option for given-geometry inputs (issue #234), which are heterogeneously
+  sized and therefore cannot be stacked before they are resized.
+"""
+
+from __future__ import annotations
+
+import torch
+from transformers.image_processing_utils import BaseImageProcessor
+from torchvision.transforms.functional import to_pil_image
+
+from .types import BatchTransformSpec
+
+
+def build_batch_transform_spec(transforms) -> BatchTransformSpec | None:
+    if isinstance(transforms, BaseImageProcessor):
+        crop_size = transforms.crop_size if hasattr(transforms, "crop_size") else None
+        size = transforms.size if hasattr(transforms, "size") else None
+        resize_size = normalize_hw(crop_size or size)
+        if resize_size is None:
+            return None
+        mean = transforms.image_mean if hasattr(transforms, "image_mean") else None
+        std = transforms.image_std if hasattr(transforms, "image_std") else None
+        return BatchTransformSpec(
+            resize_size=resize_size,
+            center_crop_size=None,
+            mean=tuple(float(value) for value in mean) if mean is not None else None,
+            std=tuple(float(value) for value in std) if std is not None else None,
+        )
+
+    transform_steps = iter_transform_steps(transforms)
+    if transform_steps is None:
+        return None
+
+    resize_size = None
+    resize_interpolation = "bilinear"
+    center_crop_size = None
+    mean = None
+    std = None
+    supported_step_names = {
+        "Resize",
+        "CenterCrop",
+        "Normalize",
+        "ToTensor",
+        "MaybeToTensor",
+        "ToImage",
+        "ToDtype",
+        "ConvertImageDtype",
+    }
+    for step in transform_steps:
+        step_name = type(step).__name__
+        if step_name not in supported_step_names:
+            return None
+        if step_name == "Resize":
+            resize_size = normalize_hw(step.size if hasattr(step, "size") else None)
+            resize_interpolation = interp_mode_to_str(step.interpolation if hasattr(step, "interpolation") else None)
+        elif step_name == "CenterCrop":
+            center_crop_size = normalize_hw(step.size if hasattr(step, "size") else None)
+        elif step_name == "ToDtype":
+            if (
+                getattr(step, "dtype", None) != torch.float32
+                or getattr(step, "scale", None) is not True
+            ):
+                return None
+        elif step_name == "Normalize":
+            mean = tuple(float(value) for value in step.mean)
+            std = tuple(float(value) for value in step.std)
+    return BatchTransformSpec(
+        resize_size=resize_size,
+        center_crop_size=center_crop_size,
+        mean=mean,
+        std=std,
+        resize_interpolation=resize_interpolation,
+    )
+
+
+def iter_transform_steps(transforms):
+    transform_steps = transforms.transforms if hasattr(transforms, "transforms") else None
+    if transform_steps is None:
+        return None
+    flattened = []
+    for step in transform_steps:
+        nested = iter_transform_steps(step)
+        if nested is not None:
+            flattened.extend(nested)
+        else:
+            flattened.append(step)
+    return flattened
+
+
+def prepare_batch_tensor(image):
+    if image.dtype == torch.uint8:
+        return image.float().div(255.0)
+    return image.float()
+
+
+def _apply_transform_sample(sample, transforms):
+    if not torch.is_tensor(sample):
+        return transforms(sample)
+    try:
+        return transforms(sample)
+    except AttributeError as exc:
+        message = str(exc)
+        if "convert" not in message and "Tensor" not in message:
+            raise
+        return transforms(to_pil_image(sample.cpu()))
+
+
+def apply_transforms_itemwise(image, transforms):
+    if not torch.is_tensor(image) or image.ndim <= 3:
+        return _apply_transform_sample(image, transforms)
+
+    transformed_items = [_apply_transform_sample(sample, transforms) for sample in image.cpu()]
+    if not transformed_items:
+        return image.new_empty((0,), dtype=torch.float32)
+    if not all(torch.is_tensor(item) for item in transformed_items):
+        transformed_items = [torch.as_tensor(item) for item in transformed_items]
+    return torch.stack(transformed_items, dim=0)
+
+
+def interp_mode_to_str(interp_mode) -> str:
+    if interp_mode is None:
+        return "bilinear"
+    name = str(interp_mode).upper()
+    if "BICUBIC" in name:
+        return "bicubic"
+    if "NEAREST" in name:
+        return "nearest"
+    return "bilinear"
+
+
+def resize_image_batch(image, size: tuple[int, int], *, mode: str = "bilinear"):
+    if tuple(int(dim) for dim in image.shape[-2:]) == size:
+        return image
+
+    align_corners = False if mode in ("bilinear", "bicubic") else None
+    kwargs = {"antialias": True} if mode in ("bilinear", "bicubic") else {}
+    return torch.nn.functional.interpolate(
+        image,
+        size=size,
+        mode=mode,
+        **({"align_corners": align_corners} if align_corners is not None else {}),
+        **kwargs,
+    )
+
+
+def apply_batch_transform_spec(image, spec: BatchTransformSpec):
+    if spec.resize_size is not None:
+        image = resize_image_batch(image, spec.resize_size, mode=spec.resize_interpolation)
+    if spec.center_crop_size is not None:
+        image = center_crop_batch(image, spec.center_crop_size)
+    if spec.mean is not None and spec.std is not None:
+        mean = torch.tensor(spec.mean, dtype=image.dtype, device=image.device).view(1, -1, 1, 1)
+        std = torch.tensor(spec.std, dtype=image.dtype, device=image.device).view(1, -1, 1, 1)
+        image = (image - mean) / std
+    return image
+
+
+def normalize_hw(value) -> tuple[int, int] | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return (int(value), int(value))
+    if isinstance(value, (tuple, list)):
+        if len(value) == 1:
+            return (int(value[0]), int(value[0]))
+        if len(value) >= 2:
+            return (int(value[0]), int(value[1]))
+        return None
+    if isinstance(value, dict):
+        if "height" in value and "width" in value:
+            return (int(value["height"]), int(value["width"]))
+        if "shortest_edge" in value:
+            edge = int(value["shortest_edge"])
+            return (edge, edge)
+    return None
+
+
+def center_crop_batch(image, size: tuple[int, int]):
+    target_h, target_w = size
+    height, width = int(image.shape[-2]), int(image.shape[-1])
+    crop_h = min(target_h, height)
+    crop_w = min(target_w, width)
+    top = max((height - crop_h) // 2, 0)
+    left = max((width - crop_w) // 2, 0)
+    return image[..., top : top + crop_h, left : left + crop_w]

--- a/slide2vec/runtime/sharding.py
+++ b/slide2vec/runtime/sharding.py
@@ -1,0 +1,34 @@
+"""The one work-splitting kernel every distributed extraction path shares.
+
+slide2vec fans a flat, ordered list of independent work units (dense ROIs, given-geometry
+images) across ``world_size`` ranks. There is exactly one rule for how that split is made,
+and it lives here so no path can grow a second one.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, TypeVar
+
+import numpy as np
+
+T = TypeVar("T")
+
+
+def plan_contiguous_shards(items: Sequence[T], world_size: int) -> list[list[T]]:
+    """Partition an ordered work list into ``world_size`` contiguous shards.
+
+    Contiguous :func:`numpy.array_split` over the index range: exactly ``world_size``
+    shards, balanced to within one item, deterministic, and an exact ordered partition of
+    the input (the union preserves order, the shards are pairwise disjoint). Contiguity is
+    what keeps a slide's ROIs together on the dense path — only slides straddling a shard
+    boundary are opened twice — and costs the given-image path nothing. Shards may be empty
+    when ``world_size`` exceeds the item count.
+
+    Every rank derives its own shard from the same ordered list, so no coordination,
+    assignment file, or collective is needed to agree on who owns what.
+    """
+    if world_size < 1:
+        raise ValueError(f"world_size must be at least 1, got {world_size}")
+    items = list(items)
+    index_shards = np.array_split(np.arange(len(items)), world_size)
+    return [[items[int(i)] for i in shard] for shard in index_shards]

--- a/tests/test_architecture_runtime_split.py
+++ b/tests/test_architecture_runtime_split.py
@@ -42,6 +42,7 @@ def test_internal_runtime_modules_stay_small():
         package_root / "hierarchical.py",
         package_root / "model_settings.py",
         package_root / "persistence.py",
+        package_root / "preprocessing.py",
         package_root / "progress_bridge.py",
         package_root / "registry.py",
         package_root / "serialization.py",

--- a/tests/test_dense_shard.py
+++ b/tests/test_dense_shard.py
@@ -1,13 +1,10 @@
-"""Tests for distributed dense sharding + the CPU encode/write loop (issue #217).
+"""Tests for the CPU dense encode/write loop (issue #217).
 
-Three layers, top two pure and CPU-testable (D12):
-
-1. ``plan_dense_shards`` — pure ROI-granularity partition of the slide-ordered flat
-   ROI list into ``world_size`` contiguous shards (balanced ±1, deterministic).
-2. ``run_dense_shard`` — the device-agnostic encode+write loop: read each ROI, encode
-   the dense grid (reusing ``iter_regions_dense``), and write ``<x>_<y>.pt`` +
-   ``<x>_<y>.meta.json`` per ROI. Tested on CPU with a fake WSI backend
-   (``_open_wsi_backend`` monkeypatch) + a random-weight encoder.
+``run_dense_shard`` is the device-agnostic encode+write loop: read each ROI, encode the
+dense grid (reusing ``iter_regions_dense``), and write ``<x>_<y>.pt`` +
+``<x>_<y>.meta.json`` per ROI. Tested on CPU with a fake WSI backend
+(``_open_wsi_backend`` monkeypatch) + a random-weight encoder. The ROI-granularity split
+itself is the shared ``plan_contiguous_shards`` (see ``test_sharding.py``).
 
 The real 4-rank equivalence check runs on CPU: world_size=1 vs 4 shards, same file
 set, grids within a per-grid cosine tolerance (docs/adr/0002).
@@ -28,11 +25,8 @@ from slide2vec.api import DenseOptions  # noqa: E402
 from slide2vec.artifacts import region_dense_paths, write_dense_region  # noqa: E402
 from slide2vec.data import tile_reader  # noqa: E402
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
-from slide2vec.runtime.dense_shard import (  # noqa: E402
-    RegionSpec,
-    plan_dense_shards,
-    run_dense_shard,
-)
+from slide2vec.runtime.dense_shard import RegionSpec, run_dense_shard  # noqa: E402
+from slide2vec.runtime.sharding import plan_contiguous_shards  # noqa: E402
 
 
 def _encoder(**kwargs) -> TimmTileEncoder:
@@ -115,65 +109,7 @@ def _spec(x, y, *, sample_id="s0", image_path="s0.tif", annotation=None,
 
 
 # --------------------------------------------------------------------------------------
-# Layer 1: plan_dense_shards (pure)
-# --------------------------------------------------------------------------------------
-
-
-def test_plan_dense_shards_partitions_exactly():
-    """Union of the shards == input, in order, with no ROI dropped or duplicated."""
-    regions = [_spec(i * 64, 0) for i in range(10)]
-    shards = plan_dense_shards(regions, 4)
-    assert len(shards) == 4
-    flat = [r for shard in shards for r in shard]
-    assert flat == regions  # order preserved, exact partition
-
-
-def test_plan_dense_shards_balanced_within_one():
-    """Shard sizes differ by at most one ROI (np.array_split balance)."""
-    regions = [_spec(i * 64, 0) for i in range(10)]
-    sizes = [len(shard) for shard in plan_dense_shards(regions, 4)]
-    assert sizes == [3, 3, 2, 2]
-    assert max(sizes) - min(sizes) <= 1
-
-
-def test_plan_dense_shards_is_contiguous_and_slide_ordered():
-    """Each shard is a contiguous slice, so a slide's ROIs stay together (few re-opens)."""
-    regions = [_spec(i * 64, 0) for i in range(10)]
-    shards = plan_dense_shards(regions, 3)
-    assert [[r.x for r in shard] for shard in shards] == [
-        [0, 64, 128, 192],
-        [256, 320, 384],
-        [448, 512, 576],
-    ]
-
-
-def test_plan_dense_shards_deterministic():
-    regions = [_spec(i * 64, 0) for i in range(7)]
-    assert [
-        [r.x for r in shard] for shard in plan_dense_shards(regions, 3)
-    ] == [[r.x for r in shard] for shard in plan_dense_shards(regions, 3)]
-
-
-def test_plan_dense_shards_world_size_one_returns_input_unchanged():
-    regions = [_spec(i * 64, 0) for i in range(5)]
-    shards = plan_dense_shards(regions, 1)
-    assert len(shards) == 1
-    assert shards[0] == regions
-
-
-def test_plan_dense_shards_allows_empty_shards_when_more_ranks_than_rois():
-    regions = [_spec(0, 0), _spec(64, 0)]
-    shards = plan_dense_shards(regions, 4)
-    assert [len(s) for s in shards] == [1, 1, 0, 0]
-
-
-def test_plan_dense_shards_rejects_non_positive_world_size():
-    with pytest.raises(ValueError):
-        plan_dense_shards([_spec(0, 0)], 0)
-
-
-# --------------------------------------------------------------------------------------
-# Layer 2: run_dense_shard (device-agnostic encode+write loop, CPU-tested)
+# run_dense_shard: the device-agnostic encode+write loop, CPU-tested
 # --------------------------------------------------------------------------------------
 
 
@@ -320,7 +256,7 @@ def test_multi_rank_matches_single_rank(fake_backend, tmp_path):
                     batch_size=3, device="cpu")
 
     multi_dir = tmp_path / "multi"
-    shards = plan_dense_shards(regions, 4)
+    shards = plan_contiguous_shards(regions, 4)
     for shard in shards:  # ranks run the identical loop over their contiguous shard
         run_dense_shard(shard, model=enc, out_dir=multi_dir, dense=_dense(),
                         batch_size=3, device="cpu")

--- a/tests/test_dense_stage.py
+++ b/tests/test_dense_stage.py
@@ -149,7 +149,8 @@ def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend,
     """``num_gpus>1`` launches ``slide2vec.distributed.dense_worker`` under torchrun, handing
     it the coordinates as an npz (D10b) — the parent itself encodes nothing. The fake torchrun
     stands in for the ranks (reconstruct specs → shard → encode) so collection sees N grids."""
-    from slide2vec.runtime.dense_shard import plan_dense_shards, run_dense_shard
+    from slide2vec.runtime.dense_shard import run_dense_shard
+    from slide2vec.runtime.sharding import plan_contiguous_shards
     from slide2vec.runtime.serialization import deserialize_dense_options
 
     caller_dir = tmp_path / "caller"
@@ -173,7 +174,7 @@ def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend,
         # Simulate the ranks: rebuild the flat specs, shard, encode each shard on CPU.
         specs = dense_stage.region_specs_from_request(request)
         dense = deserialize_dense_options(request["dense"])
-        for shard in plan_dense_shards(specs, num_gpus):
+        for shard in plan_contiguous_shards(specs, num_gpus):
             run_dense_shard(shard, model=rank_encoder, out_dir=Path(output_dir), dense=dense,
                             batch_size=2, device="cpu")
 

--- a/tests/test_dense_worker.py
+++ b/tests/test_dense_worker.py
@@ -92,7 +92,7 @@ def test_dense_worker_encodes_only_its_rank_shard(monkeypatch, tmp_path):
     request_path = tmp_path / "dense_request.json"
     request_path.write_text(json.dumps(request), encoding="utf-8")
 
-    # World of 2 ranks: plan_dense_shards([0,1,2,3], 2) => rank 1 owns ROIs [2, 3].
+    # World of 2 ranks: plan_contiguous_shards([0,1,2,3], 2) => rank 1 owns ROIs [2, 3].
     monkeypatch.setenv("RANK", "1")
     monkeypatch.setenv("WORLD_SIZE", "2")
     monkeypatch.setenv("LOCAL_RANK", "0")

--- a/tests/test_image_shard.py
+++ b/tests/test_image_shard.py
@@ -265,6 +265,23 @@ def test_multi_rank_matches_single_rank(tmp_path):
         torch.testing.assert_close(one, many)
 
 
+def test_run_image_shard_reencodes_when_the_output_format_changes(tmp_path):
+    """The sidecar name carries no format, so resume must check this run's payload too."""
+    encoder = _encoder()
+    specs = [_spec(tmp_path, "a", width=64, height=64)]
+    out_dir = tmp_path / "out"
+    run_image_shard(specs, loaded=_loaded(encoder), out_dir=out_dir, batch_size=1,
+                    output_precision="fp32", num_workers=0)
+
+    artifacts = run_image_shard(specs, loaded=_loaded(encoder), out_dir=out_dir, batch_size=1,
+                               output_precision="fp32", output_format="npz", num_workers=0)
+
+    assert artifacts[0].path.suffix == ".npz"
+    assert artifacts[0].path.exists()
+    payload = np.load(artifacts[0].path)["features"]
+    assert payload.shape == (encoder.encode_dim,)
+
+
 def test_payload_size_is_independent_of_batch_size(tmp_path):
     """Each artifact holds one vector, not a view onto its whole batch's storage."""
     encoder = _encoder()

--- a/tests/test_image_shard.py
+++ b/tests/test_image_shard.py
@@ -1,0 +1,296 @@
+"""Tests for the given-geometry image artifacts + the CPU encode/write loop (issue #234).
+
+Two layers, both CPU-testable:
+
+1. ``slide2vec.artifacts.write_image_embedding`` — one payload + one sidecar per image,
+   written atomically and sidecar-last, so the sidecar is an unambiguous done-marker.
+2. ``run_image_shard`` — the device-agnostic encode+write loop each rank runs over its
+   shard: decode each image, apply the encoder's shipped transform **itemwise** in the
+   loader workers, stack, encode, persist. Exercised here with a random-weight timm
+   encoder over real PNGs, including heterogeneously sized and non-square inputs.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+PIL = pytest.importorskip("PIL")
+
+from PIL import Image  # noqa: E402
+
+from slide2vec.api import ImageSpec  # noqa: E402
+from slide2vec.artifacts import (  # noqa: E402
+    image_embedding_paths,
+    write_image_embedding,
+)
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime.image_shard import run_image_shard  # noqa: E402
+from slide2vec.runtime.types import LoadedModel  # noqa: E402
+
+
+def _encoder() -> TimmTileEncoder:
+    return TimmTileEncoder("vit_tiny_patch16_224", pretrained=False, num_classes=0)
+
+
+def _loaded(encoder: TimmTileEncoder) -> LoadedModel:
+    """A ``LoadedModel`` under the Given contract: the encoder's shipped transform."""
+    return LoadedModel(
+        name="fake-encoder",
+        level="tile",
+        model=encoder,
+        transforms=encoder.get_transform(),
+        feature_dim=int(encoder.encode_dim),
+        device=torch.device("cpu"),
+    )
+
+
+def _write_image(path, *, width: int, height: int) -> None:
+    rng = np.random.default_rng(abs(hash((width, height, path.name))) % (2**32))
+    pixels = rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(pixels).save(path)
+
+
+def _spec(tmp_path, sample_id: str, *, width: int, height: int) -> ImageSpec:
+    path = tmp_path / "images" / f"{sample_id}.png"
+    _write_image(path, width=width, height=height)
+    return ImageSpec(sample_id=sample_id, image_path=str(path))
+
+
+# --------------------------------------------------------------------------------------
+# Layer 1: the artifact write (payload atomic, sidecar last)
+# --------------------------------------------------------------------------------------
+
+
+def test_image_embedding_paths_rejects_sample_id_paths(tmp_path):
+    with pytest.raises(ValueError, match="sample_id"):
+        image_embedding_paths(tmp_path, sample_id="/tmp/outside", output_format="pt")
+
+
+def test_image_embedding_paths_rejects_symlink_escape(tmp_path):
+    output_dir = tmp_path / "output"
+    embeddings_dir = output_dir / "image_embeddings"
+    outside_dir = tmp_path / "outside"
+    embeddings_dir.parent.mkdir(parents=True)
+    outside_dir.mkdir()
+    embeddings_dir.symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="output_dir"):
+        image_embedding_paths(output_dir, sample_id="image-1", output_format="pt")
+
+
+def test_write_image_embedding_does_not_publish_interrupted_sidecar(tmp_path, monkeypatch):
+    """A crashed sidecar write leaves the payload but no done-marker."""
+    from pathlib import Path
+
+    original_write_text = Path.write_text
+
+    def _interrupted_write(path, text, *, encoding):
+        original_write_text(path, text[:1], encoding=encoding)
+        raise OSError("simulated interrupted metadata write")
+
+    monkeypatch.setattr(Path, "write_text", _interrupted_write)
+
+    with pytest.raises(OSError, match="interrupted metadata write"):
+        write_image_embedding(
+            torch.zeros((4,)),
+            output_dir=tmp_path,
+            sample_id="image-1",
+            output_format="pt",
+            metadata={"feature_dim": 4},
+        )
+
+    payload_path, sidecar_path = image_embedding_paths(
+        tmp_path, sample_id="image-1", output_format="pt"
+    )
+    assert payload_path.exists()
+    assert not sidecar_path.exists()
+
+
+# --------------------------------------------------------------------------------------
+# Layer 2: run_image_shard (device-agnostic encode+write loop)
+# --------------------------------------------------------------------------------------
+
+
+def test_run_image_shard_embeds_heterogeneously_sized_images_in_one_run(tmp_path):
+    """BACH-sized 2048x1536 next to PCam-sized 96x96 next to a non-square input.
+
+    Given-geometry inputs cannot be stacked before preprocessing, so the shipped transform
+    runs itemwise and only the *transformed* items are stacked — which is what makes a
+    single batch over these three images possible at all.
+    """
+    encoder = _encoder()
+    specs = [
+        _spec(tmp_path, "bach", width=2048, height=1536),
+        _spec(tmp_path, "pcam", width=96, height=96),
+        _spec(tmp_path, "wide", width=300, height=150),
+    ]
+
+    artifacts = run_image_shard(
+        specs,
+        loaded=_loaded(encoder),
+        out_dir=tmp_path / "out",
+        batch_size=3,
+        output_precision="fp32",
+        num_workers=0,
+    )
+
+    assert [artifact.sample_id for artifact in artifacts] == ["bach", "pcam", "wide"]
+    embeddings_dir = tmp_path / "out" / "image_embeddings"
+    for artifact in artifacts:
+        assert artifact.path == (embeddings_dir / f"{artifact.sample_id}.pt").resolve()
+        assert artifact.metadata_path.exists()
+        assert artifact.feature_dim == encoder.encode_dim
+        payload = torch.load(artifact.path, weights_only=True)
+        assert tuple(payload.shape) == (encoder.encode_dim,)
+    assert list(embeddings_dir.glob("*.tmp*")) == []
+
+
+def test_run_image_shard_records_the_observed_encoder_input_size(tmp_path):
+    """The Given regime's obligation: record what the encoder actually saw."""
+    encoder = _encoder()
+    specs = [_spec(tmp_path, "wide", width=300, height=150)]
+
+    artifacts = run_image_shard(
+        specs,
+        loaded=_loaded(encoder),
+        out_dir=tmp_path / "out",
+        batch_size=1,
+        output_precision="fp32",
+        num_workers=0,
+    )
+
+    metadata = json.loads(artifacts[0].metadata_path.read_text())
+    assert metadata["encoder_input_regime"] == "given"
+    assert metadata["encoder_input_size_px"] == 224
+    assert metadata["artifact_type"] == "image_embeddings"
+    assert metadata["sample_id"] == "wide"
+    assert metadata["feature_dim"] == encoder.encode_dim
+    assert metadata["feature_dtype"] == "fp32"
+    assert metadata["image_path"] == str(specs[0].image_path)
+
+
+def test_run_image_shard_does_not_use_the_batched_transform_spec(tmp_path, monkeypatch):
+    """The batched spec is exclusive to the uniform-size declared paths."""
+    from slide2vec.runtime import batching, preprocessing
+
+    def _forbidden(transforms):
+        pytest.fail("the given-image path must preprocess itemwise")
+
+    # Patched both where it is defined and where the batched pooled path bound it, so the
+    # test cannot pass merely because one reference was missed.
+    monkeypatch.setattr(preprocessing, "build_batch_transform_spec", _forbidden)
+    monkeypatch.setattr(batching, "build_batch_transform_spec", _forbidden)
+    specs = [_spec(tmp_path, "a", width=128, height=64)]
+
+    run_image_shard(
+        specs,
+        loaded=_loaded(_encoder()),
+        out_dir=tmp_path / "out",
+        batch_size=2,
+        output_precision="fp32",
+        num_workers=0,
+    )
+
+
+def test_run_image_shard_skips_images_with_existing_sidecar(tmp_path):
+    """Resume: an image whose sidecar exists is not re-decoded or re-encoded."""
+    encoder = _encoder()
+    specs = [_spec(tmp_path, name, width=64, height=64) for name in ("a", "b", "c")]
+    out_dir = tmp_path / "out"
+
+    first = run_image_shard(
+        specs, loaded=_loaded(encoder), out_dir=out_dir, batch_size=2,
+        output_precision="fp32", num_workers=0,
+    )
+    payload_mtimes = {a.sample_id: a.path.stat().st_mtime_ns for a in first}
+
+    second = run_image_shard(
+        specs, loaded=_loaded(encoder), out_dir=out_dir, batch_size=2,
+        output_precision="fp32", num_workers=0,
+    )
+
+    assert [a.sample_id for a in second] == [a.sample_id for a in first]
+    assert {a.sample_id: a.path.stat().st_mtime_ns for a in second} == payload_mtimes
+
+
+def test_run_image_shard_reencodes_payload_missing_its_sidecar(tmp_path):
+    """Crash-safety: a payload with no sidecar is incomplete and is re-encoded."""
+    encoder = _encoder()
+    specs = [_spec(tmp_path, name, width=64, height=64) for name in ("a", "b")]
+    out_dir = tmp_path / "out"
+    run_image_shard(specs, loaded=_loaded(encoder), out_dir=out_dir, batch_size=2,
+                    output_precision="fp32", num_workers=0)
+
+    _, sidecar_path = image_embedding_paths(out_dir, sample_id="b", output_format="pt")
+    sidecar_path.unlink()
+
+    run_image_shard(specs, loaded=_loaded(encoder), out_dir=out_dir, batch_size=2,
+                    output_precision="fp32", num_workers=0)
+
+    assert sidecar_path.exists()
+
+
+def test_multi_rank_matches_single_rank(tmp_path):
+    """Sharding equivalence: 3 shards vs 1 → identical file set and identical payloads."""
+    from slide2vec.runtime.sharding import plan_contiguous_shards
+
+    encoder = _encoder()  # every rank loads the same checkpoint
+    specs = [_spec(tmp_path, f"image-{i}", width=64 + i, height=96) for i in range(7)]
+
+    single_dir = tmp_path / "single"
+    run_image_shard(specs, loaded=_loaded(encoder), out_dir=single_dir, batch_size=3,
+                    output_precision="fp32", num_workers=0)
+
+    multi_dir = tmp_path / "multi"
+    for shard in plan_contiguous_shards(specs, 3):
+        run_image_shard(shard, loaded=_loaded(encoder), out_dir=multi_dir, batch_size=3,
+                        output_precision="fp32", num_workers=0)
+
+    def _files(root):
+        base = root / "image_embeddings"
+        return {p.relative_to(base).as_posix() for p in base.rglob("*") if p.is_file()}
+
+    assert _files(single_dir) == _files(multi_dir)
+    for name in _files(single_dir):
+        if not name.endswith(".pt"):
+            continue
+        one = torch.load(single_dir / "image_embeddings" / name, weights_only=True)
+        many = torch.load(multi_dir / "image_embeddings" / name, weights_only=True)
+        torch.testing.assert_close(one, many)
+
+
+def test_payload_size_is_independent_of_batch_size(tmp_path):
+    """Each artifact holds one vector, not a view onto its whole batch's storage."""
+    encoder = _encoder()
+    specs = [_spec(tmp_path, f"image-{i}", width=64, height=64) for i in range(4)]
+
+    sizes = {}
+    for batch_size in (1, 4):
+        out_dir = tmp_path / f"out-{batch_size}"
+        artifacts = run_image_shard(
+            specs, loaded=_loaded(encoder), out_dir=out_dir, batch_size=batch_size,
+            output_precision="fp32", num_workers=0,
+        )
+        sizes[batch_size] = [artifact.path.stat().st_size for artifact in artifacts]
+
+    assert sizes[1] == sizes[4]
+
+
+def test_run_image_shard_honors_the_on_disk_feature_dtype(tmp_path):
+    artifacts = run_image_shard(
+        [_spec(tmp_path, "a", width=64, height=64)],
+        loaded=_loaded(_encoder()),
+        out_dir=tmp_path / "out",
+        batch_size=1,
+        output_precision="fp16",
+        num_workers=0,
+    )
+    payload = torch.load(artifacts[0].path, weights_only=True)
+    assert payload.dtype == torch.float16
+    assert json.loads(artifacts[0].metadata_path.read_text())["feature_dtype"] == "fp16"

--- a/tests/test_image_stage.py
+++ b/tests/test_image_stage.py
@@ -1,0 +1,306 @@
+"""Tests for the parent-side given-image orchestration (issue #234).
+
+``embed_images`` normalizes the caller's images, resume-filters them, then either runs the
+encode/write loop in-process (``num_gpus=1``) or fans it out over torchrun ranks
+(``num_gpus>1``) — reusing the same distributed machinery the dense path uses. These tests
+run on CPU with a random-weight encoder; the torchrun launch is captured rather than executed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+PIL = pytest.importorskip("PIL")
+
+from PIL import Image  # noqa: E402
+
+from slide2vec.api import ExecutionOptions, ImageSpec  # noqa: E402
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime import image_stage  # noqa: E402
+from slide2vec.runtime.types import LoadedModel  # noqa: E402
+
+
+def _encoder() -> TimmTileEncoder:
+    return TimmTileEncoder("vit_tiny_patch16_224", pretrained=False, num_classes=0)
+
+
+def _loaded(encoder: TimmTileEncoder) -> LoadedModel:
+    return LoadedModel(
+        name="fake-encoder",
+        level="tile",
+        model=encoder,
+        transforms=encoder.get_transform(),
+        feature_dim=int(encoder.encode_dim),
+        device=torch.device("cpu"),
+    )
+
+
+class _FakeModel:
+    """Minimal ``Model`` stand-in exposing what the in-process image path reads.
+
+    ``_load_backend`` refuses to hand out a backend until the Given encoder-input contract
+    has been declared, mirroring the real ``Model``.
+    """
+
+    def __init__(self, encoder) -> None:
+        self._loaded = _loaded(encoder)
+        self.name = "fake-encoder"
+        self._output_variant = None
+        self._requested_device = "cpu"
+        self.allow_non_recommended_settings = False
+        self.declared_given = False
+
+    def _declare_given_encoder_input(self, *, emit_run_info):
+        self.declared_given = True
+
+    def _load_backend(self):
+        assert self.declared_given, "the image path must declare Given before it loads"
+        return self._loaded
+
+
+def _images(tmp_path, names, *, width=64, height=64) -> list[ImageSpec]:
+    specs = []
+    for name in names:
+        path = tmp_path / "images" / f"{name}.png"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        rng = np.random.default_rng(abs(hash(name)) % (2**32))
+        pixels = rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+        Image.fromarray(pixels).save(path)
+        specs.append(ImageSpec(sample_id=name, image_path=path))
+    return specs
+
+
+def test_embed_images_num_gpus_one_runs_in_process(tmp_path, monkeypatch):
+    """``num_gpus=1`` encodes in-process — no torchrun subprocess — and writes every image."""
+    monkeypatch.setattr(
+        image_stage, "run_torchrun_worker",
+        lambda **kwargs: pytest.fail("num_gpus=1 must not launch torchrun"),
+    )
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+
+    artifacts = image_stage.embed_images(model, _images(tmp_path, ["a", "b", "c"]), execution=execution)
+
+    assert [artifact.sample_id for artifact in artifacts] == ["a", "b", "c"]
+    assert model.declared_given
+    embeddings_dir = tmp_path / "out" / "image_embeddings"
+    assert sorted(p.name for p in embeddings_dir.glob("*.pt")) == ["a.pt", "b.pt", "c.pt"]
+    for artifact in artifacts:
+        assert artifact.metadata_path.exists()
+
+
+def test_embed_images_num_gpus_gt_one_launches_image_worker(tmp_path, monkeypatch):
+    """``num_gpus>1`` launches ``slide2vec.distributed.image_worker`` under torchrun; the
+    parent itself encodes nothing and collects the artifacts back off disk."""
+    from slide2vec.runtime.image_shard import run_image_shard
+    from slide2vec.runtime.sharding import plan_contiguous_shards
+
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    monkeypatch.chdir(caller_dir)
+    captured: dict = {}
+    rank_loaded = _loaded(_encoder())  # every rank loads the same checkpoint
+
+    def _fake_run(*, module, num_gpus, output_dir, request_path, **kwargs):
+        request = json.loads(Path(request_path).read_text())
+        captured.update(module=module, num_gpus=num_gpus, output_dir=output_dir, request=request)
+        specs = image_stage.image_specs_from_request(request)
+        for shard in plan_contiguous_shards(specs, num_gpus):
+            run_image_shard(shard, loaded=rank_loaded, out_dir=Path(output_dir), batch_size=2,
+                            output_precision="fp32", num_workers=0)
+
+    monkeypatch.setattr(image_stage, "run_torchrun_worker", _fake_run)
+    monkeypatch.setattr(image_stage, "validate_multi_gpu_execution", lambda *a, **k: None)
+    monkeypatch.setattr(
+        image_stage, "_run_images_in_process",
+        lambda *a, **k: pytest.fail("num_gpus>1 must not encode in-process"),
+    )
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=Path("output"), num_gpus=3, precision="fp32")
+
+    artifacts = image_stage.embed_images(model, _images(tmp_path, ["a", "b", "c"]), execution=execution)
+
+    assert captured["module"] == "slide2vec.distributed.image_worker"
+    assert captured["num_gpus"] == 3
+    expected_output_dir = (caller_dir / "output").resolve()
+    assert Path(captured["output_dir"]) == expected_output_dir
+    assert captured["request"]["execution"]["output_dir"] == str(expected_output_dir)
+    assert [image["sample_id"] for image in captured["request"]["images"]] == ["a", "b", "c"]
+    assert all(Path(image["image_path"]).is_absolute() for image in captured["request"]["images"])
+    assert len(artifacts) == 3
+    assert (expected_output_dir / "image_embeddings" / "a.pt").exists()
+
+
+def test_embed_images_resume_skips_existing_and_logs(tmp_path, caplog):
+    """Resume: images already on disk are filtered before dispatch; the skip count is logged."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    first = _images(tmp_path, ["a", "b"])
+    image_stage.embed_images(model, first, execution=execution)
+    written_at = {spec.sample_id: (tmp_path / "out" / "image_embeddings" / f"{spec.sample_id}.pt").stat().st_mtime_ns
+                  for spec in first}
+
+    with caplog.at_level("INFO", logger="slide2vec.runtime.image_stage"):
+        artifacts = image_stage.embed_images(model, _images(tmp_path, ["a", "b", "c"]), execution=execution)
+
+    assert len(artifacts) == 3
+    assert "2/3 images already on disk, encoding 1" in caplog.text
+    for sample_id, mtime in written_at.items():
+        payload = tmp_path / "out" / "image_embeddings" / f"{sample_id}.pt"
+        assert payload.stat().st_mtime_ns == mtime  # untouched
+
+
+def test_embed_images_all_present_does_not_dispatch(tmp_path, monkeypatch):
+    """A fully-resumed run encodes nothing yet still returns every artifact."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    specs = _images(tmp_path, ["a", "b"])
+    image_stage.embed_images(model, specs, execution=execution)
+
+    monkeypatch.setattr(image_stage, "_run_images_in_process",
+                        lambda *a, **k: pytest.fail("nothing to encode"))
+    monkeypatch.setattr(image_stage, "run_torchrun_worker",
+                        lambda **k: pytest.fail("nothing to encode"))
+    assert len(image_stage.embed_images(model, specs, execution=execution)) == 2
+
+
+def test_embed_images_rejects_duplicate_sample_ids(tmp_path):
+    """Two images sharing a sample id would silently overwrite one another's artifact."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    specs = _images(tmp_path, ["a"])
+    duplicated = [*specs, ImageSpec(sample_id="a", image_path=tmp_path / "images" / "a.png")]
+
+    with pytest.raises(ValueError, match="duplicate sample_id"):
+        image_stage.embed_images(model, duplicated, execution=execution)
+
+
+def test_embed_images_requires_at_least_one_image(tmp_path):
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    with pytest.raises(ValueError, match="At least one image"):
+        image_stage.embed_images(model, [], execution=execution)
+
+
+def test_image_specs_round_trip_through_request(tmp_path):
+    """The request rebuilds the exact spec list the parent sharded (the worker's inverse)."""
+    specs = [
+        ImageSpec(sample_id="a", image_path="/data/a.png"),
+        ImageSpec(sample_id="b", image_path="/data/nested/b.tif"),
+    ]
+    request = image_stage.build_image_worker_request(specs)
+    assert image_stage.image_specs_from_request(request) == specs
+
+
+def test_model_embed_images_delegates_and_requires_output_dir(monkeypatch, tmp_path):
+    """The public API coerces execution, requires an output dir, and delegates to the stage."""
+    import slide2vec.runtime.image_stage as stage_mod
+    from slide2vec.api import Model
+
+    seen: dict = {}
+
+    def _fake_stage(model, images, *, execution):
+        seen.update(model=model, images=images, execution=execution)
+        return ["artifact"]
+
+    monkeypatch.setattr(stage_mod, "embed_images", _fake_stage)
+    model = Model(name="virchow2")  # constructing a Model does not load weights
+    specs = [ImageSpec(sample_id="a", image_path=tmp_path / "a.png")]
+
+    with pytest.raises(ValueError):
+        model.embed_images(specs, execution=ExecutionOptions(num_gpus=1))
+
+    result = model.embed_images(specs, execution=ExecutionOptions(output_dir=tmp_path, num_gpus=1))
+    assert result == ["artifact"]
+    assert seen["model"] is model
+    assert seen["execution"].output_dir == tmp_path
+
+
+def test_declaring_given_selects_the_shipped_transform(monkeypatch):
+    """The path states Given explicitly — the contract's own mechanism, not an absent one."""
+    import slide2vec.inference as inference
+    from slide2vec.api import Model
+
+    class _StandInEncoder:
+        shipped = object()
+
+        def __init__(self, *, output_variant=None, allow_non_recommended_settings=False):
+            self.device = torch.device("cpu")
+            self.encode_dim = 4
+            self.patch_size = (16, 16)
+
+        def get_transform(self):
+            return self.shipped
+
+        def to(self, device):
+            return self
+
+    monkeypatch.setattr(inference.encoder_registry, "require", lambda name: _StandInEncoder)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    model = Model.from_preset("gigapath", device="cpu")
+
+    with pytest.raises(ValueError, match="No encoder-input contract"):
+        model._load_backend()
+
+    model._declare_given_encoder_input(emit_run_info=False)
+
+    assert model._encoder_input.regime == "given"
+    assert model._encoder_input.plan is None
+    assert model._load_backend().transforms is _StandInEncoder.shipped
+
+
+def test_embed_images_is_exported_from_the_package():
+    import slide2vec
+
+    assert "ImageSpec" in slide2vec.__all__
+    assert "ImageEmbeddingArtifact" in slide2vec.__all__
+    assert hasattr(slide2vec.Model, "embed_images")
+
+
+def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
+    """The torchrun entry is near logic-free: env rank → shared shard planner → shard loop."""
+    import slide2vec.api as api
+    from slide2vec.distributed import image_worker
+    from slide2vec.runtime.serialization import serialize_execution
+
+    specs = _images(tmp_path, ["a", "b", "c", "d"])
+    loaded = _loaded(_encoder())
+    declared: list = []
+
+    monkeypatch.setattr(
+        api.Model, "from_preset",
+        classmethod(lambda cls, name, **kwargs: SimpleNamespace(
+            _declare_given_encoder_input=lambda *, emit_run_info: declared.append(True),
+            _load_backend=lambda: (declared and loaded) or pytest.fail("must declare first"),
+        )),
+    )
+
+    request = {
+        "model": {"name": "fake", "output_variant": None, "allow_non_recommended_settings": False},
+        "execution": serialize_execution(
+            ExecutionOptions(output_dir=tmp_path / "out", num_gpus=2, precision="fp32", batch_size=2)
+        ),
+        "output_dir": str(tmp_path / "out"),
+        "progress_events_path": None,
+        **image_stage.build_image_worker_request(specs),
+    }
+    request_path = tmp_path / "image_request.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+
+    rc = image_worker.main(["--output-dir", str(tmp_path / "out"), "--request-path", str(request_path)])
+
+    assert rc == 0
+    # World of 2 ranks: plan_contiguous_shards([a,b,c,d], 2) => rank 1 owns [c, d].
+    embeddings_dir = tmp_path / "out" / "image_embeddings"
+    assert sorted(p.name for p in embeddings_dir.glob("*.pt")) == ["c.pt", "d.pt"]

--- a/tests/test_pooled_encoder_input.py
+++ b/tests/test_pooled_encoder_input.py
@@ -115,7 +115,7 @@ def test_permitted_variable_plan_preserves_exact_geometry_with_normalization_onl
 
 
 def test_batch_transform_parser_accepts_scaled_float32_to_dtype():
-    from slide2vec.runtime.batching import build_batch_transform_spec
+    from slide2vec.runtime.preprocessing import build_batch_transform_spec
 
     transforms = v2.Compose(
         [v2.ToImage(), v2.ToDtype(torch.float32, scale=True)]
@@ -125,7 +125,7 @@ def test_batch_transform_parser_accepts_scaled_float32_to_dtype():
 
 
 def test_batch_transform_parser_rejects_other_to_dtype_semantics():
-    from slide2vec.runtime.batching import build_batch_transform_spec
+    from slide2vec.runtime.preprocessing import build_batch_transform_spec
 
     unscaled = v2.Compose(
         [v2.ToImage(), v2.ToDtype(torch.float32, scale=False)]

--- a/tests/test_runtime_batching.py
+++ b/tests/test_runtime_batching.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import torch
 from torchvision.transforms import functional as tvF
 
-from slide2vec.runtime.batching import apply_transforms_itemwise
+from slide2vec.runtime.preprocessing import apply_transforms_itemwise
 
 
 class ConvertToRgbAndBack:

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,0 +1,58 @@
+"""The shared contiguous work split every distributed extraction path rides on.
+
+``plan_contiguous_shards`` is pure and generic: it partitions an ordered work list —
+dense ROIs (issue #217) or given-geometry images (issue #234) — into ``world_size``
+contiguous shards. Every rank derives its own shard from the same list, so these
+properties (exact partition, order preserved, balanced to ±1, deterministic) are what
+guarantee no unit is dropped, duplicated, or encoded twice.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from slide2vec.runtime.sharding import plan_contiguous_shards
+
+
+def test_partitions_exactly():
+    """Union of the shards == input, in order, with nothing dropped or duplicated."""
+    items = list(range(10))
+    shards = plan_contiguous_shards(items, 4)
+    assert len(shards) == 4
+    assert [item for shard in shards for item in shard] == items
+
+
+def test_balanced_within_one():
+    sizes = [len(shard) for shard in plan_contiguous_shards(list(range(10)), 4)]
+    assert sizes == [3, 3, 2, 2]
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_shards_are_contiguous_slices():
+    """Contiguity keeps neighbouring units (e.g. one slide's ROIs) on the same rank."""
+    assert plan_contiguous_shards(list(range(10)), 3) == [
+        [0, 1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+    ]
+
+
+def test_deterministic():
+    items = list(range(7))
+    assert plan_contiguous_shards(items, 3) == plan_contiguous_shards(items, 3)
+
+
+def test_world_size_one_returns_input_unchanged():
+    items = ["a", "b", "c"]
+    shards = plan_contiguous_shards(items, 1)
+    assert len(shards) == 1
+    assert shards[0] == items
+
+
+def test_allows_empty_shards_when_more_ranks_than_items():
+    assert [len(shard) for shard in plan_contiguous_shards(["a", "b"], 4)] == [1, 1, 0, 0]
+
+
+def test_rejects_non_positive_world_size():
+    with pytest.raises(ValueError, match="world_size"):
+        plan_contiguous_shards(["a"], 0)


### PR DESCRIPTION
Closes #234

## What

`Model.embed_images(images, *, execution)` — the Given-geometry counterpart of the declared pooled and dense paths. A list of `ImageSpec(sample_id, image_path)` in, one `ImageEmbeddingArtifact` per image out, sharded across visible GPUs, resume-aware, payload written atomically with the sidecar last as the done-marker.

```python
from slide2vec import ExecutionOptions, ImageSpec, Model

artifacts = Model.from_preset("virchow2").embed_images(
    [ImageSpec(sample_id="bach-001", image_path="/data/bach/001.tif")],
    execution=ExecutionOptions(output_dir="outputs/bach", num_gpus=2),
)
```

Artifacts land in `image_embeddings/<sample_id>.pt` + `<sample_id>.meta.json` (documented in `docs/output-layout.rst`; API in `docs/api.rst`).

## Why

Consumers holding pre-cropped tile images (BACH, CRC, Gleason, BreakHis, MHIST, PCam) had no public entry point, reached in through `slide2vec.inference.load_model`, and rebuilt the surrounding engine themselves — including a second implementation of multi-GPU sharding with atomic writes, tested against nothing.

So the point of this change is reuse, not addition. What is new is the given-image work unit; everything structural is shared:

- **Sharding** — `plan_dense_shards` was lifted out of `runtime/dense_shard.py` into `runtime/sharding.py` as `plan_contiguous_shards`, and both paths now call the one implementation. No second splitter.
- **Distribution** — `runtime/distributed`'s `run_torchrun_worker`, coordination dir and progress-event tail, unchanged. The two torchrun workers' identical preamble (rank from env, model from request, progress reporter) is now `distributed/worker_entry.py`, shared by `dense_worker` and the new `image_worker`.
- **Forward pass** — `batching.run_forward_pass` was split into an `iter_forward_batches` generator plus the accumulating wrapper. The pooled routes still gather a whole slide; the image path consumes the same generator and persists write-through per batch, because its work unit is the individual image and a killed rank should resume at image granularity.
- **Artifact write** — `artifacts.write_atomically` (extracted from the existing metadata writer) now backs both the dense grid payload and the new image payload.

## Preprocessing is itemwise

Given inputs are heterogeneously sized (2048×1536 beside 96×96) and cannot be stacked into one `(B, 3, H, W)` uint8 tensor before resizing, so `build_batch_transform_spec` is structurally inapplicable and is not used on this path (a test fails if it is touched). The encoder's shipped transform runs per item in the loader workers and only the transformed items are stacked. That batched-vs-itemwise distinction now has its own module, `runtime/preprocessing.py`, carved out of `batching.py` — which the forward-loop split had pushed past the 500-line architecture guard.

## Contract

The path declares `EncoderInputContract.given()` explicitly via `Model._declare_given_encoder_input`, in the parent and again on every rank, and records the observed encoder input size in each sidecar (`encoder_input_regime`, `encoder_input_size_px`) as provenance rather than validating it against a request.

## Tests

`tests/test_image_shard.py`, `tests/test_image_stage.py`, `tests/test_sharding.py` — heterogeneous sizes and a non-square input in one run, resume (including a payload missing its sidecar, and an `output_format` switch), multi-rank == single-rank equivalence, the torchrun worker encoding only its own shard, and a payload-size check that would catch saving a batch view instead of one vector.

`python -m pytest tests -m 'not heavy'` → 603 passed. Heavy tests whose weights are cached locally (`-k "phikon or lunit"`) → 3 passed; CI runs the full set.
