### PR TITLE
Prepare slide coordinates through encoder hooks

### DIFF
--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -385,6 +385,16 @@ class Encoder(ABC):
         """Move encoder to the given device. Returns self."""
         ...
 
+    def prepare_coordinates(
+        self,
+        coordinates: Tensor,
+        *,
+        base_spacing_um: float,
+        requested_spacing_um: float,
+    ) -> Tensor:
+        """Hook for model-specific coordinate normalization."""
+        return coordinates
+
 
 class TileEncoder(Encoder):
     """Base class for encoders that operate directly on image tiles."""
@@ -494,16 +504,6 @@ class SlideEncoder(Encoder):
     ) -> Tensor:
         """Pool tile-level features into a single slide-level embedding."""
         ...
-
-    def prepare_coordinates(
-        self,
-        coordinates: Tensor,
-        *,
-        base_spacing_um: float,
-        requested_spacing_um: float,
-    ) -> Tensor:
-        """Hook for model-specific coordinate normalization."""
-        return coordinates
 
 
 class PatientEncoder(Encoder):

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -15,7 +15,6 @@ import pandas as pd
 import torch
 from hs2p import SlideSpec, tile_slides
 from hs2p.utils.stderr import run_with_filtered_stderr
-import numpy as np
 
 from slide2vec.runtime import (
     artifacts_collect,
@@ -69,7 +68,6 @@ from slide2vec.progress import (
     emit_progress,
     read_tiling_progress_snapshot,
 )
-from slide2vec.utils.coordinates import coordinate_arrays
 from slide2vec.utils.log_utils import suppress_c_stderr
 from slide2vec.data.dataset import BatchTileCollator, TileIndexDataset
 from slide2vec.data.tile_reader import OnTheFlyBatchTileCollator, OnTheFlyHierarchicalBatchCollator
@@ -724,27 +722,15 @@ def aggregate_tiles(
             Path(metadata["coordinates_npz_path"]),
             Path(metadata["coordinates_meta_path"]),
         )
-        x_values, y_values = coordinate_arrays(tiling_result)
-        coordinates = np.column_stack((x_values, y_values))
-        image_path = Path(metadata["image_path"])
-        if model.name == "prov-gigapath":
-            coordinates = tiling.scale_coordinates(
-                coordinates,
-                float(tiling_result.base_spacing_um),
-                float(tiling_result.requested_spacing_um),
-            )
-        coordinate_tensor = torch.tensor(coordinates, dtype=torch.int, device=loaded.device)
         tile_features = load_array(artifact.path)
         if not torch.is_tensor(tile_features):
             tile_features = torch.as_tensor(tile_features)
-        tile_features = tile_features.to(loaded.device)
-        with slide_encode.slide_encode_autocast_ctx(loaded.device, execution.precision):
-            with torch.inference_mode():
-                slide_embedding = loaded.model.encode_slide(
-                    tile_features,
-                    coordinate_tensor,
-                    tile_size_lv0=int(tiling_result.tile_size_lv0),
-                )
+        slide_embedding = slide_encode.encode_slide_from_tiles(
+            loaded,
+            tile_features,
+            tiling_result,
+            execution=execution,
+        )
         latents = None
         slide_artifact = embedding.write_slide_embedding_artifact(
             artifact.sample_id,

--- a/slide2vec/runtime/embedding_pipeline.py
+++ b/slide2vec/runtime/embedding_pipeline.py
@@ -30,11 +30,12 @@ from slide2vec.runtime.hierarchical import (
     num_tiles,
     resolve_hierarchical_geometry,
 )
-from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
+from slide2vec.runtime.slide_encode import encode_slide_from_tiles
+from slide2vec.runtime.tiling import resolve_slide_backend, resolve_tile_store_archive_for_slide
 from slide2vec.runtime.types import LoadedModel
 from slide2vec.runtime.worker_io import configure_cucim_worker_stderr, uses_cuda_runtime
-from slide2vec.runtime.tiling import resolve_slide_backend, resolve_tile_store_archive_for_slide, scale_coordinates
-from slide2vec.utils.coordinates import coordinate_arrays
+
+
 def aggregate_tile_embeddings_for_slide(
     loaded: LoadedModel,
     model,
@@ -48,25 +49,14 @@ def aggregate_tile_embeddings_for_slide(
     if model.level != "slide":
         return None, None
 
-    x_values, y_values = coordinate_arrays(tiling_result)
-    coordinates = np.column_stack((x_values, y_values))
-    if model.name == "prov-gigapath":
-        coordinates = scale_coordinates(
-            coordinates,
-            float(tiling_result.base_spacing_um),
-            float(tiling_result.requested_spacing_um),
-        )
-    coordinate_tensor = torch.tensor(coordinates, dtype=torch.int, device=loaded.device)
     if not torch.is_tensor(tile_embeddings):
         tile_embeddings = torch.as_tensor(tile_embeddings)
-    features = tile_embeddings.to(loaded.device)
-    with slide_encode_autocast_ctx(loaded.device, execution.precision):
-        with torch.inference_mode():
-            slide_embedding = loaded.model.encode_slide(
-                features,
-                coordinate_tensor,
-                tile_size_lv0=int(tiling_result.tile_size_lv0),
-            ).detach().cpu()
+    slide_embedding = encode_slide_from_tiles(
+        loaded,
+        tile_embeddings,
+        tiling_result,
+        execution=execution,
+    )
     latents = None
     return slide_embedding, latents
 

--- a/slide2vec/runtime/slide_encode.py
+++ b/slide2vec/runtime/slide_encode.py
@@ -32,7 +32,7 @@ def encode_slide_from_tiles(
     """
     x_values, y_values = coordinate_arrays(tiling_result)
     coordinates = np.column_stack((x_values, y_values))
-    coordinate_tensor = torch.tensor(coordinates, dtype=torch.long, device=loaded.device)
+    coordinate_tensor = torch.tensor(coordinates, dtype=torch.int, device=loaded.device)
     coordinate_tensor = loaded.model.prepare_coordinates(
         coordinate_tensor,
         base_spacing_um=float(tiling_result.base_spacing_um),

--- a/slide2vec/runtime/slide_encode.py
+++ b/slide2vec/runtime/slide_encode.py
@@ -32,7 +32,12 @@ def encode_slide_from_tiles(
     """
     x_values, y_values = coordinate_arrays(tiling_result)
     coordinates = np.column_stack((x_values, y_values))
-    coordinate_tensor = torch.tensor(coordinates, dtype=torch.int, device=loaded.device)
+    coordinate_tensor = torch.tensor(coordinates, dtype=torch.long, device=loaded.device)
+    coordinate_tensor = loaded.model.prepare_coordinates(
+        coordinate_tensor,
+        base_spacing_um=float(tiling_result.base_spacing_um),
+        requested_spacing_um=float(tiling_result.requested_spacing_um),
+    )
     features = tile_embeddings.to(loaded.device)
     with slide_encode_autocast_ctx(loaded.device, None if execution is None else execution.precision):
         with torch.inference_mode():

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -1265,6 +1265,7 @@ def test_aggregate_tiles_uses_autocast_for_slide_encoding(monkeypatch, tmp_path:
             x=np.array([0], dtype=np.int64),
             y=np.array([1], dtype=np.int64),
             tile_size_lv0=224,
+            base_spacing_um=0.25,
             requested_spacing_um=0.5,
         ),
     )
@@ -1284,7 +1285,13 @@ def test_aggregate_tiles_uses_autocast_for_slide_encoding(monkeypatch, tmp_path:
         captured["latents"] = latents
         return SimpleNamespace(sample_id=sample_id, path=tmp_path / "slide_embeddings" / f"{sample_id}.pt")
 
-    loaded = SimpleNamespace(device=torch.device("cpu"), model=SimpleNamespace(encode_slide=encode_slide))
+    loaded = SimpleNamespace(
+        device=torch.device("cpu"),
+        model=SimpleNamespace(
+            encode_slide=encode_slide,
+            prepare_coordinates=lambda coordinates, **_spacings: coordinates,
+        ),
+    )
     model = SimpleNamespace(
         name="prism",
         level="slide",
@@ -1343,13 +1350,21 @@ def test_aggregate_tile_embeddings_for_slide_uses_autocast(monkeypatch, tmp_path
     monkeypatch.setattr(slide_encode, "autocast_dtype", lambda torch_module, precision: torch_module.float16)
     monkeypatch.setattr(slide_encode, "uses_cuda_runtime", lambda device: True)
 
-    loaded = SimpleNamespace(device=torch.device("cpu"), model=SimpleNamespace(encode_slide=encode_slide))
+    loaded = SimpleNamespace(
+        device=torch.device("cpu"),
+        model=SimpleNamespace(
+            encode_slide=encode_slide,
+            prepare_coordinates=lambda coordinates, **_spacings: coordinates,
+        ),
+    )
     model = SimpleNamespace(level="slide", name="prism")
     slide = make_slide("slide-a")
     tiling_result = SimpleNamespace(
         x=np.array([0], dtype=np.int64),
         y=np.array([1], dtype=np.int64),
         tile_size_lv0=224,
+        base_spacing_um=0.25,
+        requested_spacing_um=0.5,
     )
     tile_embeddings = np.ones((1, 4), dtype=np.float32)
 

--- a/tests/test_slide_coordinate_preparation.py
+++ b/tests/test_slide_coordinate_preparation.py
@@ -18,22 +18,7 @@ from slide2vec.runtime import (
 )
 
 
-class CapturingGigaPathEncoder(GigaPathSlideEncoder):
-    def __init__(self) -> None:
-        self.coordinates: torch.Tensor | None = None
-
-    def encode_slide(
-        self,
-        tile_features: torch.Tensor,
-        coordinates: torch.Tensor | None = None,
-        *,
-        tile_size_lv0: int | None = None,
-    ) -> torch.Tensor:
-        self.coordinates = coordinates
-        return torch.zeros(4)
-
-
-class CapturingPatientEncoder(PatientEncoder):
+class CapturingSlideEncoderMixin:
     def __init__(self) -> None:
         self.coordinates: torch.Tensor | None = None
 
@@ -45,7 +30,7 @@ class CapturingPatientEncoder(PatientEncoder):
     def device(self) -> torch.device:
         return torch.device("cpu")
 
-    def to(self, device: torch.device | str) -> "CapturingPatientEncoder":
+    def to(self, device: torch.device | str) -> "CapturingSlideEncoderMixin":
         return self
 
     def encode_slide(
@@ -58,41 +43,22 @@ class CapturingPatientEncoder(PatientEncoder):
         self.coordinates = coordinates
         return torch.zeros(4)
 
+
+class CapturingGigaPathEncoder(CapturingSlideEncoderMixin, GigaPathSlideEncoder):
+    pass
+
+
+class CapturingPatientEncoder(CapturingSlideEncoderMixin, PatientEncoder):
     def encode_patient(self, slide_embeddings: torch.Tensor) -> torch.Tensor:
         return slide_embeddings.mean(dim=0)
 
 
-class CapturingIdentitySlideEncoder(SlideEncoder):
-    def __init__(self) -> None:
-        self.coordinates: torch.Tensor | None = None
-
-    @property
-    def encode_dim(self) -> int:
-        return 4
-
-    @property
-    def device(self) -> torch.device:
-        return torch.device("cpu")
-
-    def to(self, device: torch.device | str) -> "CapturingIdentitySlideEncoder":
-        return self
-
-    def encode_slide(
-        self,
-        tile_features: torch.Tensor,
-        coordinates: torch.Tensor | None = None,
-        *,
-        tile_size_lv0: int | None = None,
-    ) -> torch.Tensor:
-        self.coordinates = coordinates
-        return torch.zeros(4)
+class CapturingIdentitySlideEncoder(CapturingSlideEncoderMixin, SlideEncoder):
+    pass
 
 
-def test_direct_slide_aggregation_prepares_gigapath_coordinates() -> None:
-    encoder = CapturingGigaPathEncoder()
-    loaded = SimpleNamespace(device=torch.device("cpu"), model=encoder)
-    model = SimpleNamespace(level="slide", name="gigapath-slide")
-    tiling_result = SimpleNamespace(
+def make_tiling_result() -> SimpleNamespace:
+    return SimpleNamespace(
         x=np.array([0, 512], dtype=np.int64),
         y=np.array([0, 1024], dtype=np.int64),
         tile_size_lv0=512,
@@ -100,11 +66,17 @@ def test_direct_slide_aggregation_prepares_gigapath_coordinates() -> None:
         requested_spacing_um=0.5,
     )
 
+
+def test_direct_slide_aggregation_prepares_gigapath_coordinates() -> None:
+    encoder = CapturingGigaPathEncoder()
+    loaded = SimpleNamespace(device=torch.device("cpu"), model=encoder)
+    model = SimpleNamespace(level="slide", name="gigapath-slide")
+
     embedding_pipeline.aggregate_tile_embeddings_for_slide(
         loaded,
         model,
         SimpleNamespace(sample_id="slide-a", image_path=Path("slide-a.svs")),
-        tiling_result,
+        make_tiling_result(),
         torch.ones((2, 4)),
         preprocessing=PreprocessingConfig(
             requested_spacing_um=0.5,
@@ -131,13 +103,6 @@ def test_patient_pipeline_uses_shared_coordinate_preparation(
         _declare_encoder_input=lambda *_args, **_kwargs: None,
         _load_backend=lambda: loaded,
     )
-    tiling_result = SimpleNamespace(
-        x=np.array([0, 512], dtype=np.int64),
-        y=np.array([0, 1024], dtype=np.int64),
-        tile_size_lv0=512,
-        base_spacing_um=0.25,
-        requested_spacing_um=0.5,
-    )
     monkeypatch.setattr(
         patient_pipeline,
         "compute_tile_embeddings_for_slide",
@@ -158,7 +123,7 @@ def test_patient_pipeline_uses_shared_coordinate_preparation(
                 mask_path=None,
             )
         ],
-        embeddable_tiling_results=[tiling_result],
+        embeddable_tiling_results=[make_tiling_result()],
         patient_id_map={"slide-a": "patient-a"},
         preprocessing=PreprocessingConfig(
             requested_spacing_um=0.5,
@@ -170,8 +135,9 @@ def test_patient_pipeline_uses_shared_coordinate_preparation(
 
     assert torch.equal(
         encoder.coordinates,
-        torch.tensor([[0, 0], [512, 1024]], dtype=torch.long),
+        torch.tensor([[0, 0], [512, 1024]], dtype=torch.int),
     )
+    assert encoder.coordinates.dtype == torch.int
 
 
 def test_distributed_slide_aggregation_uses_shared_coordinate_preparation(
@@ -190,13 +156,7 @@ def test_distributed_slide_aggregation_uses_shared_coordinate_preparation(
         image_path=tmp_path / "slide-a.svs",
         mask_path=None,
     )
-    tiling_result = SimpleNamespace(
-        x=np.array([0, 512], dtype=np.int64),
-        y=np.array([0, 1024], dtype=np.int64),
-        tile_size_lv0=512,
-        base_spacing_um=0.25,
-        requested_spacing_um=0.5,
-    )
+    tiling_result = make_tiling_result()
 
     @contextmanager
     def fake_coordination_dir(_work_dir: Path):
@@ -241,19 +201,12 @@ def test_non_gigapath_slide_aggregation_retains_coordinates_with_base_identity_h
     encoder = CapturingIdentitySlideEncoder()
     loaded = SimpleNamespace(device=torch.device("cpu"), model=encoder)
     model = SimpleNamespace(level="slide", name="identity-slide")
-    tiling_result = SimpleNamespace(
-        x=np.array([0, 512], dtype=np.int64),
-        y=np.array([0, 1024], dtype=np.int64),
-        tile_size_lv0=512,
-        base_spacing_um=0.25,
-        requested_spacing_um=0.5,
-    )
 
     embedding_pipeline.aggregate_tile_embeddings_for_slide(
         loaded,
         model,
         SimpleNamespace(sample_id="slide-a", image_path=Path("slide-a.svs")),
-        tiling_result,
+        make_tiling_result(),
         torch.ones((2, 4)),
         preprocessing=PreprocessingConfig(
             requested_spacing_um=0.5,
@@ -264,8 +217,9 @@ def test_non_gigapath_slide_aggregation_retains_coordinates_with_base_identity_h
 
     assert torch.equal(
         encoder.coordinates,
-        torch.tensor([[0, 0], [512, 1024]], dtype=torch.long),
+        torch.tensor([[0, 0], [512, 1024]], dtype=torch.int),
     )
+    assert encoder.coordinates.dtype == torch.int
 
 
 def test_persisted_tile_aggregation_prepares_gigapath_coordinates(
@@ -279,13 +233,7 @@ def test_persisted_tile_aggregation_prepares_gigapath_coordinates(
         name="gigapath-slide",
         _load_backend_without_transform=lambda: loaded,
     )
-    tiling_result = SimpleNamespace(
-        x=np.array([0, 512], dtype=np.int64),
-        y=np.array([0, 1024], dtype=np.int64),
-        tile_size_lv0=512,
-        base_spacing_um=0.25,
-        requested_spacing_um=0.5,
-    )
+    tiling_result = make_tiling_result()
     monkeypatch.setattr(tiling, "load_tiling_result_from_paths", lambda *_args: tiling_result)
     monkeypatch.setattr(inference, "load_array", lambda _path: torch.ones((2, 4)))
     monkeypatch.setattr(

--- a/tests/test_slide_coordinate_preparation.py
+++ b/tests/test_slide_coordinate_preparation.py
@@ -1,0 +1,315 @@
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+import slide2vec.inference as inference
+from slide2vec.api import ExecutionOptions, PreprocessingConfig
+from slide2vec.encoders.base import PatientEncoder, SlideEncoder
+from slide2vec.encoders.models.gigapath import GigaPathSlideEncoder
+from slide2vec.runtime import (
+    distributed_stage,
+    embedding,
+    embedding_pipeline,
+    patient_pipeline,
+    tiling,
+)
+
+
+class CapturingGigaPathEncoder(GigaPathSlideEncoder):
+    def __init__(self) -> None:
+        self.coordinates: torch.Tensor | None = None
+
+    def encode_slide(
+        self,
+        tile_features: torch.Tensor,
+        coordinates: torch.Tensor | None = None,
+        *,
+        tile_size_lv0: int | None = None,
+    ) -> torch.Tensor:
+        self.coordinates = coordinates
+        return torch.zeros(4)
+
+
+class CapturingPatientEncoder(PatientEncoder):
+    def __init__(self) -> None:
+        self.coordinates: torch.Tensor | None = None
+
+    @property
+    def encode_dim(self) -> int:
+        return 4
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cpu")
+
+    def to(self, device: torch.device | str) -> "CapturingPatientEncoder":
+        return self
+
+    def encode_slide(
+        self,
+        tile_features: torch.Tensor,
+        coordinates: torch.Tensor | None = None,
+        *,
+        tile_size_lv0: int | None = None,
+    ) -> torch.Tensor:
+        self.coordinates = coordinates
+        return torch.zeros(4)
+
+    def encode_patient(self, slide_embeddings: torch.Tensor) -> torch.Tensor:
+        return slide_embeddings.mean(dim=0)
+
+
+class CapturingIdentitySlideEncoder(SlideEncoder):
+    def __init__(self) -> None:
+        self.coordinates: torch.Tensor | None = None
+
+    @property
+    def encode_dim(self) -> int:
+        return 4
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cpu")
+
+    def to(self, device: torch.device | str) -> "CapturingIdentitySlideEncoder":
+        return self
+
+    def encode_slide(
+        self,
+        tile_features: torch.Tensor,
+        coordinates: torch.Tensor | None = None,
+        *,
+        tile_size_lv0: int | None = None,
+    ) -> torch.Tensor:
+        self.coordinates = coordinates
+        return torch.zeros(4)
+
+
+def test_direct_slide_aggregation_prepares_gigapath_coordinates() -> None:
+    encoder = CapturingGigaPathEncoder()
+    loaded = SimpleNamespace(device=torch.device("cpu"), model=encoder)
+    model = SimpleNamespace(level="slide", name="gigapath-slide")
+    tiling_result = SimpleNamespace(
+        x=np.array([0, 512], dtype=np.int64),
+        y=np.array([0, 1024], dtype=np.int64),
+        tile_size_lv0=512,
+        base_spacing_um=0.25,
+        requested_spacing_um=0.5,
+    )
+
+    embedding_pipeline.aggregate_tile_embeddings_for_slide(
+        loaded,
+        model,
+        SimpleNamespace(sample_id="slide-a", image_path=Path("slide-a.svs")),
+        tiling_result,
+        torch.ones((2, 4)),
+        preprocessing=PreprocessingConfig(
+            requested_spacing_um=0.5,
+            requested_tile_size_px=512,
+        ),
+        execution=ExecutionOptions(precision="fp32"),
+    )
+
+    assert torch.equal(
+        encoder.coordinates,
+        torch.tensor([[0, 0], [256, 512]], dtype=torch.long),
+    )
+
+
+def test_patient_pipeline_uses_shared_coordinate_preparation(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    encoder = CapturingPatientEncoder()
+    loaded = SimpleNamespace(device=torch.device("cpu"), model=encoder)
+    model = SimpleNamespace(
+        level="patient",
+        name="identity-patient",
+        _declare_encoder_input=lambda *_args, **_kwargs: None,
+        _load_backend=lambda: loaded,
+    )
+    tiling_result = SimpleNamespace(
+        x=np.array([0, 512], dtype=np.int64),
+        y=np.array([0, 1024], dtype=np.int64),
+        tile_size_lv0=512,
+        base_spacing_um=0.25,
+        requested_spacing_um=0.5,
+    )
+    monkeypatch.setattr(
+        patient_pipeline,
+        "compute_tile_embeddings_for_slide",
+        lambda *_args, **_kwargs: torch.ones((2, 4)),
+    )
+    monkeypatch.setattr(
+        patient_pipeline,
+        "write_patient_embeddings",
+        lambda patient_id, *_args, **_kwargs: SimpleNamespace(patient_id=patient_id),
+    )
+
+    patient_pipeline.run_patient_pipeline(
+        model,
+        embeddable_slides=[
+            SimpleNamespace(
+                sample_id="slide-a",
+                image_path=tmp_path / "slide-a.svs",
+                mask_path=None,
+            )
+        ],
+        embeddable_tiling_results=[tiling_result],
+        patient_id_map={"slide-a": "patient-a"},
+        preprocessing=PreprocessingConfig(
+            requested_spacing_um=0.5,
+            requested_tile_size_px=512,
+        ),
+        execution=ExecutionOptions(output_dir=tmp_path, precision="fp32"),
+        output_dir=tmp_path,
+    )
+
+    assert torch.equal(
+        encoder.coordinates,
+        torch.tensor([[0, 0], [512, 1024]], dtype=torch.long),
+    )
+
+
+def test_distributed_slide_aggregation_uses_shared_coordinate_preparation(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    encoder = CapturingGigaPathEncoder()
+    loaded = SimpleNamespace(device=torch.device("cpu"), model=encoder)
+    model = SimpleNamespace(
+        level="slide",
+        name="gigapath-slide",
+        _load_backend_without_transform=lambda: loaded,
+    )
+    slide = SimpleNamespace(
+        sample_id="slide-a",
+        image_path=tmp_path / "slide-a.svs",
+        mask_path=None,
+    )
+    tiling_result = SimpleNamespace(
+        x=np.array([0, 512], dtype=np.int64),
+        y=np.array([0, 1024], dtype=np.int64),
+        tile_size_lv0=512,
+        base_spacing_um=0.25,
+        requested_spacing_um=0.5,
+    )
+
+    @contextmanager
+    def fake_coordination_dir(_work_dir: Path):
+        yield tmp_path / "coordination"
+
+    monkeypatch.setattr(distributed_stage, "distributed_coordination_dir", fake_coordination_dir)
+    monkeypatch.setattr(
+        distributed_stage,
+        "run_distributed_direct_embedding_stage",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        distributed_stage,
+        "load_tile_embedding_shards",
+        lambda *_args, **_kwargs: [
+            {
+                "tile_index": np.array([0, 1], dtype=np.int64),
+                "tile_embeddings": np.ones((2, 4), dtype=np.float32),
+            }
+        ],
+    )
+
+    distributed_stage.embed_single_slide_distributed(
+        model,
+        slide=slide,
+        tiling_result=tiling_result,
+        preprocessing=PreprocessingConfig(
+            requested_spacing_um=0.5,
+            requested_tile_size_px=512,
+        ),
+        execution=ExecutionOptions(num_gpus=2, precision="fp32"),
+        work_dir=tmp_path,
+    )
+
+    assert torch.equal(
+        encoder.coordinates,
+        torch.tensor([[0, 0], [256, 512]], dtype=torch.long),
+    )
+
+
+def test_non_gigapath_slide_aggregation_retains_coordinates_with_base_identity_hook() -> None:
+    encoder = CapturingIdentitySlideEncoder()
+    loaded = SimpleNamespace(device=torch.device("cpu"), model=encoder)
+    model = SimpleNamespace(level="slide", name="identity-slide")
+    tiling_result = SimpleNamespace(
+        x=np.array([0, 512], dtype=np.int64),
+        y=np.array([0, 1024], dtype=np.int64),
+        tile_size_lv0=512,
+        base_spacing_um=0.25,
+        requested_spacing_um=0.5,
+    )
+
+    embedding_pipeline.aggregate_tile_embeddings_for_slide(
+        loaded,
+        model,
+        SimpleNamespace(sample_id="slide-a", image_path=Path("slide-a.svs")),
+        tiling_result,
+        torch.ones((2, 4)),
+        preprocessing=PreprocessingConfig(
+            requested_spacing_um=0.5,
+            requested_tile_size_px=512,
+        ),
+        execution=ExecutionOptions(precision="fp32"),
+    )
+
+    assert torch.equal(
+        encoder.coordinates,
+        torch.tensor([[0, 0], [512, 1024]], dtype=torch.long),
+    )
+
+
+def test_persisted_tile_aggregation_prepares_gigapath_coordinates(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    encoder = CapturingGigaPathEncoder()
+    loaded = SimpleNamespace(device=torch.device("cpu"), model=encoder)
+    model = SimpleNamespace(
+        level="slide",
+        name="gigapath-slide",
+        _load_backend_without_transform=lambda: loaded,
+    )
+    tiling_result = SimpleNamespace(
+        x=np.array([0, 512], dtype=np.int64),
+        y=np.array([0, 1024], dtype=np.int64),
+        tile_size_lv0=512,
+        base_spacing_um=0.25,
+        requested_spacing_um=0.5,
+    )
+    monkeypatch.setattr(tiling, "load_tiling_result_from_paths", lambda *_args: tiling_result)
+    monkeypatch.setattr(inference, "load_array", lambda _path: torch.ones((2, 4)))
+    monkeypatch.setattr(
+        embedding,
+        "write_slide_embedding_artifact",
+        lambda sample_id, *_args, **_kwargs: SimpleNamespace(sample_id=sample_id),
+    )
+    artifact = SimpleNamespace(
+        sample_id="slide-a",
+        path=tmp_path / "slide-a.tiles.h5",
+        metadata={
+            "coordinates_npz_path": str(tmp_path / "slide-a.coordinates.npz"),
+            "coordinates_meta_path": str(tmp_path / "slide-a.coordinates.meta.json"),
+            "image_path": str(tmp_path / "slide-a.svs"),
+        },
+    )
+
+    inference.aggregate_tiles(
+        model,
+        [artifact],
+        execution=ExecutionOptions(output_dir=tmp_path, precision="fp32"),
+    )
+
+    assert torch.equal(
+        encoder.coordinates,
+        torch.tensor([[0, 0], [256, 512]], dtype=torch.long),
+    )


### PR DESCRIPTION
## Summary

- route all tile-to-slide aggregation through the loaded encoder's coordinate-preparation hook
- let GigaPath scale level-0 coordinates by base spacing / requested spacing while preserving identity behavior for other encoders
- cover direct, persisted-artifact, patient, and distributed aggregation routes

## Tests

- `python -m pytest -q tests/test_slide_coordinate_preparation.py --no-cov`
- `python -m pytest -q tests/test_slide_coordinate_preparation.py tests/test_regression_inference.py tests/test_encoder_input_contract.py --no-cov`

Closes #244