### PR TITLE
Add a public dense-grid API for pre-cropped images

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -275,24 +275,80 @@ the same read / pad / window path.
 Variable encoder input for dense runs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A dense run states a *supervision* geometry — the ROI ``target_size`` the token
-grid registers to, plus an optional ``window_size`` — not an encoder input.
-``Model.embed_regions_dense`` derives the **effective encoder input** from it,
-i.e. the geometry of the tensor handed to ``encode_tiles_dense``:
+A dense run states a *supervision* geometry — the ``target_size`` the token grid
+registers to, plus an optional ``window_size`` — not an encoder input.
+``Model.embed_regions_dense`` and ``Model.embed_images_dense`` derive the
+**effective encoder input** from it, i.e. the geometry of the tensor handed to
+``encode_tiles_dense``:
 
-- whole-tile (``window_size=None``): the ROI padded up to the patch multiple;
+- whole-tile (``window_size=None``): the ROI or image padded up to the patch
+  multiple;
 - sliding: the ``window_size`` rounded to the patch multiple and clamped to that
   padded extent.
 
 That size then goes through the same check as a pooled
 ``requested_tile_size_px``: when it differs from the encoder's registered input
-size, the encoder must declare ``supports_variable_input_size=True``, and its
+size (in either dimension — a non-square image geometry is checked per axis, not
+rejected for not being square), the encoder must declare ``supports_variable_input_size=True``, and its
 ``variable_input_model_kwargs`` (e.g. ``dynamic_img_size=True``) are applied at
 construction. Whole-tile dense at a non-native size on a fixed-input encoder
 (e.g. ``phikon``) therefore fails before any region is read, instead of feeding
 the backbone a size it cannot accept; sliding at the native window passes the
 check trivially. Callers never pass ``dynamic_img_size`` — it is derived from the
 declared geometry plus the registry metadata.
+
+Dense Grids from Images
+-----------------------
+
+When the supervision arrives as image/mask pairs rather than as slides —
+segmentation and detection datasets, exported ROI sets —
+:meth:`Model.embed_images_dense` is the image-sourced counterpart of
+``embed_regions_dense``: the image *is* the region, so there is no slide, no
+coordinate and no spacing→level plan.
+
+.. code-block:: python
+
+   from slide2vec import DenseImageOptions, ExecutionOptions, ImageSpec, Model
+
+   model = Model.from_preset("virchow2")
+   artifacts = model.embed_images_dense(
+       [
+           ImageSpec(sample_id="ocelot-001", image_path="/data/ocelot/001.jpg"),
+           ImageSpec(sample_id="ocelot-002", image_path="/data/ocelot/002.jpg"),
+       ],
+       dense=DenseImageOptions(target_size=1024, window_size=224),
+       execution=ExecutionOptions(output_dir="outputs/ocelot", num_gpus=2),
+   )
+
+   print(artifacts[0].path)        # outputs/ocelot/dense_image_embeddings/ocelot-001.pt
+   print(artifacts[0].grid_shape)  # (74, 74) for a 1024px image on a 14px patch encoder
+
+Everything after the pixels arrive is shared with the ROI path: the same
+geometry resolution, the same bottom/right padding up to the patch multiple, the
+same whole-image-vs-sliding encode and raised-cosine blending, and the same
+``feature_kind`` choice between the patch-token grid and the CLS-attention grid.
+The run splits its images across all visible GPUs (``num_gpus=1`` encodes
+in-process) and is resume-aware — an image whose ``.meta.json`` sidecar already
+exists is skipped — so an interrupted run is restarted by re-issuing the call.
+
+**target_size is a declaration, not a resize.** Dense extraction encodes through
+the encoder's normalization-only transform, so it never rescales: every image
+must already be exactly ``target_size`` (a non-square ``(height, width)`` pair is
+accepted), and one that is not raises naming the images. Declaring the geometry
+up front is what lets the *effective* encoder input — the padded image, or one
+patch-aligned window of it — be validated, and the encoder's variable-input
+constructor settings resolved, before a single image is decoded (see
+`Variable encoder input for dense runs`_). A dataset whose images differ in size
+is therefore several runs, one per geometry — which is also the only way their
+grids could be batched downstream.
+
+.. autoclass:: slide2vec.DenseImageOptions
+   :members:
+   :undoc-members:
+
+.. autoclass:: slide2vec.DenseImageArtifact
+   :members:
+   :undoc-members:
 
 Dense Attention Map Extraction
 ------------------------------

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -100,9 +100,10 @@ Shapes by artifact type:
    * - ``patient_embeddings``
      - ``(D,)``
 
-Dense tile grids are not currently written by :class:`~slide2vec.Pipeline` or
-the CLI. They are exposed through the low-level tile encoder API as
-``encode_tiles_dense(...)``; see :doc:`api` for usage.
+Dense grids are not written by :class:`~slide2vec.Pipeline` or the CLI. They are
+produced by :meth:`~slide2vec.Model.embed_regions_dense` (slide ROIs) and
+:meth:`~slide2vec.Model.embed_images_dense` (pre-cropped images), and exposed at
+the encoder level as ``encode_tiles_dense(...)``; see :doc:`api` for usage.
 
 
 Embedding Meta Files
@@ -230,6 +231,60 @@ resumable at image granularity across GPUs.
 saw, after its shipped transform ran on that image. In the Given regime it is
 recorded, never validated: the caller supplied pixels it never requested, so
 there is no request to check it against.
+
+
+Dense Image Grids
+-----------------
+
+:meth:`~slide2vec.Model.embed_images_dense` (see :doc:`api`) writes the dense
+counterpart of that layout — one flat directory, one grid payload plus one
+geometry sidecar per input image:
+
+.. code-block:: text
+
+   <output_dir>/
+   └── dense_image_embeddings/
+       ├── <sample_id>.pt          ← Tensor of shape (d, grid_h, grid_w)
+       └── <sample_id>.meta.json
+
+As with every dense artifact the sidecar is written **last**, after the payload
+has been published atomically, so a payload without its sidecar unambiguously
+means an interrupted image and resume treats the sidecar as the done-marker.
+
+**dense_image_embeddings**
+
+.. code-block:: text
+
+   {
+     "sample_id": "ocelot-001",
+     "artifact_type": "dense_image_embeddings",
+     "encoder_name": "virchow2",
+     "encoder_level": "tile",
+     "encoder_input_regime": "declared",
+     "image_path": "/data/ocelot/001.jpg",
+     "format": "pt",
+     "dtype": "float32",
+     "feature_dim": 1280,
+     "grid_shape": [74, 74],
+     "target_size": [1024, 1024],
+     "patch_size": [14, 14],
+     "encoded_size": [1036, 1036],
+     "pad": [12, 12],
+     "pad_mode": "reflect",
+     "image_pad_value": null,
+     "window_size": 224,
+     "overlap": 0.0,
+     "feature_kind": "patch_features",
+     "attention_blocks": [-1],
+     "attention_include_registers": false,
+   }
+
+The geometry fields are the whole extraction contract: ``target_size`` is what
+the caller declared, ``encoded_size`` is that padded up to the encoder's patch
+multiple, ``pad`` is the bottom/right padding applied, and ``grid_shape`` is the
+token grid the payload holds. ``encoder_input_regime`` is ``"declared"`` — unlike
+a pooled image embedding, this run *stated* its geometry and it was validated
+before any image was read.
 
 
 Coordinate Files

--- a/slide2vec/__init__.py
+++ b/slide2vec/__init__.py
@@ -1,4 +1,5 @@
 from slide2vec.api import (
+    DenseImageOptions,
     DenseOptions,
     EmbeddedPatient,
     EmbeddedSlide,
@@ -12,6 +13,7 @@ from slide2vec.api import (
     list_models,
 )
 from slide2vec.artifacts import (
+    DenseImageArtifact,
     DenseRegionArtifact,
     HierarchicalEmbeddingArtifact,
     ImageEmbeddingArtifact,
@@ -28,6 +30,7 @@ __all__ = [
     "Pipeline",
     "PreprocessingConfig",
     "DenseOptions",
+    "DenseImageOptions",
     "SlideRegions",
     "ImageSpec",
     "ExecutionOptions",
@@ -38,6 +41,7 @@ __all__ = [
     "HierarchicalEmbeddingArtifact",
     "TileEmbeddingArtifact",
     "DenseRegionArtifact",
+    "DenseImageArtifact",
     "ImageEmbeddingArtifact",
     "__version__",
 ]

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -11,6 +11,7 @@ import torch
 from hs2p import SlideSpec
 
 from slide2vec.artifacts import (
+    DenseImageArtifact,
     DenseRegionArtifact,
     HierarchicalEmbeddingArtifact,
     ImageEmbeddingArtifact,
@@ -357,6 +358,48 @@ class DenseOptions:
     #: Together with ``target_size`` this fixes the *effective encoder input* — the geometry
     #: handed to ``encode_tiles_dense`` — from which the encoder's variable-input constructor
     #: settings are derived; hence no ``dynamic_img_size`` knob here.
+    window_size: int | None = None
+    #: Fractional window overlap in ``[0, 1)`` for the sliding path (ignored when
+    #: ``window_size is None``).
+    overlap: float = 0.0
+    #: ``"patch_features"`` (the patch-token grid) or ``"cls_attention"`` (CLS/register
+    #: self-attention grid).
+    feature_kind: str = "patch_features"
+    #: Transformer blocks whose CLS attention is read (``cls_attention`` only).
+    attention_blocks: tuple[int, ...] = (-1,)
+    #: Include register-token query rows as extra attention channels (``cls_attention`` only).
+    attention_include_registers: bool = False
+
+
+@dataclass(frozen=True, kw_only=True)
+class DenseImageOptions:
+    """Dense ``(d, gh, gw)`` grid extraction over pre-cropped images (issue #235).
+
+    :class:`DenseOptions` minus everything that only a slide has: there is no spacing, no
+    tolerance and no reading backend here, because the image *is* the region — it is read
+    from disk at the size it was written. What remains is the same supervision geometry and
+    the same dense encode knobs, so a run migrating from ROIs to image/mask pairs keeps its
+    recipe.
+
+    ``target_size`` is a **declaration**, not a resize: the dense transform is
+    normalization-only, so every image must already be exactly this size and one that is not
+    is an error rather than a silent rescale. Declaring it up front is what lets the
+    effective encoder input be validated (and the encoder's variable-input constructor
+    settings resolved) before a single image is decoded. A run whose images are not all the
+    same size is therefore several runs, one per geometry — which is also the only way their
+    grids could be batched downstream.
+    """
+
+    #: Supervision geometry in pixels the dense grid registers to: a square side length, or
+    #: an explicit ``(height, width)`` for non-square images.
+    target_size: int | tuple[int, int]
+    #: Padding mode used to pad the image up to the encoder's patch multiple.
+    #: One of ``"reflect"`` / ``"replicate"`` / ``"constant"`` / ``"zero"``.
+    pad_mode: str = "reflect"
+    #: Constant fill value for ``pad_mode in {"constant", "zero"}`` (ignored otherwise).
+    image_pad_value: float | None = None
+    #: Encoder field-of-view chunk fed through the backbone per forward. ``None`` (default)
+    #: is one whole-image forward; a smaller value slides the encoder and blends token grids.
     window_size: int | None = None
     #: Fractional window overlap in ``[0, 1)`` for the sliding path (ignored when
     #: ``window_size is None``).
@@ -720,6 +763,43 @@ class Model:
         with _auto_progress_reporting(output_dir=resolved.output_dir):
             return embed_regions_dense(self, regions, dense=dense, execution=resolved)
 
+    def embed_images_dense(
+        self,
+        images: "Sequence[ImageSpec]",
+        *,
+        dense: "DenseImageOptions",
+        execution: ExecutionOptions | None = None,
+    ) -> list[DenseImageArtifact]:
+        """Extract + persist a dense ``(d, gh, gw)`` grid per caller-supplied image.
+
+        The image-sourced counterpart of :meth:`embed_regions_dense`, for consumers whose
+        supervision arrives as image/mask pairs rather than as slides (segmentation,
+        detection): each :class:`ImageSpec` is decoded, run through the encoder's
+        **normalization-only** transform, padded up to the encoder's patch multiple, encoded
+        — whole-image, or by sliding the encoder's native field and blending the token grids
+        — and written to ``dense_image_embeddings/<sample_id>.pt`` plus a geometry sidecar.
+        The run splits its images across all visible GPUs (``execution.num_gpus``);
+        ``num_gpus=1`` encodes fully in-process. Resume is automatic — images whose sidecar
+        already exists are skipped. Returns one
+        :class:`~slide2vec.artifacts.DenseImageArtifact` per input image, in input order.
+
+        It differs from :meth:`embed_regions_dense` in exactly one respect: there is no
+        slide, no coordinate and no spacing→level plan, because the image *is* the region.
+        Everything else is shared, including the effective encoder input — the padded image
+        for a whole-image run, one patch-aligned window for a sliding one — which is declared
+        before any image is decoded, so a geometry the encoder cannot accept raises here
+        rather than on a torchrun rank's first forward pass.
+
+        ``dense.target_size`` is a declaration, not a resize request: dense extraction never
+        rescales, so every image must already be that size (a non-square ``(h, w)`` is fine).
+        """
+        from slide2vec.runtime.dense_image_stage import embed_images_dense
+
+        resolved = _coerce_execution_options(execution, model=self)
+        _require_output_dir_for_persistence(resolved, method_name="Model.embed_images_dense(...)")
+        with _auto_progress_reporting(output_dir=resolved.output_dir):
+            return embed_images_dense(self, images, dense=dense, execution=resolved)
+
     def embed_images(
         self,
         images: "Sequence[ImageSpec]",
@@ -795,15 +875,19 @@ class Model:
     ) -> EncoderInputContract:
         """Declare the dense encoder input geometry this run requested, or raise.
 
-        Dense states a supervision geometry (ROI ``target_size``, optional ``window_size``)
+        Dense states a supervision geometry (``target_size``, optional ``window_size``)
         rather than an encoder input; the contract derives the tensor the backbone will
         actually see and validates it exactly as the pooled path's is validated. Like the
         pooled declaration this is idempotent, so each layer that reaches the encoder — the
         parent stage and every torchrun rank — declares for itself.
+
+        *dense* is a :class:`DenseOptions` (ROIs on a slide) or a :class:`DenseImageOptions`
+        (pre-cropped images); only the supervision geometry is read here, and the two state
+        it the same way.
         """
         contract = EncoderInputContract.declared_dense(
             self.name,
-            target_size_px=int(dense.target_size),
+            target_size_px=dense.target_size,
             window_size=None if dense.window_size is None else int(dense.window_size),
         )
         self._encoder_input = contract
@@ -811,11 +895,11 @@ class Model:
         if emit_run_info and plan.requires_variable_model_input:
             logging.getLogger("slide2vec").info(
                 "Dense encoder input for '%s': native %dpx, effective encoder input %s "
-                "(target_size=%dpx, window_size=%s); enabling variable input size via %s.",
+                "(target_size=%s, window_size=%s); enabling variable input size via %s.",
                 self.name,
                 plan.preset_input_size_px,
                 format_input_size(plan.effective_encoder_input_size_px),
-                plan.target_size_px,
+                format_input_size(plan.target_size_px),
                 plan.window_size_px,
                 plan.model_construction_kwargs or "no constructor setting",
             )

--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -96,6 +96,27 @@ class DenseRegionArtifact:
 
 
 @dataclass(frozen=True, kw_only=True)
+class DenseImageArtifact:
+    """One persisted dense grid over a pre-cropped image: payload + geometry sidecar.
+
+    The unit of :meth:`slide2vec.api.Model.embed_images_dense`. Same payload as a
+    :class:`DenseRegionArtifact` — a ``(d, gh, gw)`` grid plus the geometry that produced it
+    — but named the way a given-geometry input can be named: by the caller's ``sample_id``
+    alone, since there is no slide, no level-0 coordinate and no sampled class.
+    """
+
+    sample_id: str
+    path: Path
+    metadata_path: Path
+    feature_dim: int
+    grid_shape: tuple[int, int]
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return load_metadata(self.metadata_path)
+
+
+@dataclass(frozen=True, kw_only=True)
 class ImageEmbeddingArtifact:
     """One persisted given-geometry image embedding: the ``(D,)`` payload + its sidecar.
 
@@ -279,6 +300,23 @@ def region_dense_paths(
     return slide_dir / f"{stem}.pt", slide_dir / f"{stem}.meta.json"
 
 
+def _write_dense_grid(
+    grid, *, payload_path: Path, metadata_path: Path, metadata: dict[str, Any]
+) -> np.ndarray:
+    """Publish one dense grid: payload atomically, then the sidecar. Returns the array.
+
+    The single write order every dense artifact follows (D6), whatever named it: payload to
+    a temp file in the destination directory → ``os.replace`` into place (atomic on the same
+    filesystem) → then the ``.meta.json`` sidecar. A payload present without its sidecar
+    therefore unambiguously means an incomplete unit, and resume treats the sidecar as the
+    done-marker.
+    """
+    grid_array = _ensure_array(grid)
+    write_atomically(payload_path, lambda tmp_path: torch.save(_ensure_tensor(grid), tmp_path))
+    _write_metadata(metadata_path, metadata)
+    return grid_array
+
+
 def write_dense_region(
     grid,
     *,
@@ -289,19 +327,14 @@ def write_dense_region(
     y: int,
     metadata: dict[str, Any],
 ) -> DenseRegionArtifact:
-    """Persist one ``(d, gh, gw)`` grid + its geometry sidecar, atomically and sidecar-last.
-
-    Write order (D6): payload to a temp file in the destination directory → ``os.replace``
-    into ``<x>_<y>.pt`` (atomic on the same filesystem) → then the ``<x>_<y>.meta.json``
-    sidecar. A payload present without its sidecar therefore unambiguously means an
-    incomplete ROI, and resume treats the sidecar as the done-marker.
-    """
+    """Persist one ROI's ``(d, gh, gw)`` grid + its geometry sidecar (see
+    :func:`_write_dense_grid` for the write order this shares with every dense artifact)."""
     payload_path, metadata_path = region_dense_paths(
         output_dir, sample_id=sample_id, annotation=annotation, x=x, y=y
     )
-    grid_array = _ensure_array(grid)
-    write_atomically(payload_path, lambda tmp_path: torch.save(_ensure_tensor(grid), tmp_path))
-    _write_metadata(metadata_path, metadata)
+    grid_array = _write_dense_grid(
+        grid, payload_path=payload_path, metadata_path=metadata_path, metadata=metadata
+    )
     return DenseRegionArtifact(
         sample_id=sample_id,
         x=int(x),
@@ -311,6 +344,47 @@ def write_dense_region(
         feature_dim=int(grid_array.shape[0]),
         grid_shape=(int(grid_array.shape[1]), int(grid_array.shape[2])),
         annotation=annotation,
+    )
+
+
+def dense_image_paths(output_dir: str | Path, *, sample_id: str) -> tuple[Path, Path]:
+    """``(payload_path, sidecar_path)`` for one image's dense grid.
+
+    ``dense_image_embeddings/<sample_id>.pt`` plus ``<sample_id>.meta.json``. Flat, like the
+    pooled image layout and unlike the per-slide dense one: a pre-cropped image has no slide
+    directory to live under and no ``(x, y)`` to be named by, so the caller's ``sample_id``
+    is the whole identity and the resume check needs nothing else.
+    """
+    output_root = Path(output_dir).expanduser().resolve()
+    sample_component = _validate_path_component(sample_id, field="sample_id")
+    embeddings_dir = (output_root / "dense_image_embeddings").resolve()
+    if not embeddings_dir.is_relative_to(output_root):
+        raise ValueError("Dense image artifact path must stay within output_dir")
+    return (
+        embeddings_dir / f"{sample_component}.pt",
+        embeddings_dir / f"{sample_component}.meta.json",
+    )
+
+
+def write_dense_image(
+    grid,
+    *,
+    output_dir: str | Path,
+    sample_id: str,
+    metadata: dict[str, Any],
+) -> DenseImageArtifact:
+    """Persist one image's ``(d, gh, gw)`` grid + its geometry sidecar (see
+    :func:`_write_dense_grid` for the write order this shares with every dense artifact)."""
+    payload_path, metadata_path = dense_image_paths(output_dir, sample_id=sample_id)
+    grid_array = _write_dense_grid(
+        grid, payload_path=payload_path, metadata_path=metadata_path, metadata=metadata
+    )
+    return DenseImageArtifact(
+        sample_id=sample_id,
+        path=payload_path,
+        metadata_path=metadata_path,
+        feature_dim=int(grid_array.shape[0]),
+        grid_shape=(int(grid_array.shape[1]), int(grid_array.shape[2])),
     )
 
 

--- a/slide2vec/data/dataset.py
+++ b/slide2vec/data/dataset.py
@@ -74,6 +74,47 @@ class StackedImageCollator:
         )
 
 
+class DeclaredGeometryCollator:
+    """Stack images, refusing any that is not the geometry its run declared.
+
+    The dense counterpart of :class:`StackedImageCollator`. Dense extraction encodes through
+    a normalization-only transform, so it never rescales: the run's ``target_size`` is a
+    contract each image must already satisfy, and an image of another size would otherwise
+    produce a grid registered to the wrong extent.
+
+    Checking here — per item, *before* the stack — is what lets the error name the offending
+    images: a mixed-size batch would otherwise fail inside ``torch.stack`` with a list of
+    shapes and no way back to a sample id. The ids are supplied as plain data (indexed by
+    dataset position), so this stays free of any runtime dependency.
+    """
+
+    def __init__(self, *, sample_ids, target_size: tuple[int, int]) -> None:
+        self.sample_ids = [str(sample_id) for sample_id in sample_ids]
+        self.target_size = (int(target_size[0]), int(target_size[1]))
+
+    def __call__(self, batch):
+        worker_start = time.perf_counter()
+        indices = [int(index) for index, _ in batch]
+        images = [torch.as_tensor(image) for _, image in batch]
+        offenders = {
+            self.sample_ids[index]: tuple(int(size) for size in image.shape[-2:])
+            for index, image in zip(indices, images)
+            if tuple(int(size) for size in image.shape[-2:]) != self.target_size
+        }
+        if offenders:
+            raise ValueError(
+                f"images {offenders} are not the declared target_size {self.target_size} "
+                "after the normalization-only dense transform (sample_id: observed (h, w)). "
+                "Dense extraction never resizes: state the images' own geometry, or split "
+                "the run so each geometry is declared once."
+            )
+        return (
+            torch.as_tensor(indices, dtype=torch.long),
+            torch.stack(images, dim=0),
+            {"worker_batch_ms": (time.perf_counter() - worker_start) * 1000.0},
+        )
+
+
 class BatchTileCollator:
     def __init__(
         self,

--- a/slide2vec/distributed/dense_image_worker.py
+++ b/slide2vec/distributed/dense_image_worker.py
@@ -1,0 +1,78 @@
+"""torchrun entry point for distributed dense-over-images extraction (issue #235).
+
+One of these runs per GPU under ``torch.distributed.run``. Like its two siblings it is near
+logic-free: the rank, the model and the progress wiring come from
+:mod:`slide2vec.distributed.worker_entry`; what is left here is this path's own — declare the
+dense encoder-input contract, rebuild the image list the parent staged, then call the two
+CPU-tested layers: :func:`~slide2vec.runtime.sharding.plan_contiguous_shards` to pick this
+rank's contiguous shard and
+:func:`~slide2vec.runtime.dense_image_shard.run_dense_image_shard` to encode + persist it.
+"""
+
+import json
+from pathlib import Path
+
+from slide2vec.distributed.worker_entry import (
+    model_from_request,
+    resolve_worker_rank,
+    worker_args_parser,
+    worker_progress_context,
+)
+
+
+def get_args_parser(add_help: bool = True):
+    return worker_args_parser("slide2vec.distributed.dense_image_worker", add_help=add_help)
+
+
+def main(argv=None) -> int:
+    from slide2vec.progress import emit_progress
+    from slide2vec.runtime.dense_image_shard import run_dense_image_shard
+    from slide2vec.runtime.dense_stage import resolve_output_torch_dtype
+    from slide2vec.runtime.image_specs import image_specs_from_request
+    from slide2vec.runtime.serialization import (
+        deserialize_dense_image_options,
+        deserialize_execution,
+    )
+    from slide2vec.runtime.sharding import plan_contiguous_shards
+
+    args = get_args_parser(add_help=True).parse_args(argv)
+    request = json.loads(Path(args.request_path).read_text(encoding="utf-8"))
+    output_dir = Path(args.output_dir)
+    rank = resolve_worker_rank()
+
+    specs = image_specs_from_request(request)
+    shard = plan_contiguous_shards(specs, rank.world_size)[rank.global_rank]
+    if not shard:
+        return 0
+
+    model = model_from_request(request, rank=rank)
+    dense = deserialize_dense_image_options(request["dense"])
+    execution = deserialize_execution(request["execution"])
+    # Each rank declares the dense contract for itself rather than trusting the parent to
+    # have done it (the declaration is idempotent): that is what supplies the variable-input
+    # constructor settings this geometry implies. emit_run_info=False — the run-info line is
+    # logged once by the parent, not once per rank.
+    model._declare_dense_encoder_input(dense, emit_run_info=False)
+    loaded = model._load_backend()
+
+    with worker_progress_context(request, rank=rank):
+        def _on_batch(count: int) -> None:
+            emit_progress("dense.images.batch.finished", rank=rank.global_rank, images=int(count))
+
+        run_dense_image_shard(
+            shard,
+            loaded=loaded,
+            out_dir=output_dir,
+            dense=dense,
+            batch_size=int(execution.batch_size),
+            precision=execution.precision,
+            output_dtype=resolve_output_torch_dtype(execution),
+            num_workers=execution.resolved_num_workers_per_gpu(),
+            prefetch_factor=int(execution.prefetch_factor),
+            on_batch=_on_batch,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slide2vec/distributed/image_worker.py
+++ b/slide2vec/distributed/image_worker.py
@@ -27,7 +27,7 @@ def get_args_parser(add_help: bool = True):
 def main(argv=None) -> int:
     from slide2vec.progress import emit_progress
     from slide2vec.runtime.image_shard import run_image_shard
-    from slide2vec.runtime.image_stage import image_specs_from_request
+    from slide2vec.runtime.image_specs import image_specs_from_request
     from slide2vec.runtime.model_settings import resolve_output_precision
     from slide2vec.runtime.serialization import deserialize_execution
     from slide2vec.runtime.sharding import plan_contiguous_shards

--- a/slide2vec/runtime/dense_encoder_input.py
+++ b/slide2vec/runtime/dense_encoder_input.py
@@ -25,7 +25,10 @@ from slide2vec.encoders.registry import (
     resolve_patch_size,
     resolve_preprocessing_requirements,
 )
-from slide2vec.runtime.effective_encoder_input import EffectiveEncoderInput
+from slide2vec.runtime.effective_encoder_input import (
+    EffectiveEncoderInput,
+    format_input_size,
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -35,8 +38,10 @@ class DenseEncoderInputPlan:
     encoder_name: str
     tile_encoder_name: str
     preset_input_size_px: int
-    #: Supervision tile side length the dense grid registers to (``DenseOptions.target_size``).
-    target_size_px: int
+    #: Supervision geometry ``(h, w)`` the dense grid registers to (the run's
+    #: ``target_size``). Always a pair: a slide ROI is square by construction, a pre-cropped
+    #: image need not be, and both are checked per dimension against the patch geometry.
+    target_size_px: tuple[int, int]
     #: Requested encoder field-of-view chunk; ``None`` is one whole-tile forward.
     window_size_px: int | None
     #: ``target_size_px`` padded up to the patch multiple — the padded tensor's geometry.
@@ -51,7 +56,7 @@ class DenseEncoderInputPlan:
         cls,
         encoder_name: str,
         *,
-        target_size_px: int,
+        target_size_px: int | tuple[int, int],
         window_size: int | None,
     ) -> "DenseEncoderInputPlan":
         # Imported here, not at module scope: the dense geometry kernels live next to the
@@ -67,14 +72,14 @@ class DenseEncoderInputPlan:
         # resolved *before* the encoder is constructed. ``load_model`` asserts the two
         # agree, so the geometry resolved here is the geometry that gets encoded.
         patch_size = resolve_patch_size(tile_encoder_name)
-        geometry = compute_dense_geometry(
-            target_size=int(target_size_px), patch_size=patch_size
-        )
+        # The geometry kernel normalizes an int side length into an (h, w) pair, so the plan
+        # states one shape whether the caller asked for a square or a rectangle.
+        geometry = compute_dense_geometry(target_size=target_size_px, patch_size=patch_size)
         if window_size is None:
             effective_size = geometry.encoded_size
             origin = (
-                f"dense whole-tile target_size={int(target_size_px)} padded to the "
-                "patch multiple"
+                f"dense whole-tile target_size={format_input_size(geometry.target_size)} "
+                "padded to the patch multiple"
             )
         else:
             # Ask the sliding kernel itself, so the declaration cannot drift from the
@@ -95,7 +100,7 @@ class DenseEncoderInputPlan:
             encoder_name=encoder_name,
             tile_encoder_name=tile_encoder_name,
             preset_input_size_px=effective.preset_input_size_px,
-            target_size_px=int(target_size_px),
+            target_size_px=geometry.target_size,
             window_size_px=None if window_size is None else int(window_size),
             encoded_size_px=geometry.encoded_size,
             effective_encoder_input_size_px=effective.size_px,

--- a/slide2vec/runtime/dense_image_shard.py
+++ b/slide2vec/runtime/dense_image_shard.py
@@ -1,0 +1,221 @@
+"""The device-agnostic dense encode/write loop for pre-cropped images (issue #235).
+
+The image-sourced sibling of :mod:`slide2vec.runtime.dense_shard`: each rank runs this
+identical loop over its own contiguous shard (cut by the shared
+:func:`~slide2vec.runtime.sharding.plan_contiguous_shards`) and writes one ``(d, gh, gw)``
+grid plus one geometry sidecar per image. It is device-agnostic and ``RANK``-free, so the
+very same code path runs in-process for ``num_gpus=1`` and on every torchrun rank — and is
+exercised on CPU.
+
+It differs from the ROI loop in exactly one respect: there is no slide, no coordinate and no
+spacing→level plan, because the image *is* the region and is read from disk. Everything
+after the pixels arrive — geometry, padding, whole-tile vs sliding encode, output dtype — is
+the shared :class:`~slide2vec.runtime.dense_regions.DenseGridEncoder`, so this module owns no
+padding, batching or blending logic of its own.
+
+Decoding and the normalization-only transform run **itemwise in the loader workers** (the
+same seam :mod:`slide2vec.runtime.image_shard` uses), and only the transformed items are
+stacked. Unlike the pooled given-image path that is not because the geometry is
+heterogeneous — here it is declared, uniform, and checked — but because decoding a directory
+of large images is the bottleneck this path has, and it parallelizes per item.
+
+Writes are atomic and sidecar-last (see :func:`~slide2vec.artifacts.write_dense_image`), so a
+payload without a sidecar unambiguously means an interrupted image and resume trusts the
+sidecar as the done-marker.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, Callable, Sequence
+
+import torch
+
+from slide2vec.artifacts import (
+    DenseImageArtifact,
+    dense_image_paths,
+    load_metadata,
+    write_dense_image,
+)
+from slide2vec.data.dataset import ImageFileDataset, StackedImageCollator
+from slide2vec.runtime.batching import dataloader_kwargs, uses_cuda_runtime
+from slide2vec.runtime.dense_regions import DenseGridEncoder
+from slide2vec.runtime.preprocessing import apply_transforms_itemwise
+from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from slide2vec.api import DenseImageOptions, ImageSpec
+    from slide2vec.runtime.types import LoadedModel
+
+
+def dense_image_needs_encode(out_dir, spec: "ImageSpec") -> bool:
+    """Resume predicate: an image needs encoding iff its sidecar is absent.
+
+    The sidecar is written last, so its presence is the done-marker; a ``.pt`` with no
+    sidecar is a crashed write and is re-encoded. Unlike the pooled image path there is no
+    format to disambiguate — a dense grid is always a ``.pt`` payload.
+    """
+    _, sidecar_path = dense_image_paths(out_dir, sample_id=spec.sample_id)
+    return not sidecar_path.exists()
+
+
+def dense_image_artifact_from_disk(out_dir, spec: "ImageSpec") -> DenseImageArtifact:
+    """Rebuild the artifact record for an image already on disk (skipped, or final collect)."""
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id=spec.sample_id)
+    metadata = load_metadata(sidecar_path)
+    grid_shape = tuple(int(value) for value in metadata["grid_shape"])
+    return DenseImageArtifact(
+        sample_id=spec.sample_id,
+        path=payload_path,
+        metadata_path=sidecar_path,
+        feature_dim=int(metadata["feature_dim"]),
+        grid_shape=(grid_shape[0], grid_shape[1]),
+    )
+
+
+def dense_image_metadata(
+    spec: "ImageSpec",
+    *,
+    loaded: "LoadedModel",
+    dense: "DenseImageOptions",
+    encoder: DenseGridEncoder,
+    grid: "np.ndarray",
+) -> dict:
+    """The geometry sidecar: what was encoded, and with which dense recipe.
+
+    The dense ROI sidecar's fields minus the slide's read plan (there is none) plus the
+    encoder identity, which a given-geometry artifact cannot recover from a coordinate.
+    ``encoder_input_regime`` is ``"declared"``: unlike the pooled given-image path this run
+    *did* state its geometry — ``target_size`` — and it was validated before any image was
+    read, so the sidecar records a request that was honored rather than a size observed.
+    """
+    geometry = encoder.geometry
+    return {
+        "artifact_type": "dense_image_embeddings",
+        "sample_id": spec.sample_id,
+        "image_path": str(spec.image_path),
+        "format": "pt",
+        "dtype": str(grid.dtype),
+        "feature_dim": int(grid.shape[0]),
+        "grid_shape": [int(geometry.grid_shape[0]), int(geometry.grid_shape[1])],
+        "target_size": [int(geometry.target_size[0]), int(geometry.target_size[1])],
+        "patch_size": [int(geometry.patch_size[0]), int(geometry.patch_size[1])],
+        "encoded_size": [int(geometry.encoded_size[0]), int(geometry.encoded_size[1])],
+        "pad": [int(geometry.pad[0]), int(geometry.pad[1])],
+        "encoder_name": loaded.name,
+        "encoder_level": loaded.level,
+        "encoder_input_regime": "declared",
+        "pad_mode": dense.pad_mode,
+        "image_pad_value": dense.image_pad_value,
+        "window_size": dense.window_size,
+        "overlap": float(dense.overlap),
+        "feature_kind": dense.feature_kind,
+        "attention_blocks": [int(block) for block in dense.attention_blocks],
+        "attention_include_registers": bool(dense.attention_include_registers),
+    }
+
+
+def _check_declared_geometry(batch: torch.Tensor, encoder: DenseGridEncoder, specs) -> None:
+    """Fail loudly when the decoded images are not the geometry the run declared.
+
+    ``target_size`` is a declaration, not a resize request: the dense transform is
+    normalization-only, so an image of another size would silently produce a grid registered
+    to the wrong extent. The check names the images in the batch, because the fix is either
+    to correct ``target_size`` or to split the run per geometry.
+    """
+    observed = (int(batch.shape[-2]), int(batch.shape[-1]))
+    if observed == encoder.geometry.target_size:
+        return
+    raise ValueError(
+        f"images {[spec.sample_id for spec in specs]} decode to {observed} after the "
+        f"normalization-only dense transform, but the declared target_size is "
+        f"{encoder.geometry.target_size}. Dense extraction never resizes: state the images' "
+        "own geometry, or split the run so each geometry is declared once."
+    )
+
+
+def run_dense_image_shard(
+    images: Sequence["ImageSpec"],
+    *,
+    loaded: "LoadedModel",
+    out_dir,
+    dense: "DenseImageOptions",
+    batch_size: int,
+    precision: str = "fp32",
+    output_dtype: "torch.dtype | None" = None,
+    num_workers: int = 4,
+    prefetch_factor: int = 4,
+    on_batch: Callable[[int], None] | None = None,
+) -> list[DenseImageArtifact]:
+    """Encode + persist one shard's images, one grid payload + one sidecar per image.
+
+    Skips any image already complete on disk (see :func:`dense_image_needs_encode`), encodes
+    the rest through the shared dense kernel, and writes each batch's grids before the next
+    batch is encoded — which is what makes a killed rank resumable at image granularity
+    rather than losing the whole shard. Returns one
+    :class:`~slide2vec.artifacts.DenseImageArtifact` per input image in input order — freshly
+    written or (when skipped) read back off disk. ``on_batch`` is invoked with each encoded
+    batch's image count for per-batch progress.
+    """
+    images = list(images)
+    pending = [spec for spec in images if dense_image_needs_encode(out_dir, spec)]
+    written: dict[str, DenseImageArtifact] = {}
+    if pending:
+        encoder = DenseGridEncoder.resolve(
+            loaded.model,
+            target_size=dense.target_size,
+            pad_mode=dense.pad_mode,
+            image_pad_value=dense.image_pad_value,
+            window_size=dense.window_size,
+            overlap=dense.overlap,
+            feature_kind=dense.feature_kind,
+            attention_blocks=dense.attention_blocks,
+            attention_include_registers=dense.attention_include_registers,
+            precision=precision,
+            output_dtype=output_dtype,
+        )
+        dataset = ImageFileDataset(
+            [spec.image_path for spec in pending],
+            # partial, not a closure: the recipe is pickled into the loader workers. Only
+            # the transform crosses — never the encoder — so a worker carries no weights.
+            partial(apply_transforms_itemwise, transforms=encoder.dense_transform),
+        )
+        dataloader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=max(1, int(batch_size)),
+            shuffle=False,
+            collate_fn=StackedImageCollator(),
+            **dataloader_kwargs(
+                device=loaded.device,
+                num_workers=int(num_workers),
+                prefetch_factor=int(prefetch_factor),
+            ),
+        )
+        with torch.inference_mode(), slide_encode_autocast_ctx(loaded.device, precision):
+            for indices, batch, _timing in dataloader:
+                batch_specs = [pending[int(index)] for index in indices.tolist()]
+                _check_declared_geometry(batch, encoder, batch_specs)
+                batch = encoder.pad_to_encoded(
+                    batch.to(loaded.device, non_blocking=uses_cuda_runtime(loaded.device))
+                )
+                grids = encoder.encode_batch(batch)
+                for spec, grid in zip(batch_specs, grids):
+                    # ``copy`` before persisting: each grid is a view onto the whole batch's
+                    # array, and torch.save serializes a tensor's *storage*, so saving the
+                    # view unclipped would write the entire batch into every artifact.
+                    written[spec.sample_id] = write_dense_image(
+                        grid.copy(),
+                        output_dir=out_dir,
+                        sample_id=spec.sample_id,
+                        metadata=dense_image_metadata(
+                            spec, loaded=loaded, dense=dense, encoder=encoder, grid=grid
+                        ),
+                    )
+                if on_batch is not None:
+                    on_batch(int(indices.numel()))
+    return [
+        written.get(spec.sample_id) or dense_image_artifact_from_disk(out_dir, spec)
+        for spec in images
+    ]

--- a/slide2vec/runtime/dense_image_shard.py
+++ b/slide2vec/runtime/dense_image_shard.py
@@ -16,7 +16,8 @@ padding, batching or blending logic of its own.
 Decoding and the normalization-only transform run **itemwise in the loader workers** (the
 same seam :mod:`slide2vec.runtime.image_shard` uses), and only the transformed items are
 stacked. Unlike the pooled given-image path that is not because the geometry is
-heterogeneous — here it is declared, uniform, and checked — but because decoding a directory
+heterogeneous — here it is declared, uniform, and checked while stacking (see
+:class:`~slide2vec.data.dataset.DeclaredGeometryCollator`) — but because decoding a directory
 of large images is the bottleneck this path has, and it parallelizes per item.
 
 Writes are atomic and sidecar-last (see :func:`~slide2vec.artifacts.write_dense_image`), so a
@@ -37,7 +38,7 @@ from slide2vec.artifacts import (
     load_metadata,
     write_dense_image,
 )
-from slide2vec.data.dataset import ImageFileDataset, StackedImageCollator
+from slide2vec.data.dataset import DeclaredGeometryCollator, ImageFileDataset
 from slide2vec.runtime.batching import dataloader_kwargs, uses_cuda_runtime
 from slide2vec.runtime.dense_regions import DenseGridEncoder
 from slide2vec.runtime.preprocessing import apply_transforms_itemwise
@@ -117,25 +118,6 @@ def dense_image_metadata(
     }
 
 
-def _check_declared_geometry(batch: torch.Tensor, encoder: DenseGridEncoder, specs) -> None:
-    """Fail loudly when the decoded images are not the geometry the run declared.
-
-    ``target_size`` is a declaration, not a resize request: the dense transform is
-    normalization-only, so an image of another size would silently produce a grid registered
-    to the wrong extent. The check names the images in the batch, because the fix is either
-    to correct ``target_size`` or to split the run per geometry.
-    """
-    observed = (int(batch.shape[-2]), int(batch.shape[-1]))
-    if observed == encoder.geometry.target_size:
-        return
-    raise ValueError(
-        f"images {[spec.sample_id for spec in specs]} decode to {observed} after the "
-        f"normalization-only dense transform, but the declared target_size is "
-        f"{encoder.geometry.target_size}. Dense extraction never resizes: state the images' "
-        "own geometry, or split the run so each geometry is declared once."
-    )
-
-
 def run_dense_image_shard(
     images: Sequence["ImageSpec"],
     *,
@@ -166,6 +148,7 @@ def run_dense_image_shard(
         encoder = DenseGridEncoder.resolve(
             loaded.model,
             target_size=dense.target_size,
+            target_size_origin="the declared target_size",
             pad_mode=dense.pad_mode,
             image_pad_value=dense.image_pad_value,
             window_size=dense.window_size,
@@ -186,7 +169,13 @@ def run_dense_image_shard(
             dataset,
             batch_size=max(1, int(batch_size)),
             shuffle=False,
-            collate_fn=StackedImageCollator(),
+            # The collator, not this loop, holds the declared geometry: an off-size image has
+            # to be refused *before* the stack, which would otherwise fail first with a list
+            # of shapes and no way back to the sample id that has to be fixed.
+            collate_fn=DeclaredGeometryCollator(
+                sample_ids=[spec.sample_id for spec in pending],
+                target_size=encoder.geometry.target_size,
+            ),
             **dataloader_kwargs(
                 device=loaded.device,
                 num_workers=int(num_workers),
@@ -196,7 +185,6 @@ def run_dense_image_shard(
         with torch.inference_mode(), slide_encode_autocast_ctx(loaded.device, precision):
             for indices, batch, _timing in dataloader:
                 batch_specs = [pending[int(index)] for index in indices.tolist()]
-                _check_declared_geometry(batch, encoder, batch_specs)
                 batch = encoder.pad_to_encoded(
                     batch.to(loaded.device, non_blocking=uses_cuda_runtime(loaded.device))
                 )

--- a/slide2vec/runtime/dense_image_stage.py
+++ b/slide2vec/runtime/dense_image_stage.py
@@ -1,0 +1,151 @@
+"""Parent-side orchestration for dense grids over pre-cropped images (issue #235).
+
+The glue that turns a caller's :class:`~slide2vec.api.ImageSpec` list into persisted dense
+grids. Deliberately the same five steps as the dense ROI stage, over the same machinery,
+because only the source of the pixels differs:
+
+1. **declare** the dense encoder-input contract — the caller states a supervision
+   ``target_size``, and the geometry the backbone will actually see (the padded image, or one
+   patch-aligned window of it) is validated here, before anything is decoded or launched;
+2. **normalize** the images into resolved, uniquely-named specs;
+3. **resume-filter** them — drop images whose sidecar already exists, before sharding, so no
+   rank draws an all-done shard and idles; the skip count is logged;
+4. **dispatch**: ``num_gpus=1`` runs
+   :func:`~slide2vec.runtime.dense_image_shard.run_dense_image_shard` fully in-process (no
+   torchrun); ``num_gpus>1`` writes a JSON request and launches
+   :mod:`slide2vec.distributed.dense_image_worker` under torchrun, which splits the list with
+   the shared :func:`~slide2vec.runtime.sharding.plan_contiguous_shards`;
+5. **collect** one :class:`~slide2vec.artifacts.DenseImageArtifact` per input image by reading
+   the sidecars back off disk (the ranks already persisted them; nobody gathers grids).
+
+There is no step here for the one thing the ROI stage does extra — resolving each slide's
+spacing→level read plan — because there is no slide: the image *is* the region.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from subprocess import Popen
+from typing import Sequence
+
+from slide2vec.artifacts import DenseImageArtifact
+from slide2vec.progress import emit_progress
+from slide2vec.runtime.dense_image_shard import (
+    dense_image_artifact_from_disk,
+    dense_image_needs_encode,
+    run_dense_image_shard,
+)
+from slide2vec.runtime.dense_stage import resolve_output_torch_dtype
+from slide2vec.runtime.distributed import (
+    distributed_coordination_dir,
+    reset_progress_event_logs,
+    run_torchrun_worker,
+)
+from slide2vec.runtime.distributed_stage import validate_multi_gpu_execution
+from slide2vec.runtime.image_specs import build_image_specs_request, normalize_image_specs
+from slide2vec.runtime.serialization import (
+    serialize_dense_image_options,
+    serialize_execution,
+    serialize_model,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def partition_dense_images_by_resume(specs: Sequence, out_dir) -> tuple[list, int]:
+    """Split the spec list into (needs-encode, already-on-disk-count) by sidecar existence."""
+    remaining = [spec for spec in specs if dense_image_needs_encode(out_dir, spec)]
+    return remaining, len(specs) - len(remaining)
+
+
+def embed_images_dense(model, images: Sequence, *, dense, execution) -> list[DenseImageArtifact]:
+    """Extract + persist a dense grid per caller-supplied image across all visible GPUs."""
+    # Declare the effective encoder input before anything is decoded, sharded or launched: an
+    # image geometry this encoder cannot accept must fail here, not on the first forward pass
+    # of a torchrun rank. Idempotent, so every rank re-declares for itself (dense_image_worker).
+    model._declare_dense_encoder_input(dense, emit_run_info=True)
+    specs = normalize_image_specs(
+        images,
+        method_name="embed_images_dense()",
+        artifact_location="dense_image_embeddings/<sample_id>",
+    )
+    out_dir = Path(execution.output_dir).expanduser().resolve()
+    execution = execution.with_output_dir(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
+    remaining, skipped = partition_dense_images_by_resume(specs, out_dir)
+    if skipped:
+        logger.info(
+            "resume: %s/%s images already on disk, encoding %s",
+            f"{skipped:,}", f"{len(specs):,}", f"{len(remaining):,}",
+        )
+    emit_progress(
+        "dense.images.started",
+        total=len(specs),
+        skipped=skipped,
+        encoding=len(remaining),
+        num_gpus=execution.num_gpus,
+    )
+    if remaining:
+        if execution.num_gpus == 1:
+            _run_dense_images_in_process(
+                model, remaining, dense=dense, execution=execution, out_dir=out_dir
+            )
+        else:
+            _run_dense_images_distributed(
+                model, remaining, dense=dense, execution=execution, out_dir=out_dir
+            )
+    emit_progress("dense.images.finished", total=len(specs))
+    return [dense_image_artifact_from_disk(out_dir, spec) for spec in specs]
+
+
+def _run_dense_images_in_process(model, specs, *, dense, execution, out_dir) -> None:
+    # Loaded under the dense contract declared by embed_images_dense, which supplies the
+    # variable-input constructor settings this geometry needs. The shard builds its own
+    # normalization-only transform — the same one this contract selects.
+    loaded = model._load_backend()
+
+    def _on_batch(count: int) -> None:
+        # Same per-batch event the ranks emit, so a single-GPU run reports progress the same
+        # way a distributed one does.
+        emit_progress("dense.images.batch.finished", rank=0, images=int(count))
+
+    run_dense_image_shard(
+        specs,
+        loaded=loaded,
+        out_dir=out_dir,
+        dense=dense,
+        batch_size=int(execution.batch_size),
+        precision=execution.precision,
+        output_dtype=resolve_output_torch_dtype(execution),
+        num_workers=execution.resolved_num_workers_per_gpu(),
+        prefetch_factor=int(execution.prefetch_factor),
+        on_batch=_on_batch,
+    )
+
+
+def _run_dense_images_distributed(model, specs, *, dense, execution, out_dir) -> None:
+    validate_multi_gpu_execution(model, execution)
+    progress_events_path = out_dir / "logs" / "dense_image_worker.progress.jsonl"
+    reset_progress_event_logs(progress_events_path)
+    with distributed_coordination_dir(out_dir) as coordination_dir:
+        request_path = coordination_dir / "dense_image_request.json"
+        request = {
+            "model": serialize_model(model),
+            "dense": serialize_dense_image_options(dense),
+            "execution": serialize_execution(execution),
+            "output_dir": str(out_dir),
+            "progress_events_path": str(progress_events_path),
+            **build_image_specs_request(specs),
+        }
+        request_path.write_text(json.dumps(request, indent=2, sort_keys=True), encoding="utf-8")
+        run_torchrun_worker(
+            module="slide2vec.distributed.dense_image_worker",
+            num_gpus=execution.num_gpus,
+            output_dir=out_dir,
+            request_path=request_path,
+            failure_title="Distributed dense image feature extraction failed",
+            progress_events_path=progress_events_path,
+            popen_factory=Popen,
+        )

--- a/slide2vec/runtime/dense_image_stage.py
+++ b/slide2vec/runtime/dense_image_stage.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from subprocess import Popen
 from typing import Sequence
 
+from slide2vec.api import DenseImageOptions, ImageSpec
 from slide2vec.artifacts import DenseImageArtifact
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.dense_image_shard import (
@@ -54,13 +55,21 @@ from slide2vec.runtime.serialization import (
 logger = logging.getLogger(__name__)
 
 
-def partition_dense_images_by_resume(specs: Sequence, out_dir) -> tuple[list, int]:
+def partition_dense_images_by_resume(
+    specs: Sequence[ImageSpec], out_dir
+) -> tuple[list[ImageSpec], int]:
     """Split the spec list into (needs-encode, already-on-disk-count) by sidecar existence."""
     remaining = [spec for spec in specs if dense_image_needs_encode(out_dir, spec)]
     return remaining, len(specs) - len(remaining)
 
 
-def embed_images_dense(model, images: Sequence, *, dense, execution) -> list[DenseImageArtifact]:
+def embed_images_dense(
+    model,
+    images: Sequence[ImageSpec],
+    *,
+    dense: DenseImageOptions,
+    execution,
+) -> list[DenseImageArtifact]:
     """Extract + persist a dense grid per caller-supplied image across all visible GPUs."""
     # Declare the effective encoder input before anything is decoded, sharded or launched: an
     # image geometry this encoder cannot accept must fail here, not on the first forward pass
@@ -100,7 +109,9 @@ def embed_images_dense(model, images: Sequence, *, dense, execution) -> list[Den
     return [dense_image_artifact_from_disk(out_dir, spec) for spec in specs]
 
 
-def _run_dense_images_in_process(model, specs, *, dense, execution, out_dir) -> None:
+def _run_dense_images_in_process(
+    model, specs: Sequence[ImageSpec], *, dense: DenseImageOptions, execution, out_dir
+) -> None:
     # Loaded under the dense contract declared by embed_images_dense, which supplies the
     # variable-input constructor settings this geometry needs. The shard builds its own
     # normalization-only transform — the same one this contract selects.
@@ -125,7 +136,9 @@ def _run_dense_images_in_process(model, specs, *, dense, execution, out_dir) -> 
     )
 
 
-def _run_dense_images_distributed(model, specs, *, dense, execution, out_dir) -> None:
+def _run_dense_images_distributed(
+    model, specs: Sequence[ImageSpec], *, dense: DenseImageOptions, execution, out_dir
+) -> None:
     validate_multi_gpu_execution(model, execution)
     progress_events_path = out_dir / "logs" / "dense_image_worker.progress.jsonl"
     reset_progress_event_logs(progress_events_path)

--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -199,6 +199,11 @@ class DenseGridEncoder:
     #: ``(B, C, h, w) -> (B, d, gh, gw)`` for the selected ``feature_kind``.
     encode_fn: Callable[[torch.Tensor], torch.Tensor]
     feature_kind: str
+    #: Short phrase naming where ``target_size`` came from (``"requested_tile_size_px"``,
+    #: ``"the declared target_size"``). Shapes the geometry-mismatch error only, so each
+    #: source keeps its own actionable vocabulary — the same convention
+    #: :meth:`~slide2vec.runtime.effective_encoder_input.EffectiveEncoderInput.resolve` uses.
+    target_size_origin: str
     pad_mode: str
     image_pad_value: float | None
     window_size: int | None
@@ -212,6 +217,7 @@ class DenseGridEncoder:
         model,
         *,
         target_size: int | tuple[int, int],
+        target_size_origin: str,
         pad_mode: str = "reflect",
         image_pad_value: float | None = None,
         window_size: int | None = None,
@@ -244,6 +250,7 @@ class DenseGridEncoder:
                 attention_include_registers=attention_include_registers,
             ),
             feature_kind=str(feature_kind),
+            target_size_origin=str(target_size_origin),
             pad_mode=str(pad_mode),
             image_pad_value=image_pad_value,
             window_size=None if window_size is None else int(window_size),
@@ -275,7 +282,7 @@ class DenseGridEncoder:
         if tuple(int(s) for s in tensor.shape[-2:]) != self.geometry.target_size:
             raise ValueError(
                 f"region at {origin} is {tuple(int(s) for s in tensor.shape[-2:])} after the dense "
-                f"transform, but the target size is {self.geometry.target_size}. The dense transform "
+                f"transform, but {self.target_size_origin} is {self.geometry.target_size}. The dense transform "
                 "must be normalization-only (no resize/crop)."
             )
         return self.pad_to_encoded(tensor)
@@ -384,6 +391,7 @@ def iter_regions_dense(
     encoder = DenseGridEncoder.resolve(
         model,
         target_size=requested_tile_size_px,
+        target_size_origin="requested_tile_size_px",
         pad_mode=pad_mode,
         image_pad_value=image_pad_value,
         window_size=window_size,

--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -134,17 +134,23 @@ def pad_image_to_encoded(
     pad_mode: str,
     image_pad_value: float | None,
 ) -> torch.Tensor:
-    """Pad a ``(C, H, W)`` tile (bottom/right) up to ``geometry.encoded_size``."""
+    """Pad a ``(C, H, W)`` tile — or a whole ``(B, C, H, W)`` batch — up to ``encoded_size``.
+
+    Padding is bottom/right only, so it never shifts the token grid's registration to the
+    tile's top-left origin. Both ranks are accepted because the two dense sources pad at
+    different moments: the slide path pads each region as it is transformed (the error can
+    then name the ROI's coordinate), the image path pads the stacked batch in one call.
+    """
     pad_bottom, pad_right = geometry.pad
     if pad_bottom == 0 and pad_right == 0:
         return tensor
-    x = tensor.unsqueeze(0)  # F.pad's 2-D modes need a batch dim
+    x = tensor.unsqueeze(0) if tensor.ndim == 3 else tensor  # F.pad's 2-D modes need a batch dim
     pad = (0, pad_right, 0, pad_bottom)  # (left, right, top, bottom)
     if pad_mode in ("constant", "zero"):
         x = F.pad(x, pad, mode="constant", value=float(image_pad_value or 0.0))
     else:
         x = F.pad(x, pad, mode=pad_mode)
-    return x.squeeze(0)
+    return x.squeeze(0) if tensor.ndim == 3 else x
 
 
 def _resolve_encode_fn(
@@ -169,6 +175,131 @@ def _resolve_encode_fn(
     raise ValueError(
         f"unsupported feature_kind {feature_kind!r}; expected 'patch_features' or 'cls_attention'"
     )
+
+
+@dataclass(frozen=True, kw_only=True)
+class DenseGridEncoder:
+    """One dense run's resolved encode recipe: geometry, transform, padding, encode fn.
+
+    Everything between "an RGB region" and "a ``(d, gh, gw)`` grid" that does not depend on
+    *where* the region came from. Both dense sources share it, which is what keeps the second
+    source from growing its own padding, batching or blending logic: ROIs streamed off a
+    slide (:func:`iter_regions_dense`) and pre-cropped image files
+    (:mod:`slide2vec.runtime.dense_image_shard`) differ only in who hands over the pixels.
+
+    Resolved **eagerly** — an unsupported ``pad_mode`` or ``feature_kind``, or a geometry the
+    encoder cannot express, raises at resolve time rather than on the first batch.
+    """
+
+    #: The encoder module the grids are produced by (dense-capable tile encoder).
+    model: object
+    geometry: DenseGridGeometry
+    #: Normalization-only transform; a resizing transform would destroy the registration.
+    dense_transform: Callable
+    #: ``(B, C, h, w) -> (B, d, gh, gw)`` for the selected ``feature_kind``.
+    encode_fn: Callable[[torch.Tensor], torch.Tensor]
+    feature_kind: str
+    pad_mode: str
+    image_pad_value: float | None
+    window_size: int | None
+    overlap: float
+    #: torch dtype the emitted grids are materialized in before ``.numpy()``.
+    output_dtype: "torch.dtype"
+
+    @classmethod
+    def resolve(
+        cls,
+        model,
+        *,
+        target_size: int | tuple[int, int],
+        pad_mode: str = "reflect",
+        image_pad_value: float | None = None,
+        window_size: int | None = None,
+        overlap: float = 0.0,
+        feature_kind: str = "patch_features",
+        attention_blocks: tuple[int, ...] = (-1,),
+        attention_include_registers: bool = False,
+        precision: str = "fp32",
+        output_dtype: "torch.dtype | None" = None,
+        dense_transform: Callable | None = None,
+    ) -> "DenseGridEncoder":
+        if pad_mode not in _PAD_MODES:
+            raise ValueError(
+                f"unsupported pad_mode {pad_mode!r}; expected one of {sorted(_PAD_MODES)}"
+            )
+        return cls(
+            model=model,
+            geometry=compute_dense_geometry(
+                target_size=target_size, patch_size=model.patch_size
+            ),
+            dense_transform=(
+                model.get_normalization_transform()
+                if dense_transform is None
+                else dense_transform
+            ),
+            encode_fn=_resolve_encode_fn(
+                model,
+                feature_kind=feature_kind,
+                attention_blocks=attention_blocks,
+                attention_include_registers=attention_include_registers,
+            ),
+            feature_kind=str(feature_kind),
+            pad_mode=str(pad_mode),
+            image_pad_value=image_pad_value,
+            window_size=None if window_size is None else int(window_size),
+            overlap=float(overlap),
+            output_dtype=_resolve_output_dtype(output_dtype, precision),
+        )
+
+    def pad_to_encoded(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Pad a ``(C, H, W)`` item or a ``(B, C, H, W)`` batch up to the patch multiple."""
+        return pad_image_to_encoded(
+            tensor,
+            self.geometry,
+            pad_mode=self.pad_mode,
+            image_pad_value=self.image_pad_value,
+        )
+
+    def transform_and_pad(self, region, *, origin) -> torch.Tensor:
+        """RGB region (PIL image or ``(H, W, C)`` array) → padded ``(C, enc_h, enc_w)``.
+
+        *origin* names the region in the error messages (a ROI coordinate, an image path).
+        """
+        if not isinstance(region, Image.Image):
+            region = Image.fromarray(np.ascontiguousarray(np.asarray(region)[..., :3]))
+        tensor = torch.as_tensor(self.dense_transform(region)).as_subclass(torch.Tensor)
+        if tensor.ndim != 3:
+            raise ValueError(
+                f"dense transform at {origin} produced a {tensor.ndim}-D tensor; expected (C, H, W)."
+            )
+        if tuple(int(s) for s in tensor.shape[-2:]) != self.geometry.target_size:
+            raise ValueError(
+                f"region at {origin} is {tuple(int(s) for s in tensor.shape[-2:])} after the dense "
+                f"transform, but the target size is {self.geometry.target_size}. The dense transform "
+                "must be normalization-only (no resize/crop)."
+            )
+        return self.pad_to_encoded(tensor)
+
+    def encode_batch(self, batch: torch.Tensor) -> np.ndarray:
+        """Padded ``(B, C, enc_h, enc_w)`` batch → ``(B, d, gh, gw)`` array in ``output_dtype``.
+
+        Every batch goes through the one windowed primitive: ``window_size=None``
+        short-circuits to a single whole-tile forward (byte-identical to the whole-region
+        encode), so there is no separate whole-region branch.
+        """
+        out = encode_dense_sliding(
+            self.model,
+            batch,
+            geometry=self.geometry,
+            window_size=self.window_size,
+            overlap=self.overlap,
+            encode_fn=self.encode_fn,
+        )
+        if out.ndim != 4:
+            raise ValueError(
+                f"{self.feature_kind} encode returned a {out.ndim}-D tensor; expected (B, d, gh, gw)."
+            )
+        return out.detach().to(self.output_dtype).cpu().numpy()
 
 
 def iter_regions_dense(
@@ -247,24 +378,23 @@ def iter_regions_dense(
     share this path. Each yielded grid is a standalone contiguous copy, so it does not pin
     the rest of its batch's memory alive.
     """
-    if pad_mode not in _PAD_MODES:
-        raise ValueError(f"unsupported pad_mode {pad_mode!r}; expected one of {sorted(_PAD_MODES)}")
-    resolved_output_dtype = _resolve_output_dtype(output_dtype, precision)
     read_level = int(tiling_result.read_level)
     read_tile_size_px = int(tiling_result.read_tile_size_px)
     requested_tile_size_px = int(tiling_result.requested_tile_size_px)
-    geometry = compute_dense_geometry(
-        target_size=requested_tile_size_px, patch_size=model.patch_size
-    )
-    if dense_transform is None:
-        dense_transform = model.get_normalization_transform()
-    encode_fn = _resolve_encode_fn(
+    encoder = DenseGridEncoder.resolve(
         model,
+        target_size=requested_tile_size_px,
+        pad_mode=pad_mode,
+        image_pad_value=image_pad_value,
+        window_size=window_size,
+        overlap=overlap,
         feature_kind=feature_kind,
         attention_blocks=attention_blocks,
         attention_include_registers=attention_include_registers,
+        precision=precision,
+        output_dtype=output_dtype,
+        dense_transform=dense_transform,
     )
-    target_h, target_w = geometry.target_size
     x = np.asarray(tiling_result.x)
     y = np.asarray(tiling_result.y)
     coords = [(int(x[i]), int(y[i])) for i in range(x.shape[0])]
@@ -284,23 +414,6 @@ def iter_regions_dense(
         interpolation="area",
     )
 
-    def _transform_and_pad(region_hwc: np.ndarray, location: tuple[int, int]) -> torch.Tensor:
-        region = np.ascontiguousarray(np.asarray(region_hwc)[..., :3])
-        tensor = torch.as_tensor(dense_transform(Image.fromarray(region))).as_subclass(torch.Tensor)
-        if tensor.ndim != 3:
-            raise ValueError(
-                f"dense transform at {location} produced a {tensor.ndim}-D tensor; expected (C, H, W)."
-            )
-        if tuple(int(s) for s in tensor.shape[-2:]) != (target_h, target_w):
-            raise ValueError(
-                f"region at {location} is {tuple(int(s) for s in tensor.shape[-2:])} after the dense "
-                f"transform, but requested_tile_size_px is {(target_h, target_w)}. The dense transform "
-                "must be normalization-only (no resize/crop)."
-            )
-        return pad_image_to_encoded(
-            tensor, geometry, pad_mode=pad_mode, image_pad_value=image_pad_value
-        )
-
     def _stream() -> Iterator[np.ndarray]:
         with torch.inference_mode(), slide_encode_autocast_ctx(device, precision):
             for start in range(0, len(coords), step):
@@ -311,24 +424,12 @@ def iter_regions_dense(
                 region_batch, _timing = reader.read_batch_with_timing(chunk)
                 region_np = region_batch.permute(0, 2, 3, 1).numpy()  # (B, H, W, 3) uint8
                 batch = torch.stack(
-                    [_transform_and_pad(region_np[i], chunk[i]) for i in range(region_np.shape[0])]
+                    [
+                        encoder.transform_and_pad(region_np[i], origin=chunk[i])
+                        for i in range(region_np.shape[0])
+                    ]
                 ).to(device, non_blocking=True)
-                # Every batch goes through the one windowed primitive: window_size=None
-                # short-circuits to a single whole-tile forward (byte-identical to the
-                # whole-region encode), so there is no separate whole-region branch.
-                out = encode_dense_sliding(
-                    model,
-                    batch,
-                    geometry=geometry,
-                    window_size=window_size,
-                    overlap=overlap,
-                    encode_fn=encode_fn,
-                )
-                if out.ndim != 4:
-                    raise ValueError(
-                        f"{feature_kind} encode returned a {out.ndim}-D tensor; expected (B, d, gh, gw)."
-                    )
-                batch_np = out.detach().to(resolved_output_dtype).cpu().numpy()
+                batch_np = encoder.encode_batch(batch)
                 for i in range(batch_np.shape[0]):
                     # Standalone C-contiguous copy: a per-row view would pin the whole
                     # batch alive (the blended sliding output is contiguous, so a view of

--- a/slide2vec/runtime/encoder_input_contract.py
+++ b/slide2vec/runtime/encoder_input_contract.py
@@ -82,7 +82,7 @@ class EncoderInputContract:
         cls,
         encoder_name: str,
         *,
-        target_size_px: int,
+        target_size_px: int | tuple[int, int],
         window_size: int | None,
     ) -> "EncoderInputContract":
         """Resolve the dense ROI geometry the caller asked for, or raise.

--- a/slide2vec/runtime/image_specs.py
+++ b/slide2vec/runtime/image_specs.py
@@ -1,0 +1,70 @@
+"""The flat list of named image files both given-geometry paths work over.
+
+:meth:`slide2vec.api.Model.embed_images` (pooled, issue #234) and
+:meth:`slide2vec.api.Model.embed_images_dense` (dense grids, issue #235) take the same input
+unit — a caller-named image file — and stage it the same way, so normalizing that list and
+moving it to the torchrun ranks lives here rather than being copied per path. What differs
+between them is only what each rank *does* with an image, which is the shard loops' business.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Sequence
+
+from slide2vec.api import ImageSpec
+
+
+def normalize_image_specs(
+    images: Sequence[ImageSpec], *, method_name: str, artifact_location: str
+) -> list[ImageSpec]:
+    """Resolve each image path and guarantee the sample ids can name distinct artifacts.
+
+    ``sample_id`` is the artifact's whole identity on these paths, so a duplicate would make
+    two images silently overwrite one another — and, worse, make the second look already
+    done to resume. That is a hard error, not a warning. *method_name* and
+    *artifact_location* only shape the message, so each path names its own API and layout.
+    """
+    specs = [
+        ImageSpec(
+            sample_id=str(image.sample_id),
+            image_path=str(Path(image.image_path).expanduser().resolve()),
+        )
+        for image in images
+    ]
+    if not specs:
+        raise ValueError("At least one image is required")
+    duplicates = sorted(
+        sample_id
+        for sample_id, count in Counter(spec.sample_id for spec in specs).items()
+        if count > 1
+    )
+    if duplicates:
+        raise ValueError(
+            f"{method_name} received duplicate sample_id values: {duplicates}. Each image "
+            f"is persisted as {artifact_location}, so sample ids must be unique."
+        )
+    return specs
+
+
+def build_image_specs_request(specs: Sequence[ImageSpec]) -> dict:
+    """The flat image list crossing to the torchrun ranks, in the order the parent fixed.
+
+    Order is the payload: every rank rebuilds this exact list and derives its own contiguous
+    shard from it, so the ordering *is* the work assignment. Unlike the dense ROI request
+    there is no side-car npz — the units are two strings each, not numeric coordinate arrays.
+    """
+    return {
+        "images": [
+            {"sample_id": spec.sample_id, "image_path": str(spec.image_path)} for spec in specs
+        ]
+    }
+
+
+def image_specs_from_request(request: dict) -> list[ImageSpec]:
+    """Inverse of :func:`build_image_specs_request`: request → flat spec list."""
+    return [
+        ImageSpec(sample_id=str(image["sample_id"]), image_path=str(image["image_path"]))
+        for image in request["images"]
+    ]

--- a/slide2vec/runtime/image_stage.py
+++ b/slide2vec/runtime/image_stage.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import json
 import logging
-from collections import Counter
 from pathlib import Path
 from subprocess import Popen
 from typing import Sequence
@@ -41,39 +40,11 @@ from slide2vec.runtime.image_shard import (
     image_needs_encode,
     run_image_shard,
 )
+from slide2vec.runtime.image_specs import build_image_specs_request, normalize_image_specs
 from slide2vec.runtime.model_settings import resolve_output_precision
 from slide2vec.runtime.serialization import serialize_execution, serialize_model
 
 logger = logging.getLogger(__name__)
-
-
-def normalize_image_specs(images: Sequence[ImageSpec]) -> list[ImageSpec]:
-    """Resolve each image path and guarantee the sample ids can name distinct artifacts.
-
-    ``sample_id`` is the artifact's whole identity on this path, so a duplicate would make
-    two images silently overwrite one another — and, worse, make the second look already
-    done to resume. That is a hard error, not a warning.
-    """
-    specs = [
-        ImageSpec(
-            sample_id=str(image.sample_id),
-            image_path=str(Path(image.image_path).expanduser().resolve()),
-        )
-        for image in images
-    ]
-    if not specs:
-        raise ValueError("At least one image is required")
-    duplicates = sorted(
-        sample_id
-        for sample_id, count in Counter(spec.sample_id for spec in specs).items()
-        if count > 1
-    )
-    if duplicates:
-        raise ValueError(
-            f"embed_images() received duplicate sample_id values: {duplicates}. Each image "
-            "is persisted as image_embeddings/<sample_id>, so sample ids must be unique."
-        )
-    return specs
 
 
 def partition_images_by_resume(
@@ -86,28 +57,6 @@ def partition_images_by_resume(
     return remaining, len(specs) - len(remaining)
 
 
-def build_image_worker_request(specs: Sequence[ImageSpec]) -> dict:
-    """The flat image list crossing to the torchrun ranks, in the order the parent fixed.
-
-    Order is the payload: every rank rebuilds this exact list and derives its own contiguous
-    shard from it, so the ordering *is* the work assignment. Unlike the dense request there
-    is no side-car npz — the units are two strings each, not numeric coordinate arrays.
-    """
-    return {
-        "images": [
-            {"sample_id": spec.sample_id, "image_path": str(spec.image_path)} for spec in specs
-        ]
-    }
-
-
-def image_specs_from_request(request: dict) -> list[ImageSpec]:
-    """Inverse of :func:`build_image_worker_request`: request → flat spec list."""
-    return [
-        ImageSpec(sample_id=str(image["sample_id"]), image_path=str(image["image_path"]))
-        for image in request["images"]
-    ]
-
-
 def embed_images(model, images: Sequence[ImageSpec], *, execution) -> list[ImageEmbeddingArtifact]:
     """Embed + persist one artifact per caller-supplied image across all visible GPUs."""
     # Declare Given before anything is read or launched. This is the affirmative statement
@@ -115,7 +64,11 @@ def embed_images(model, images: Sequence[ImageSpec], *, execution) -> list[Image
     # declaration, which the contract deliberately refuses to interpret. Idempotent, so
     # every torchrun rank re-declares for itself (image_worker).
     model._declare_given_encoder_input(emit_run_info=True)
-    specs = normalize_image_specs(images)
+    specs = normalize_image_specs(
+        images,
+        method_name="embed_images()",
+        artifact_location="image_embeddings/<sample_id>",
+    )
     out_dir = Path(execution.output_dir).expanduser().resolve()
     execution = execution.with_output_dir(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
@@ -181,7 +134,7 @@ def _run_images_distributed(model, specs, *, execution, out_dir) -> None:
             "execution": serialize_execution(execution),
             "output_dir": str(out_dir),
             "progress_events_path": str(progress_events_path),
-            **build_image_worker_request(specs),
+            **build_image_specs_request(specs),
         }
         request_path.write_text(json.dumps(request, indent=2, sort_keys=True), encoding="utf-8")
         run_torchrun_worker(

--- a/slide2vec/runtime/serialization.py
+++ b/slide2vec/runtime/serialization.py
@@ -2,7 +2,12 @@ import copy
 from pathlib import Path
 from typing import Any
 
-from slide2vec.api import DenseOptions, ExecutionOptions, PreprocessingConfig
+from slide2vec.api import (
+    DenseImageOptions,
+    DenseOptions,
+    ExecutionOptions,
+    PreprocessingConfig,
+)
 
 
 def serialize_model(model) -> dict[str, Any]:
@@ -90,6 +95,48 @@ def deserialize_dense_options(payload: dict[str, Any]) -> DenseOptions:
         target_size=int(payload["target_size"]),
         tolerance=float(payload.get("tolerance", 0.05)),
         backend=str(payload.get("backend", "auto")),
+        pad_mode=str(payload.get("pad_mode", "reflect")),
+        image_pad_value=(
+            float(payload["image_pad_value"]) if payload.get("image_pad_value") is not None else None
+        ),
+        window_size=int(payload["window_size"]) if payload.get("window_size") is not None else None,
+        overlap=float(payload.get("overlap", 0.0)),
+        feature_kind=str(payload.get("feature_kind", "patch_features")),
+        attention_blocks=tuple(int(b) for b in payload.get("attention_blocks", (-1,))),
+        attention_include_registers=bool(payload.get("attention_include_registers", False)),
+    )
+
+
+def serialize_dense_image_options(dense: DenseImageOptions) -> dict[str, Any]:
+    """JSON-round-trippable dense-over-images settings crossing to the torchrun ranks.
+
+    ``target_size`` keeps its shape: an int stays an int, an ``(h, w)`` pair travels as a
+    two-element list, so a non-square declaration survives the trip to the ranks intact.
+    """
+    return {
+        "target_size": (
+            int(dense.target_size)
+            if isinstance(dense.target_size, int)
+            else [int(size) for size in dense.target_size]
+        ),
+        "pad_mode": dense.pad_mode,
+        "image_pad_value": dense.image_pad_value,
+        "window_size": dense.window_size,
+        "overlap": dense.overlap,
+        "feature_kind": dense.feature_kind,
+        "attention_blocks": list(dense.attention_blocks),
+        "attention_include_registers": dense.attention_include_registers,
+    }
+
+
+def deserialize_dense_image_options(payload: dict[str, Any]) -> DenseImageOptions:
+    target_size = payload["target_size"]
+    return DenseImageOptions(
+        target_size=(
+            int(target_size)
+            if isinstance(target_size, int)
+            else (int(target_size[0]), int(target_size[1]))
+        ),
         pad_mode=str(payload.get("pad_mode", "reflect")),
         image_pad_value=(
             float(payload["image_pad_value"]) if payload.get("image_pad_value") is not None else None

--- a/tests/test_dense_encoder_input.py
+++ b/tests/test_dense_encoder_input.py
@@ -59,7 +59,9 @@ def test_dense_whole_tile_effective_input_is_the_padded_encoded_size():
         "virchow2", target_size_px=512, window_size=None
     )
 
-    assert contract.plan.target_size_px == 512
+    # The supervision geometry is always stated as an (h, w) pair, whether the caller asked
+    # for a square side length (a slide ROI) or a rectangle (a pre-cropped image).
+    assert contract.plan.target_size_px == (512, 512)
     assert contract.plan.encoded_size_px == (518, 518)
     assert contract.plan.effective_encoder_input_size_px == (518, 518)
 

--- a/tests/test_dense_image_shard.py
+++ b/tests/test_dense_image_shard.py
@@ -1,0 +1,383 @@
+"""Tests for dense grids over pre-cropped images: the artifacts + the CPU loop (issue #235).
+
+Two layers, both CPU-testable:
+
+1. ``slide2vec.artifacts.write_dense_image`` — one ``(d, gh, gw)`` payload + one geometry
+   sidecar per image, written atomically and sidecar-last, so the sidecar is an unambiguous
+   done-marker (the same contract ``write_dense_region`` follows).
+2. ``run_dense_image_shard`` — the device-agnostic encode+write loop each rank runs over its
+   shard: decode each image, apply the encoder's **normalization-only** transform itemwise in
+   the loader workers, stack, pad up to the patch multiple, encode through
+   ``encode_dense_sliding``, persist.
+
+The anchor test pins the persisted grid against the direct composition
+``compute_dense_geometry`` + ``encode_dense_sliding`` — the equivalence downstream consumers
+migrate onto — for both ``feature_kind`` values.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+PIL = pytest.importorskip("PIL")
+
+from PIL import Image  # noqa: E402
+
+from slide2vec.api import DenseImageOptions, ImageSpec  # noqa: E402
+from slide2vec.artifacts import dense_image_paths, write_dense_image  # noqa: E402
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime.dense_image_shard import run_dense_image_shard  # noqa: E402
+from slide2vec.runtime.dense_regions import (  # noqa: E402
+    compute_dense_geometry,
+    pad_image_to_encoded,
+)
+from slide2vec.runtime.dense_sliding import encode_dense_sliding  # noqa: E402
+from slide2vec.runtime.sharding import plan_contiguous_shards  # noqa: E402
+from slide2vec.runtime.types import LoadedModel  # noqa: E402
+
+
+def _encoder() -> TimmTileEncoder:
+    return TimmTileEncoder(
+        "vit_tiny_patch16_224", pretrained=False, num_classes=0, dynamic_img_size=True
+    )
+
+
+def _loaded(encoder: TimmTileEncoder) -> LoadedModel:
+    """A ``LoadedModel`` under a dense contract: the normalization-only transform."""
+    return LoadedModel(
+        name="fake-encoder",
+        level="tile",
+        model=encoder,
+        transforms=encoder.get_normalization_transform(),
+        feature_dim=int(encoder.encode_dim),
+        device=torch.device("cpu"),
+    )
+
+
+def _write_image(path: Path, *, width: int, height: int) -> None:
+    rng = np.random.default_rng(abs(hash((width, height, path.name))) % (2**32))
+    pixels = rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(pixels).save(path)
+
+
+def _spec(tmp_path, sample_id: str, *, width: int = 64, height: int = 64) -> ImageSpec:
+    path = tmp_path / "images" / f"{sample_id}.png"
+    _write_image(path, width=width, height=height)
+    return ImageSpec(sample_id=sample_id, image_path=str(path))
+
+
+def _dense(**kwargs) -> DenseImageOptions:
+    return DenseImageOptions(**{"target_size": 64, **kwargs})
+
+
+def _dense_dir(out_dir) -> Path:
+    return out_dir / "dense_image_embeddings"
+
+
+# --------------------------------------------------------------------------------------
+# Layer 1: the artifact write (payload atomic, sidecar last)
+# --------------------------------------------------------------------------------------
+
+
+def test_dense_image_paths_rejects_sample_id_paths(tmp_path):
+    with pytest.raises(ValueError, match="sample_id"):
+        dense_image_paths(tmp_path, sample_id="/tmp/outside")
+
+
+def test_dense_image_paths_rejects_symlink_escape(tmp_path):
+    output_dir = tmp_path / "output"
+    embeddings_dir = output_dir / "dense_image_embeddings"
+    outside_dir = tmp_path / "outside"
+    embeddings_dir.parent.mkdir(parents=True)
+    outside_dir.mkdir()
+    embeddings_dir.symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="output_dir"):
+        dense_image_paths(output_dir, sample_id="image-1")
+
+
+def test_write_dense_image_does_not_publish_interrupted_sidecar(tmp_path, monkeypatch):
+    """A crashed sidecar write leaves the payload but no done-marker."""
+    original_write_text = Path.write_text
+
+    def _interrupted_write(path, text, *, encoding):
+        original_write_text(path, text[:1], encoding=encoding)
+        raise OSError("simulated interrupted metadata write")
+
+    monkeypatch.setattr(Path, "write_text", _interrupted_write)
+
+    with pytest.raises(OSError, match="interrupted metadata write"):
+        write_dense_image(
+            torch.zeros((2, 2, 2)),
+            output_dir=tmp_path,
+            sample_id="image-1",
+            metadata={"feature_dim": 2, "grid_shape": [2, 2]},
+        )
+
+    payload_path, sidecar_path = dense_image_paths(tmp_path, sample_id="image-1")
+    assert payload_path.exists()
+    assert not sidecar_path.exists()
+
+
+# --------------------------------------------------------------------------------------
+# Layer 2: run_dense_image_shard (device-agnostic encode+write loop)
+# --------------------------------------------------------------------------------------
+
+
+def test_run_dense_image_shard_writes_payload_and_sidecar_per_image(tmp_path):
+    enc = _encoder()
+    specs = [_spec(tmp_path, name) for name in ("a", "b", "c")]
+
+    artifacts = run_dense_image_shard(
+        specs,
+        loaded=_loaded(enc),
+        out_dir=tmp_path / "out",
+        dense=_dense(),
+        batch_size=2,
+        num_workers=0,
+    )
+
+    assert [artifact.sample_id for artifact in artifacts] == ["a", "b", "c"]
+    dense_dir = _dense_dir(tmp_path / "out")
+    for artifact in artifacts:
+        assert artifact.path == (dense_dir / f"{artifact.sample_id}.pt").resolve()
+        assert artifact.metadata_path.exists()
+        assert artifact.grid_shape == (4, 4)
+        assert artifact.feature_dim == enc.encode_dim
+        grid = torch.load(artifact.path, weights_only=True)
+        assert tuple(grid.shape) == (enc.encode_dim, 4, 4)
+    assert sorted(p.name for p in dense_dir.glob("*.pt")) == ["a.pt", "b.pt", "c.pt"]
+    assert list(dense_dir.glob("*.tmp*")) == []
+
+
+@pytest.mark.parametrize("feature_kind", ["patch_features", "cls_attention"])
+@pytest.mark.parametrize("window_size", [None, 32])
+def test_grid_matches_the_direct_dense_composition(tmp_path, feature_kind, window_size):
+    """The equivalence downstream consumers migrate onto.
+
+    A persisted grid is exactly ``compute_dense_geometry`` + the encoder's normalization
+    transform + ``encode_dense_sliding``, at the same batch size and dtype — for the patch
+    grid and the CLS-attention grid alike, whole-tile and sliding.
+    """
+    enc = _encoder()
+    batch_size = 2
+    specs = [_spec(tmp_path, f"image-{i}") for i in range(4)]
+
+    artifacts = run_dense_image_shard(
+        specs,
+        loaded=_loaded(enc),
+        out_dir=tmp_path / "out",
+        dense=_dense(feature_kind=feature_kind, window_size=window_size),
+        batch_size=batch_size,
+        num_workers=0,
+    )
+
+    geometry = compute_dense_geometry(target_size=64, patch_size=enc.patch_size)
+    transform = enc.get_normalization_transform()
+    encode_fn = (
+        enc.encode_tiles_dense
+        if feature_kind == "patch_features"
+        else (lambda w: enc.encode_tiles_attention(w, blocks=(-1,), include_registers=False))
+    )
+    for start in range(0, len(specs), batch_size):
+        chunk = specs[start : start + batch_size]
+        items = []
+        for spec in chunk:
+            with Image.open(spec.image_path) as image:
+                tensor = torch.as_tensor(transform(image.convert("RGB")))
+            items.append(
+                pad_image_to_encoded(
+                    tensor, geometry, pad_mode="reflect", image_pad_value=None
+                )
+            )
+        with torch.inference_mode():
+            expected = encode_dense_sliding(
+                enc,
+                torch.stack(items),
+                geometry=geometry,
+                window_size=window_size,
+                overlap=0.0,
+                encode_fn=encode_fn,
+            )
+        for offset, artifact in enumerate(artifacts[start : start + batch_size]):
+            persisted = torch.load(artifact.path, weights_only=True)
+            torch.testing.assert_close(persisted, expected[offset], rtol=0, atol=0)
+
+
+def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
+    enc = _encoder()
+    dense = _dense(target_size=60, window_size=32, overlap=0.25)
+    specs = [_spec(tmp_path, "a", width=60, height=60)]
+
+    artifacts = run_dense_image_shard(
+        specs, loaded=_loaded(enc), out_dir=tmp_path / "out", dense=dense,
+        batch_size=1, num_workers=0,
+    )
+
+    meta = json.loads(artifacts[0].metadata_path.read_text())
+    assert meta == {
+        "artifact_type": "dense_image_embeddings",
+        "sample_id": "a",
+        "image_path": str(specs[0].image_path),
+        "format": "pt",
+        "dtype": "float32",
+        "feature_dim": enc.encode_dim,
+        "grid_shape": [4, 4],          # 60 padded up to 64 → 4×4 tokens
+        "target_size": [60, 60],
+        "patch_size": [16, 16],
+        "encoded_size": [64, 64],
+        "pad": [4, 4],
+        "encoder_name": "fake-encoder",
+        "encoder_level": "tile",
+        "encoder_input_regime": "declared",
+        "pad_mode": "reflect",
+        "image_pad_value": None,
+        "window_size": 32,
+        "overlap": 0.25,
+        "feature_kind": "patch_features",
+        "attention_blocks": [-1],
+        "attention_include_registers": False,
+    }
+
+
+def test_run_dense_image_shard_supports_non_square_images(tmp_path):
+    """The image *is* the region here, so a non-square declared geometry must work.
+
+    Nothing on this path narrows the encoder input to a square: the dense contract checks
+    each dimension against the patch geometry, and the square-only recorder the pooled
+    Given path uses is never reached (dense never calls ``encode_tiles``).
+    """
+    enc = _encoder()
+    specs = [_spec(tmp_path, "wide", width=96, height=64)]
+
+    artifacts = run_dense_image_shard(
+        specs,
+        loaded=_loaded(enc),
+        out_dir=tmp_path / "out",
+        dense=_dense(target_size=(64, 96)),
+        batch_size=1,
+        num_workers=0,
+    )
+
+    assert artifacts[0].grid_shape == (4, 6)
+    grid = torch.load(artifacts[0].path, weights_only=True)
+    assert tuple(grid.shape) == (enc.encode_dim, 4, 6)
+    meta = json.loads(artifacts[0].metadata_path.read_text())
+    assert meta["target_size"] == [64, 96]
+    assert meta["encoded_size"] == [64, 96]
+
+
+def test_run_dense_image_shard_rejects_images_that_are_not_the_declared_size(tmp_path):
+    """The declared geometry is the contract: an off-size image is an error, not a resize."""
+    enc = _encoder()
+    specs = [_spec(tmp_path, "small", width=32, height=32)]
+
+    with pytest.raises(ValueError, match="declared target_size"):
+        run_dense_image_shard(
+            specs, loaded=_loaded(enc), out_dir=tmp_path / "out", dense=_dense(),
+            batch_size=1, num_workers=0,
+        )
+
+
+def test_run_dense_image_shard_skips_images_with_existing_sidecar(tmp_path):
+    """Resume: an image whose sidecar exists is not re-decoded or re-encoded."""
+    enc = _encoder()
+    specs = [_spec(tmp_path, name) for name in ("a", "b", "c")]
+    out_dir = tmp_path / "out"
+
+    first = run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=out_dir,
+                                  dense=_dense(), batch_size=2, num_workers=0)
+    mtimes = {a.sample_id: a.path.stat().st_mtime_ns for a in first}
+
+    second = run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=out_dir,
+                                   dense=_dense(), batch_size=2, num_workers=0)
+
+    assert [a.sample_id for a in second] == [a.sample_id for a in first]
+    assert {a.sample_id: a.path.stat().st_mtime_ns for a in second} == mtimes
+
+
+def test_run_dense_image_shard_reencodes_payload_missing_its_sidecar(tmp_path):
+    """Crash-safety: a payload with no sidecar is incomplete and is re-encoded."""
+    enc = _encoder()
+    specs = [_spec(tmp_path, name) for name in ("a", "b")]
+    out_dir = tmp_path / "out"
+    run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
+                          batch_size=2, num_workers=0)
+
+    _, sidecar_path = dense_image_paths(out_dir, sample_id="b")
+    payload_path, _ = dense_image_paths(out_dir, sample_id="b")
+    sidecar_path.unlink()
+    payload_mtime = payload_path.stat().st_mtime_ns
+
+    run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
+                          batch_size=2, num_workers=0)
+
+    assert sidecar_path.exists()
+    assert payload_path.stat().st_mtime_ns != payload_mtime
+
+
+def test_multi_rank_matches_single_rank(tmp_path):
+    """Sharding equivalence: 3 shards vs 1 → identical file set and identical grids."""
+    enc = _encoder()  # every rank loads the same checkpoint
+    specs = [_spec(tmp_path, f"image-{i}") for i in range(7)]
+
+    single_dir = tmp_path / "single"
+    run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=single_dir, dense=_dense(),
+                          batch_size=3, num_workers=0)
+
+    multi_dir = tmp_path / "multi"
+    for shard in plan_contiguous_shards(specs, 3):
+        run_dense_image_shard(shard, loaded=_loaded(enc), out_dir=multi_dir, dense=_dense(),
+                              batch_size=3, num_workers=0)
+
+    def _files(root):
+        base = _dense_dir(root)
+        return {p.relative_to(base).as_posix() for p in base.rglob("*") if p.is_file()}
+
+    assert _files(single_dir) == _files(multi_dir)
+    for name in _files(single_dir):
+        if not name.endswith(".pt"):
+            continue
+        one = torch.load(_dense_dir(single_dir) / name, weights_only=True)
+        many = torch.load(_dense_dir(multi_dir) / name, weights_only=True)
+        # Same shard size (batch_size=3) on both sides, so the grids are bit-identical.
+        torch.testing.assert_close(one, many, rtol=0, atol=0)
+
+
+def test_run_dense_image_shard_honors_the_on_disk_grid_dtype(tmp_path):
+    artifacts = run_dense_image_shard(
+        [_spec(tmp_path, "a")],
+        loaded=_loaded(_encoder()),
+        out_dir=tmp_path / "out",
+        dense=_dense(),
+        batch_size=1,
+        output_dtype=torch.float16,
+        num_workers=0,
+    )
+    grid = torch.load(artifacts[0].path, weights_only=True)
+    assert grid.dtype == torch.float16
+    assert json.loads(artifacts[0].metadata_path.read_text())["dtype"] == "float16"
+
+
+def test_payload_size_is_independent_of_batch_size(tmp_path):
+    """Each artifact holds one grid, not a view onto its whole batch's storage."""
+    enc = _encoder()
+    specs = [_spec(tmp_path, f"image-{i}") for i in range(4)]
+
+    sizes = {}
+    for batch_size in (1, 4):
+        out_dir = tmp_path / f"out-{batch_size}"
+        artifacts = run_dense_image_shard(
+            specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
+            batch_size=batch_size, num_workers=0,
+        )
+        sizes[batch_size] = [artifact.path.stat().st_size for artifact in artifacts]
+
+    assert sizes[1] == sizes[4]

--- a/tests/test_dense_image_shard.py
+++ b/tests/test_dense_image_shard.py
@@ -279,11 +279,35 @@ def test_run_dense_image_shard_rejects_images_that_are_not_the_declared_size(tmp
     enc = _encoder()
     specs = [_spec(tmp_path, "small", width=32, height=32)]
 
-    with pytest.raises(ValueError, match="declared target_size"):
+    with pytest.raises(ValueError, match=r"'small': \(32, 32\)"):
         run_dense_image_shard(
             specs, loaded=_loaded(enc), out_dir=tmp_path / "out", dense=_dense(),
             batch_size=1, num_workers=0,
         )
+
+
+def test_off_size_images_are_named_even_when_a_batch_is_mixed(tmp_path):
+    """The error has to name the images, not report a list of shapes from ``torch.stack``.
+
+    A mixed-size batch is the realistic failure: the stack would blow up first with no way
+    back to a sample id, so the declared geometry is checked per item before stacking.
+    """
+    enc = _encoder()
+    specs = [
+        _spec(tmp_path, "right", width=64, height=64),
+        _spec(tmp_path, "short", width=64, height=48),
+        _spec(tmp_path, "narrow", width=32, height=64),
+    ]
+
+    with pytest.raises(ValueError) as excinfo:
+        run_dense_image_shard(
+            specs, loaded=_loaded(enc), out_dir=tmp_path / "out", dense=_dense(),
+            batch_size=3, num_workers=0,
+        )
+
+    message = str(excinfo.value)
+    assert "'short': (48, 64)" in message and "'narrow': (64, 32)" in message
+    assert "right" not in message  # the conforming image is not accused
 
 
 def test_run_dense_image_shard_skips_images_with_existing_sidecar(tmp_path):

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -1,0 +1,338 @@
+"""Tests for the parent-side dense-over-images orchestration (issue #235).
+
+``embed_images_dense`` declares the dense encoder-input contract, normalizes the caller's
+images, resume-filters them, then either runs the encode/write loop in-process
+(``num_gpus=1``) or fans it out over torchrun ranks (``num_gpus>1``) — reusing the same
+distributed machinery the dense ROI and pooled image paths use. These tests run on CPU with a
+random-weight encoder; the torchrun launch is captured rather than executed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+PIL = pytest.importorskip("PIL")
+
+from PIL import Image  # noqa: E402
+
+from slide2vec.api import DenseImageOptions, ExecutionOptions, ImageSpec  # noqa: E402
+from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
+from slide2vec.runtime import dense_image_stage  # noqa: E402
+from slide2vec.runtime.types import LoadedModel  # noqa: E402
+
+
+def _encoder() -> TimmTileEncoder:
+    return TimmTileEncoder(
+        "vit_tiny_patch16_224", pretrained=False, num_classes=0, dynamic_img_size=True
+    )
+
+
+def _loaded(encoder: TimmTileEncoder) -> LoadedModel:
+    return LoadedModel(
+        name="fake-encoder",
+        level="tile",
+        model=encoder,
+        transforms=encoder.get_normalization_transform(),
+        feature_dim=int(encoder.encode_dim),
+        device=torch.device("cpu"),
+    )
+
+
+class _FakeModel:
+    """Minimal ``Model`` stand-in: refuses a backend until the dense contract is declared."""
+
+    def __init__(self, encoder) -> None:
+        self._loaded = _loaded(encoder)
+        self.name = "fake-encoder"
+        self._output_variant = None
+        self._requested_device = "cpu"
+        self.allow_non_recommended_settings = False
+        self.declared: list = []
+
+    def _declare_dense_encoder_input(self, dense, *, emit_run_info):
+        self.declared.append(dense)
+
+    def _load_backend(self):
+        assert self.declared, "the dense image path must declare its geometry before loading"
+        return self._loaded
+
+
+def _images(tmp_path, names, *, width=64, height=64) -> list[ImageSpec]:
+    specs = []
+    for name in names:
+        path = tmp_path / "images" / f"{name}.png"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        rng = np.random.default_rng(abs(hash(name)) % (2**32))
+        pixels = rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+        Image.fromarray(pixels).save(path)
+        specs.append(ImageSpec(sample_id=name, image_path=path))
+    return specs
+
+
+def _dense(**kwargs) -> DenseImageOptions:
+    return DenseImageOptions(**{"target_size": 64, **kwargs})
+
+
+def test_embed_images_dense_num_gpus_one_runs_in_process(tmp_path, monkeypatch):
+    """``num_gpus=1`` encodes in-process — no torchrun subprocess — and writes every grid."""
+    monkeypatch.setattr(
+        dense_image_stage, "run_torchrun_worker",
+        lambda **kwargs: pytest.fail("num_gpus=1 must not launch torchrun"),
+    )
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+
+    artifacts = dense_image_stage.embed_images_dense(
+        model, _images(tmp_path, ["a", "b", "c"]), dense=_dense(), execution=execution
+    )
+
+    assert [artifact.sample_id for artifact in artifacts] == ["a", "b", "c"]
+    assert model.declared, "the dense contract is declared before anything is read"
+    dense_dir = tmp_path / "out" / "dense_image_embeddings"
+    assert sorted(p.name for p in dense_dir.glob("*.pt")) == ["a.pt", "b.pt", "c.pt"]
+    for artifact in artifacts:
+        assert artifact.grid_shape == (4, 4)
+        assert artifact.metadata_path.exists()
+
+
+def test_embed_images_dense_num_gpus_gt_one_launches_the_worker(tmp_path, monkeypatch):
+    """``num_gpus>1`` launches ``slide2vec.distributed.dense_image_worker`` under torchrun;
+    the parent itself encodes nothing and collects the artifacts back off disk."""
+    from slide2vec.runtime.dense_image_shard import run_dense_image_shard
+    from slide2vec.runtime.image_specs import image_specs_from_request
+    from slide2vec.runtime.sharding import plan_contiguous_shards
+
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    monkeypatch.chdir(caller_dir)
+    captured: dict = {}
+    rank_loaded = _loaded(_encoder())  # every rank loads the same checkpoint
+
+    def _fake_run(*, module, num_gpus, output_dir, request_path, **kwargs):
+        request = json.loads(Path(request_path).read_text())
+        captured.update(module=module, num_gpus=num_gpus, output_dir=output_dir, request=request)
+        specs = image_specs_from_request(request)
+        for shard in plan_contiguous_shards(specs, num_gpus):
+            run_dense_image_shard(shard, loaded=rank_loaded, out_dir=Path(output_dir),
+                                  dense=_dense(), batch_size=2, num_workers=0)
+
+    monkeypatch.setattr(dense_image_stage, "run_torchrun_worker", _fake_run)
+    monkeypatch.setattr(dense_image_stage, "validate_multi_gpu_execution", lambda *a, **k: None)
+    monkeypatch.setattr(
+        dense_image_stage, "_run_dense_images_in_process",
+        lambda *a, **k: pytest.fail("num_gpus>1 must not encode in-process"),
+    )
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=Path("output"), num_gpus=3, precision="fp32")
+
+    artifacts = dense_image_stage.embed_images_dense(
+        model, _images(tmp_path, ["a", "b", "c"]), dense=_dense(), execution=execution
+    )
+
+    assert captured["module"] == "slide2vec.distributed.dense_image_worker"
+    assert captured["num_gpus"] == 3
+    expected_output_dir = (caller_dir / "output").resolve()
+    assert Path(captured["output_dir"]) == expected_output_dir
+    assert captured["request"]["dense"]["target_size"] == 64
+    assert [image["sample_id"] for image in captured["request"]["images"]] == ["a", "b", "c"]
+    assert all(Path(image["image_path"]).is_absolute() for image in captured["request"]["images"])
+    assert len(artifacts) == 3
+    assert (expected_output_dir / "dense_image_embeddings" / "a.pt").exists()
+
+
+def test_embed_images_dense_resume_skips_existing_and_logs(tmp_path, caplog):
+    """Resume: images already on disk are filtered before dispatch; the skip count is logged."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    dense_dir = tmp_path / "out" / "dense_image_embeddings"
+    first = _images(tmp_path, ["a", "b"])
+    dense_image_stage.embed_images_dense(model, first, dense=_dense(), execution=execution)
+    written_at = {
+        spec.sample_id: (dense_dir / f"{spec.sample_id}.pt").stat().st_mtime_ns for spec in first
+    }
+
+    with caplog.at_level("INFO", logger="slide2vec.runtime.dense_image_stage"):
+        artifacts = dense_image_stage.embed_images_dense(
+            model, _images(tmp_path, ["a", "b", "c"]), dense=_dense(), execution=execution
+        )
+
+    assert len(artifacts) == 3
+    assert "2/3 images already on disk, encoding 1" in caplog.text
+    for sample_id, mtime in written_at.items():
+        assert (dense_dir / f"{sample_id}.pt").stat().st_mtime_ns == mtime  # untouched
+
+
+def test_embed_images_dense_all_present_does_not_dispatch(tmp_path, monkeypatch):
+    """A fully-resumed run encodes nothing yet still returns every artifact."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    specs = _images(tmp_path, ["a", "b"])
+    dense_image_stage.embed_images_dense(model, specs, dense=_dense(), execution=execution)
+
+    monkeypatch.setattr(dense_image_stage, "_run_dense_images_in_process",
+                        lambda *a, **k: pytest.fail("nothing to encode"))
+    monkeypatch.setattr(dense_image_stage, "run_torchrun_worker",
+                        lambda **k: pytest.fail("nothing to encode"))
+    assert len(dense_image_stage.embed_images_dense(
+        model, specs, dense=_dense(), execution=execution)) == 2
+
+
+def test_embed_images_dense_rejects_duplicate_sample_ids(tmp_path):
+    """Two images sharing a sample id would silently overwrite one another's grid."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    specs = _images(tmp_path, ["a"])
+    duplicated = [*specs, ImageSpec(sample_id="a", image_path=tmp_path / "images" / "a.png")]
+
+    with pytest.raises(ValueError, match="duplicate sample_id"):
+        dense_image_stage.embed_images_dense(
+            model, duplicated, dense=_dense(), execution=execution
+        )
+
+
+def test_embed_images_dense_requires_at_least_one_image(tmp_path):
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    with pytest.raises(ValueError, match="At least one image"):
+        dense_image_stage.embed_images_dense(model, [], dense=_dense(), execution=execution)
+
+
+def test_dense_image_options_round_trip_through_the_request():
+    """Every dense knob crosses to the ranks, including a non-square target size."""
+    from slide2vec.runtime.serialization import (
+        deserialize_dense_image_options,
+        serialize_dense_image_options,
+    )
+
+    dense = DenseImageOptions(
+        target_size=(64, 96),
+        pad_mode="constant",
+        image_pad_value=0.5,
+        window_size=32,
+        overlap=0.25,
+        feature_kind="cls_attention",
+        attention_blocks=(-2, -1),
+        attention_include_registers=True,
+    )
+    payload = json.loads(json.dumps(serialize_dense_image_options(dense)))
+    assert deserialize_dense_image_options(payload) == dense
+
+
+def test_model_embed_images_dense_delegates_and_requires_output_dir(monkeypatch, tmp_path):
+    """The public API coerces execution, requires an output dir, and delegates to the stage."""
+    import slide2vec.runtime.dense_image_stage as stage_mod
+    from slide2vec.api import Model
+
+    seen: dict = {}
+
+    def _fake_stage(model, images, *, dense, execution):
+        seen.update(model=model, images=images, dense=dense, execution=execution)
+        return ["artifact"]
+
+    monkeypatch.setattr(stage_mod, "embed_images_dense", _fake_stage)
+    model = Model(name="virchow2")  # constructing a Model does not load weights
+    specs = [ImageSpec(sample_id="a", image_path=tmp_path / "a.png")]
+    dense = _dense(target_size=224)
+
+    with pytest.raises(ValueError):
+        model.embed_images_dense(specs, dense=dense, execution=ExecutionOptions(num_gpus=1))
+
+    result = model.embed_images_dense(
+        specs, dense=dense, execution=ExecutionOptions(output_dir=tmp_path, num_gpus=1)
+    )
+    assert result == ["artifact"]
+    assert seen["model"] is model
+    assert seen["dense"] is dense
+    assert seen["execution"].output_dir == tmp_path
+
+
+def test_declaring_the_dense_contract_rejects_a_geometry_the_encoder_cannot_take(tmp_path):
+    """The #233 capability check runs before any image is decoded: phikon is fixed-input."""
+    from slide2vec.api import Model
+
+    model = Model(name="phikon", device="cpu")
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+
+    with pytest.raises(ValueError, match="does not support a variable encoder input"):
+        dense_image_stage.embed_images_dense(
+            model, _images(tmp_path, ["a"]), dense=_dense(target_size=512), execution=execution
+        )
+
+
+def test_declared_dense_contract_accepts_a_non_square_image_geometry():
+    """A non-square declared geometry is checked per dimension, not rejected for not being
+    square — the padded image, not a transform-normalised square, is the encoder input."""
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    contract = EncoderInputContract.declared_dense(
+        "virchow2", target_size_px=(224, 448), window_size=None
+    )
+
+    assert contract.plan.target_size_px == (224, 448)
+    assert contract.plan.effective_encoder_input_size_px == (224, 448)
+    assert contract.plan.requires_variable_model_input is True
+
+
+def test_embed_images_dense_is_exported_from_the_package():
+    import slide2vec
+
+    assert "DenseImageOptions" in slide2vec.__all__
+    assert "DenseImageArtifact" in slide2vec.__all__
+    assert hasattr(slide2vec.Model, "embed_images_dense")
+
+
+def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
+    """The torchrun entry is near logic-free: env rank → shared shard planner → shard loop."""
+    import slide2vec.api as api
+    from slide2vec.distributed import dense_image_worker
+    from slide2vec.runtime.image_specs import build_image_specs_request
+    from slide2vec.runtime.serialization import (
+        serialize_dense_image_options,
+        serialize_execution,
+    )
+
+    specs = _images(tmp_path, ["a", "b", "c", "d"])
+    loaded = _loaded(_encoder())
+    declared: list = []
+
+    monkeypatch.setattr(
+        api.Model, "from_preset",
+        classmethod(lambda cls, name, **kwargs: SimpleNamespace(
+            _declare_dense_encoder_input=lambda dense, *, emit_run_info: declared.append(dense),
+            _load_backend=lambda: (declared and loaded) or pytest.fail("must declare first"),
+        )),
+    )
+
+    request = {
+        "model": {"name": "fake", "output_variant": None, "allow_non_recommended_settings": False},
+        "dense": serialize_dense_image_options(_dense()),
+        "execution": serialize_execution(
+            ExecutionOptions(output_dir=tmp_path / "out", num_gpus=2, precision="fp32", batch_size=2)
+        ),
+        "output_dir": str(tmp_path / "out"),
+        "progress_events_path": None,
+        **build_image_specs_request(specs),
+    }
+    request_path = tmp_path / "dense_image_request.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+
+    rc = dense_image_worker.main(
+        ["--output-dir", str(tmp_path / "out"), "--request-path", str(request_path)]
+    )
+
+    assert rc == 0
+    assert declared, "each rank declares the dense contract for itself"
+    # World of 2 ranks: plan_contiguous_shards([a,b,c,d], 2) => rank 1 owns [c, d].
+    dense_dir = tmp_path / "out" / "dense_image_embeddings"
+    assert sorted(p.name for p in dense_dir.glob("*.pt")) == ["c.pt", "d.pt"]

--- a/tests/test_image_stage.py
+++ b/tests/test_image_stage.py
@@ -23,7 +23,7 @@ from PIL import Image  # noqa: E402
 
 from slide2vec.api import ExecutionOptions, ImageSpec  # noqa: E402
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
-from slide2vec.runtime import image_stage  # noqa: E402
+from slide2vec.runtime import image_specs, image_stage  # noqa: E402
 from slide2vec.runtime.types import LoadedModel  # noqa: E402
 
 
@@ -111,7 +111,7 @@ def test_embed_images_num_gpus_gt_one_launches_image_worker(tmp_path, monkeypatc
     def _fake_run(*, module, num_gpus, output_dir, request_path, **kwargs):
         request = json.loads(Path(request_path).read_text())
         captured.update(module=module, num_gpus=num_gpus, output_dir=output_dir, request=request)
-        specs = image_stage.image_specs_from_request(request)
+        specs = image_specs.image_specs_from_request(request)
         for shard in plan_contiguous_shards(specs, num_gpus):
             run_image_shard(shard, loaded=rank_loaded, out_dir=Path(output_dir), batch_size=2,
                             output_precision="fp32", num_workers=0)
@@ -195,8 +195,8 @@ def test_image_specs_round_trip_through_request(tmp_path):
         ImageSpec(sample_id="a", image_path="/data/a.png"),
         ImageSpec(sample_id="b", image_path="/data/nested/b.tif"),
     ]
-    request = image_stage.build_image_worker_request(specs)
-    assert image_stage.image_specs_from_request(request) == specs
+    request = image_specs.build_image_specs_request(specs)
+    assert image_specs.image_specs_from_request(request) == specs
 
 
 def test_model_embed_images_delegates_and_requires_output_dir(monkeypatch, tmp_path):
@@ -289,7 +289,7 @@ def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
         ),
         "output_dir": str(tmp_path / "out"),
         "progress_events_path": None,
-        **image_stage.build_image_worker_request(specs),
+        **image_specs.build_image_specs_request(specs),
     }
     request_path = tmp_path / "image_request.json"
     request_path.write_text(json.dumps(request), encoding="utf-8")


### PR DESCRIPTION
Closes #235

## What

`Model.embed_images_dense(images, dense=DenseImageOptions(...), execution=...)` — the image-sourced counterpart of `embed_regions_dense`. An `ImageSpec` list in, one `(d, gh, gw)` grid plus a geometry sidecar per image out, sharded across visible GPUs, resume-aware, payload written atomically with the sidecar last as the done-marker. Artifacts land in `dense_image_embeddings/<sample_id>.pt`.

It differs from the ROI path in exactly one respect — no slide, no coordinate, no spacing→level plan, because the image *is* the region.

## Why

Dense extraction covered slide ROIs only, so consumers whose supervision arrives as image/mask pairs (segmentation, detection) had no public entry point and kept their own dense engine on top of internal APIs: `iter_regions_dense` is slide- and `TilingResult`-driven, so the pieces got reassembled downstream from `encode_tiles_dense` + `get_normalization_transform` + hand-rolled padding and batching.

## Reuse, not duplication

- `DenseGridEncoder` (new, in `runtime/dense_regions.py`) holds the encode recipe both dense sources share — geometry, normalization-only transform, bottom/right padding, whole-tile vs sliding encode through `encode_dense_sliding`, output dtype. `iter_regions_dense` now runs on it too, so there is one implementation, not two.
- `runtime/image_specs.py` (new) holds the flat list of caller-named image files, its duplicate-id check and its worker request, shared with the pooled image path from #234.
- `artifacts._write_dense_grid` backs both dense writers (payload via `write_atomically`, then the sidecar).
- Reused as they stand: `sharding.plan_contiguous_shards`, `runtime/distributed`'s torchrun launcher and coordination dir, `distributed/worker_entry.py`, `preprocessing.apply_transforms_itemwise`, `batching.dataloader_kwargs`.

## target_size is a declaration, not a resize

The run states the geometry its grids register to; that geometry goes through the #233 effective-encoder-input check before any image is decoded, and an image of another size raises naming it (per item, while stacking) rather than being silently rescaled. A dataset whose images differ in size is therefore several runs — which is also the only way their grids could be batched downstream.

The declaration accepts a non-square `(h, w)` pair, since here the image is the region and need not be square; `DenseEncoderInputPlan.target_size_px` now states the supervision geometry as a pair for both dense sources. The square-only recorder `_record_encoder_input_size` does not constrain this path: it lives behind `encode_tiles` in the pooled forward loop, which dense never calls.

## Tests

`tests/test_dense_image_shard.py` + `tests/test_dense_image_stage.py`, both CPU-only with a random-weight encoder. The anchor test pins each persisted grid against the direct composition of `compute_dense_geometry` + `encode_dense_sliding`, bit-identical, parametrized over both `feature_kind` values × whole-tile/sliding at a fixed batch size and dtype. Suite: 632 passed, 26 heavy deselected.