### PR TITLE
Validate patient manifest identifiers

### DIFF
--- a/docs/manifest.rst
+++ b/docs/manifest.rst
@@ -61,6 +61,9 @@ to group slides that belong to the same patient:
 Slides sharing the same ``patient_id`` are aggregated into a single
 :class:`~slide2vec.EmbeddedPatient` by the model's patient encoder.
 ``sample_id`` remains the unique slide identifier.
+Both identifier columns are read as text, so values such as ``0007`` retain
+their leading zeros. Every ``patient_id`` must be non-empty after surrounding
+whitespace is ignored; invalid rows are rejected before tiling begins.
 
 
 Per-slide embeddings

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -752,7 +752,7 @@ def run_pipeline(
     tiling_only: bool = False,
     execution: ExecutionOptions,
 ) -> RunResult:
-    if model.level == "patient" and not tiling_only:
+    if model.level == "patient":
         patient_id_map = manifest.resolve_patient_id_map(slides=slides, manifest_path=manifest_path)
     else:
         patient_id_map = None

--- a/slide2vec/utils/tiling_io.py
+++ b/slide2vec/utils/tiling_io.py
@@ -116,7 +116,7 @@ def _optional_float(value: Any) -> float | None:
 
 def load_slide_manifest(csv_path: str | Path) -> list[SlideSpec]:
     manifest_path = Path(csv_path).resolve()
-    df = pd.read_csv(manifest_path, dtype={"sample_id": "string"})
+    df = pd.read_csv(manifest_path, converters={"sample_id": str})
     legacy_mask_columns = sorted(
         column for column in ("tissue_mask_path", "annotation_mask_path") if column in df.columns
     )
@@ -167,7 +167,7 @@ def load_patient_id_mapping(csv_path: str | Path) -> dict[str, str]:
     manifest_path = Path(csv_path).resolve()
     df = pd.read_csv(
         manifest_path,
-        dtype={"sample_id": "string", "patient_id": "string"},
+        converters={"sample_id": str, "patient_id": str},
     )
     if "patient_id" not in df.columns:
         raise ValueError(

--- a/slide2vec/utils/tiling_io.py
+++ b/slide2vec/utils/tiling_io.py
@@ -116,7 +116,7 @@ def _optional_float(value: Any) -> float | None:
 
 def load_slide_manifest(csv_path: str | Path) -> list[SlideSpec]:
     manifest_path = Path(csv_path).resolve()
-    df = pd.read_csv(manifest_path)
+    df = pd.read_csv(manifest_path, dtype={"sample_id": "string"})
     legacy_mask_columns = sorted(
         column for column in ("tissue_mask_path", "annotation_mask_path") if column in df.columns
     )
@@ -165,14 +165,25 @@ def load_patient_id_mapping(csv_path: str | Path) -> dict[str, str]:
     Raises ValueError if the 'patient_id' column is absent.
     """
     manifest_path = Path(csv_path).resolve()
-    df = pd.read_csv(manifest_path)
+    df = pd.read_csv(
+        manifest_path,
+        dtype={"sample_id": "string", "patient_id": "string"},
+    )
     if "patient_id" not in df.columns:
         raise ValueError(
             f"Input CSV {manifest_path} is missing the required 'patient_id' column "
             "for patient-level models. Add a 'patient_id' column that groups slides "
             "belonging to the same patient."
         )
-    return dict(zip(df["sample_id"].astype(str), df["patient_id"].astype(str)))
+    patient_ids = df["patient_id"]
+    invalid_patient_ids = patient_ids.fillna("").str.strip().eq("")
+    if invalid_patient_ids.any():
+        invalid_samples = df.loc[invalid_patient_ids, "sample_id"].tolist()
+        raise ValueError(
+            "Invalid patient_id values for samples: "
+            + ", ".join(str(sample_id) for sample_id in invalid_samples)
+        )
+    return dict(zip(df["sample_id"].tolist(), patient_ids.tolist()))
 
 
 def _load_base_process_df(process_list_path: str | Path) -> pd.DataFrame:

--- a/tests/test_patient_manifest.py
+++ b/tests/test_patient_manifest.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
 
+from slide2vec.inference import run_pipeline
 from slide2vec.utils.tiling_io import load_patient_id_mapping, load_slide_manifest
 
 
@@ -56,3 +58,51 @@ def test_slide_manifest_preserves_leading_zero_sample_ids(tmp_path: Path):
     slides = load_slide_manifest(manifest)
 
     assert [slide.sample_id for slide in slides] == ["0007", "0008"]
+
+
+def test_patient_tiling_only_validates_ids_before_creating_output(tmp_path: Path):
+    manifest = tmp_path / "manifest.csv"
+    manifest.write_text(
+        "sample_id,image_path,patient_id\n"
+        "sample-a,/slides/a.svs,\n"
+    )
+    output_dir = tmp_path / "output"
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid patient_id values for samples: sample-a$",
+    ):
+        run_pipeline(
+            SimpleNamespace(level="patient"),
+            manifest_path=manifest,
+            tiling_only=True,
+            execution=SimpleNamespace(output_dir=output_dir, num_gpus=1),
+        )
+
+    assert not output_dir.exists()
+
+
+def test_patient_mapping_preserves_text_matching_pandas_na_tokens(tmp_path: Path):
+    manifest = tmp_path / "manifest.csv"
+    manifest.write_text(
+        "sample_id,image_path,patient_id\n"
+        "NA,/slides/a.svs,NA\n"
+    )
+
+    mapping = load_patient_id_mapping(manifest)
+
+    assert mapping == {"NA": "NA"}
+
+
+def test_slide_manifest_preserves_sample_id_matching_pandas_na_tokens(
+    tmp_path: Path,
+):
+    manifest = tmp_path / "manifest.csv"
+    manifest.write_text(
+        "sample_id,image_path\n"
+        "NA,/slides/a.svs\n"
+    )
+
+    slides = load_slide_manifest(manifest)
+
+    assert [slide.sample_id for slide in slides] == ["NA"]

--- a/tests/test_patient_manifest.py
+++ b/tests/test_patient_manifest.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from slide2vec.utils.tiling_io import load_patient_id_mapping, load_slide_manifest
+
+
+@pytest.mark.parametrize("invalid_patient_id", [None, "", "   "])
+def test_patient_mapping_rejects_invalid_patient_ids_and_names_every_sample(
+    tmp_path: Path,
+    invalid_patient_id: str | None,
+):
+    manifest = tmp_path / "manifest.csv"
+    pd.DataFrame(
+        {
+            "sample_id": ["sample-b", "sample-a"],
+            "image_path": ["/slides/b.svs", "/slides/a.svs"],
+            "patient_id": [invalid_patient_id, invalid_patient_id],
+        }
+    ).to_csv(manifest, index=False)
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid patient_id values for samples: sample-b, sample-a$",
+    ):
+        load_patient_id_mapping(manifest)
+
+
+def test_patient_mapping_preserves_textual_ids_and_grouping(tmp_path: Path):
+    manifest = tmp_path / "manifest.csv"
+    manifest.write_text(
+        "sample_id,image_path,patient_id\n"
+        "0007,/slides/a.svs,0012\n"
+        "0008,/slides/b.svs,0012\n"
+        "0009,/slides/c.svs,0013\n"
+    )
+
+    mapping = load_patient_id_mapping(manifest)
+
+    assert mapping == {
+        "0007": "0012",
+        "0008": "0012",
+        "0009": "0013",
+    }
+
+
+def test_slide_manifest_preserves_leading_zero_sample_ids(tmp_path: Path):
+    manifest = tmp_path / "manifest.csv"
+    manifest.write_text(
+        "sample_id,image_path\n"
+        "0007,/slides/a.svs\n"
+        "0008,/slides/b.svs\n"
+    )
+
+    slides = load_slide_manifest(manifest)
+
+    assert [slide.sample_id for slide in slides] == ["0007", "0008"]


### PR DESCRIPTION
## Summary

- reject null, empty, and whitespace-only patient IDs before tiling or embedding
- preserve raw textual sample and patient identifiers, including leading zeros and pandas-like NA tokens
- validate patient manifests for tiling-only patient runs before creating output artifacts
- document patient identifier requirements

## Verification

- `python -m pytest -q tests/test_patient_manifest.py tests/test_hs2p_package_cutover.py` — 22 passed
- targeted `run_pipeline` tiling-only regression tests — 2 passed
- focused flake8 and `git diff --check` — passed
- `/code-review main` final re-review — Standards: no findings; Spec: no remaining findings

The broad non-heavy suite remains baseline-blocked by the dense-image automatic-worker deadlock tracked in #245.

Closes #242