### PR TITLE
Preserve tile annotation identity during reconciliation

### DIFF
--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -20,6 +20,7 @@ class TileEmbeddingArtifact:
     format: str
     feature_dim: int
     num_tiles: int
+    annotation: str | None = None
 
     @property
     def metadata(self) -> dict[str, Any]:
@@ -463,6 +464,7 @@ def _build_tile_embedding_metadata(
     output_format: str,
     feature_dim: int | None,
     num_tiles: int,
+    annotation: str | None,
     metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     tile_metadata = {
@@ -474,6 +476,9 @@ def _build_tile_embedding_metadata(
     }
     if metadata:
         tile_metadata.update(metadata)
+    tile_metadata["annotation"] = (
+        None if is_flattened_annotation(annotation) else str(annotation)
+    )
     return tile_metadata
 
 
@@ -521,6 +526,7 @@ def write_tile_embeddings(
         output_format=output_format,
         feature_dim=int(feature_array.shape[-1]) if feature_array.ndim else 1,
         num_tiles=int(feature_array.shape[0]) if feature_array.ndim else 1,
+        annotation=annotation,
         metadata=metadata,
     )
     _write_metadata(metadata_path, tile_metadata)
@@ -531,6 +537,7 @@ def write_tile_embeddings(
         format=output_format,
         feature_dim=tile_metadata["feature_dim"],
         num_tiles=tile_metadata["num_tiles"],
+        annotation=tile_metadata["annotation"],
     )
 
 
@@ -553,6 +560,7 @@ def write_tile_embedding_metadata(
         output_format=output_format,
         feature_dim=feature_dim,
         num_tiles=num_tiles,
+        annotation=annotation,
         metadata=metadata,
     )
     _write_metadata(metadata_path, tile_metadata)

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -239,8 +239,12 @@ def _reconcile_embedding_process_list(
     include_slide_embeddings = model.level == "slide"
     include_tile_embeddings = persist_tile_embeddings and not persist_hierarchical_embeddings
     annotations = None
-    if (include_slide_embeddings or persist_hierarchical_embeddings) and embeddable_tiling_results is not None:
-        # Re-read each class's namespaced slide- or hierarchical-embedding artifact so the
+    if (
+        include_tile_embeddings
+        or include_slide_embeddings
+        or persist_hierarchical_embeddings
+    ) and embeddable_tiling_results is not None:
+        # Re-read each class's namespaced tile-, slide-, or hierarchical-embedding artifact so the
         # final reconcile records the per-class feature path instead of collapsing every
         # annotation row onto the flat path. The default tissue-only path leaves annotations
         # None.

--- a/slide2vec/runtime/artifacts_collect.py
+++ b/slide2vec/runtime/artifacts_collect.py
@@ -168,16 +168,18 @@ def collect_distributed_pipeline_artifacts(
     persist_hierarchical_embeddings = is_hierarchical_preprocessing(preprocessing)
     include_slide_embeddings = model.level == "slide"
     include_tile_embeddings = persist_tile_embeddings and not persist_hierarchical_embeddings
-    # Slide- and hierarchical-embedding artifacts fan out per (sample_id, annotation); the process
-    # list (one row per pair after hs2p tiling) is the source of truth for which classes exist.
-    # Tile embeddings are sample_id-keyed only, so they don't need the per-class resolution.
-    annotation_aware = include_slide_embeddings or persist_hierarchical_embeddings
+    # Every persisted embedding kind can fan out per (sample_id, annotation); the process list
+    # (one row per pair after hs2p tiling) is the source of truth for which classes exist.
+    annotation_aware = (
+        include_tile_embeddings
+        or include_slide_embeddings
+        or persist_hierarchical_embeddings
+    )
     annotation_groups = (
         _embeddable_annotation_groups(process_list_path) if annotation_aware else {}
     )
-    # The embedding *stage* must fan out per (sample_id, annotation) for every level (tile / slide /
-    # hierarchical) so each class's tiles are actually embedded — independent of whether the
-    # process-list *reconcile* is annotation-aware (tile artifacts stay sample_id-keyed in #167).
+    # The embedding stage must fan out per (sample_id, annotation) for every level so each class's
+    # tiles are embedded independently.
     stage_annotation_groups = _embeddable_annotation_groups(process_list_path)
     # One annotation per ``successful_slides`` entry (the tiling spine fans out per class). Carry each
     # on a lightweight placeholder so the resume gate keys by (sample_id, annotation) and the surviving

--- a/slide2vec/runtime/persistence.py
+++ b/slide2vec/runtime/persistence.py
@@ -199,41 +199,34 @@ def update_process_list_after_embedding(
         df["feature_kind"] = [None] * len(df)
     if include_slide_embeddings and "aggregation_status" not in df.columns:
         df["aggregation_status"] = ["tbp"] * len(df)
-    tile_success_ids = {artifact.sample_id for artifact in tile_artifacts}
-    hierarchical_success_ids = {artifact.sample_id for artifact in hierarchical_artifacts}
     slide_success_ids = {artifact.sample_id for artifact in slide_artifacts}
     # Every embedding kind can fan out per (sample_id, annotation). Tissue/None annotations
     # normalize to the flat slot, preserving the default single-row path.
-    slide_path_by_key = {
-        (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(artifact.path)
-        for artifact in slide_artifacts
-    }
     slide_success_keys = {
         (artifact.sample_id, _normalized_annotation(artifact.annotation)) for artifact in slide_artifacts
     }
     if slide_artifacts:
-        feature_path_by_key = slide_path_by_key
+        feature_artifacts = slide_artifacts
         feature_kind = "slide"
-        feature_success_ids = slide_success_ids
     elif persist_hierarchical_embeddings:
-        feature_path_by_key = {
-            (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(artifact.path)
-            for artifact in hierarchical_artifacts
-        }
+        feature_artifacts = hierarchical_artifacts
         feature_kind = "hierarchical"
-        feature_success_ids = hierarchical_success_ids
     elif persist_tile_embeddings:
-        feature_path_by_key = {
-            (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(
-                artifact.path
-            )
-            for artifact in tile_artifacts
-        }
+        feature_artifacts = tile_artifacts
         feature_kind = "tile"
-        feature_success_ids = tile_success_ids
     else:
-        feature_path_by_key = {}
+        feature_artifacts = []
         feature_kind = None
+
+    feature_path_by_key = {
+        (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(
+            artifact.path
+        )
+        for artifact in feature_artifacts
+    }
+    if feature_artifacts:
+        feature_success_ids = {artifact.sample_id for artifact in feature_artifacts}
+    else:
         feature_success_ids = {slide.sample_id for slide in successful_slides}
     feature_success_keys = set(feature_path_by_key)
     annotation_aware = any(annotation is not None for _, annotation in feature_success_keys)

--- a/slide2vec/runtime/persistence.py
+++ b/slide2vec/runtime/persistence.py
@@ -17,6 +17,7 @@ from slide2vec.artifacts import (
     load_metadata,
     slide_embeddings_subdir,
     slide_latents_subdir,
+    tile_embeddings_subdir,
 )
 from slide2vec.utils.tiling_io import atomic_write_dataframe_csv
 
@@ -47,7 +48,14 @@ def collect_pipeline_artifacts(
     slide_artifacts: list[SlideEmbeddingArtifact] = []
     for slide, annotation in zip(slide_records, annotations):
         if include_tile_embeddings:
-            tile_artifacts.append(load_tile_artifact(slide.sample_id, output_dir=output_dir, output_format=output_format))
+            tile_artifacts.append(
+                load_tile_artifact(
+                    slide.sample_id,
+                    output_dir=output_dir,
+                    output_format=output_format,
+                    annotation=annotation,
+                )
+            )
         if include_hierarchical_embeddings:
             hierarchical_artifacts.append(
                 load_hierarchical_artifact(
@@ -69,9 +77,17 @@ def collect_pipeline_artifacts(
     return tile_artifacts, hierarchical_artifacts, slide_artifacts
 
 
-def load_tile_artifact(sample_id: str, *, output_dir: Path, output_format: str) -> TileEmbeddingArtifact:
-    artifact_path = output_dir / "tile_embeddings" / f"{sample_id}.{output_format}"
-    metadata_path = output_dir / "tile_embeddings" / f"{sample_id}.meta.json"
+def load_tile_artifact(
+    sample_id: str,
+    *,
+    output_dir: Path,
+    output_format: str,
+    annotation: str | None,
+) -> TileEmbeddingArtifact:
+    normalized_annotation = _normalized_annotation(annotation)
+    tile_dir = output_dir / tile_embeddings_subdir(normalized_annotation)
+    artifact_path = tile_dir / f"{sample_id}.{output_format}"
+    metadata_path = tile_dir / f"{sample_id}.meta.json"
     if metadata_path.is_file():
         metadata = load_metadata(metadata_path)
         feature_dim = int(metadata["feature_dim"])
@@ -87,6 +103,7 @@ def load_tile_artifact(sample_id: str, *, output_dir: Path, output_format: str) 
         format=output_format,
         feature_dim=feature_dim,
         num_tiles=num_tiles,
+        annotation=normalized_annotation,
     )
 
 
@@ -185,12 +202,8 @@ def update_process_list_after_embedding(
     tile_success_ids = {artifact.sample_id for artifact in tile_artifacts}
     hierarchical_success_ids = {artifact.sample_id for artifact in hierarchical_artifacts}
     slide_success_ids = {artifact.sample_id for artifact in slide_artifacts}
-    # Slide and hierarchical embeddings fan out per (sample_id, annotation): keep a per-class
-    # feature-path map (and per-class success set) so a multi-label slide records a distinct
-    # feature path on each annotation row instead of collapsing them all onto one path.
-    # Tissue/None annotations stay in the flat slot, so the default single-row path is
-    # byte-for-byte unchanged. Tile artifacts are sample_id-keyed (their per-class fan-out is
-    # wired by their own slice), so they map to a None annotation key.
+    # Every embedding kind can fan out per (sample_id, annotation). Tissue/None annotations
+    # normalize to the flat slot, preserving the default single-row path.
     slide_path_by_key = {
         (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(artifact.path)
         for artifact in slide_artifacts
@@ -211,7 +224,10 @@ def update_process_list_after_embedding(
         feature_success_ids = hierarchical_success_ids
     elif persist_tile_embeddings:
         feature_path_by_key = {
-            (artifact.sample_id, None): _resolve_path_str(artifact.path) for artifact in tile_artifacts
+            (artifact.sample_id, _normalized_annotation(artifact.annotation)): _resolve_path_str(
+                artifact.path
+            )
+            for artifact in tile_artifacts
         }
         feature_kind = "tile"
         feature_success_ids = tile_success_ids
@@ -219,15 +235,16 @@ def update_process_list_after_embedding(
         feature_path_by_key = {}
         feature_kind = None
         feature_success_ids = {slide.sample_id for slide in successful_slides}
-    annotation_aware = bool(slide_artifacts) or (persist_hierarchical_embeddings and bool(hierarchical_artifacts))
+    feature_success_keys = set(feature_path_by_key)
+    annotation_aware = any(annotation is not None for _, annotation in feature_success_keys)
     row_annotations = _row_annotation_series(df)
     for slide in successful_slides:
         mask = df["sample_id"].astype(str) == slide.sample_id
-        feature_status = "success" if slide.sample_id in feature_success_ids else "error"
-        df.loc[mask, "feature_status"] = feature_status
         if annotation_aware:
             # Resolve each (sample_id, annotation) row independently so per-class paths and
-            # aggregation statuses don't bleed across the slide's other annotation rows.
+            # statuses don't bleed across the slide's other annotation rows. An incremental
+            # update may contain only one finished annotation, so unmatched siblings stay
+            # untouched until their own artifact is available.
             for annotation in _row_annotations(row_annotations, mask):
                 # ``== None`` is element-wise False in pandas, so match the flat None key
                 # via isna() and real classes via equality.
@@ -238,15 +255,16 @@ def update_process_list_after_embedding(
                 key = (slide.sample_id, annotation)
                 mapped_feature_path = feature_path_by_key.get(key)
                 if mapped_feature_path is not None:
+                    df.loc[row_mask, "feature_status"] = "success"
                     df.loc[row_mask, "feature_path"] = mapped_feature_path
                     df.loc[row_mask, "encoder_name"] = encoder_name
                     df.loc[row_mask, "output_variant"] = output_variant
                     df.loc[row_mask, "feature_kind"] = feature_kind
-                if include_slide_embeddings:
-                    df.loc[row_mask, "aggregation_status"] = (
-                        "success" if key in slide_success_keys else "error"
-                    )
+                if include_slide_embeddings and key in slide_success_keys:
+                    df.loc[row_mask, "aggregation_status"] = "success"
         else:
+            feature_status = "success" if slide.sample_id in feature_success_ids else "error"
+            df.loc[mask, "feature_status"] = feature_status
             mapped_feature_path = feature_path_by_key.get((slide.sample_id, None))
             if mapped_feature_path is not None:
                 df.loc[mask, "feature_path"] = mapped_feature_path

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -624,6 +624,73 @@ def test_collect_distributed_pipeline_artifacts_records_per_class_slide_paths_fo
     assert stroma_row["aggregation_status"] == "success"
 
 
+def test_collect_distributed_pipeline_artifacts_reconciles_per_class_tile_paths(
+    monkeypatch,
+    per_annotation_tile_bags,
+):
+    """Distributed final reconciliation returns and records one tile artifact per annotation."""
+    fixture = per_annotation_tile_bags
+
+    monkeypatch.setattr(
+        artifacts_collect,
+        "run_distributed_embedding_stage",
+        lambda *args, **kwargs: None,
+    )
+    tile_artifacts, _, _ = artifacts_collect.collect_distributed_pipeline_artifacts(
+        model=SimpleNamespace(name="uni2", level="tile"),
+        successful_slides=fixture.slides,
+        process_list_path=fixture.process_list_path,
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=ExecutionOptions(output_dir=fixture.output_dir, num_gpus=2),
+        output_dir=fixture.output_dir,
+    )
+
+    assert [(artifact.annotation, artifact.path) for artifact in tile_artifacts] == [
+        (
+            "tumor",
+            fixture.output_dir / "tile_embeddings" / "tumor" / "slide-a.pt",
+        ),
+        (
+            "stroma",
+            fixture.output_dir / "tile_embeddings" / "stroma" / "slide-a.pt",
+        ),
+    ]
+    recorded = pd.read_csv(fixture.process_list_path).set_index("annotation")
+    assert [
+        (
+            annotation,
+            recorded.loc[annotation, "feature_status"],
+            recorded.loc[annotation, "feature_path"],
+        )
+        for annotation in ["tumor", "stroma"]
+    ] == [
+        (
+            "tumor",
+            "success",
+            str(
+                (
+                    fixture.output_dir
+                    / "tile_embeddings"
+                    / "tumor"
+                    / "slide-a.pt"
+                ).resolve()
+            ),
+        ),
+        (
+            "stroma",
+            "success",
+            str(
+                (
+                    fixture.output_dir
+                    / "tile_embeddings"
+                    / "stroma"
+                    / "slide-a.pt"
+                ).resolve()
+            ),
+        ),
+    ]
+
+
 def test_collect_distributed_pipeline_artifacts_fans_out_per_class_annotations_to_stage(
     monkeypatch,
     tmp_path: Path,
@@ -2040,7 +2107,12 @@ def test_resume_skip_accepts_existing_tile_embedding_without_metadata(tmp_path: 
         save_latents=False,
         resume=True,
     )
-    tile_artifact = persistence.load_tile_artifact("slide-a", output_dir=tmp_path, output_format="npz")
+    tile_artifact = persistence.load_tile_artifact(
+        "slide-a",
+        output_dir=tmp_path,
+        output_format="npz",
+        annotation=None,
+    )
 
     assert pending_slides == []
     assert pending_tiling_results == []
@@ -5151,6 +5223,70 @@ def _write_process_list(path: Path, rows: list[dict]) -> None:
     pd.DataFrame(rows, columns=columns).to_csv(path, index=False)
 
 
+@pytest.fixture
+def per_annotation_tile_bags(tmp_path: Path):
+    annotations = ["tumor", "stroma"]
+    slide = make_slide("slide-a", mask_path=Path("/tmp/slide-a-mask.png"))
+    process_list_path = tmp_path / "process_list.csv"
+    tiling_results = [
+        SimpleNamespace(
+            x=np.array([index], dtype=np.int64),
+            y=np.array([index + 1], dtype=np.int64),
+            tile_size_lv0=224,
+            num_tiles=1,
+            backend="asap",
+            annotation=annotation,
+            coordinates_npz_path=Path(
+                f"/tmp/slide-a.{annotation}.coordinates.npz"
+            ),
+            coordinates_meta_path=Path(
+                f"/tmp/slide-a.{annotation}.coordinates.meta.json"
+            ),
+            tiles_tar_path=None,
+        )
+        for index, annotation in enumerate(annotations)
+    ]
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": annotation,
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": f"/tmp/slide-a.{annotation}.coordinates.npz",
+                "coordinates_meta_path": f"/tmp/slide-a.{annotation}.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            }
+            for annotation in annotations
+        ],
+    )
+    for index, annotation in enumerate(annotations):
+        write_tile_embeddings(
+            "slide-a",
+            np.array([[index + 1.0, index + 2.0]], dtype=np.float32),
+            output_dir=tmp_path,
+            annotation=annotation,
+        )
+    return SimpleNamespace(
+        annotations=annotations,
+        output_dir=tmp_path,
+        process_list_path=process_list_path,
+        slide=slide,
+        slides=[slide, slide],
+        tiling_results=tiling_results,
+    )
+
+
 def _fake_tiling_result_loader(monkeypatch):
     """Make tiling_io.load_tiling_result return a minimal in-memory result (no file IO)."""
     def _fake_load_tiling_result(*, coordinates_npz_path, coordinates_meta_path):
@@ -5279,6 +5415,120 @@ def test_persist_embedded_slide_namespaces_tile_embeddings_per_class(tmp_path: P
 
     none_artifact = _persist(None)
     assert none_artifact.path == tmp_path / "tile_embeddings" / "slide-a.pt"
+
+
+def test_collect_pipeline_artifacts_reloads_per_class_tile_embeddings(
+    per_annotation_tile_bags,
+):
+    """Tile collection preserves the parallel annotation identity used for persistence."""
+    fixture = per_annotation_tile_bags
+
+    tile_artifacts, _, _ = persistence.collect_pipeline_artifacts(
+        fixture.slides,
+        output_dir=fixture.output_dir,
+        output_format="pt",
+        include_tile_embeddings=True,
+        include_hierarchical_embeddings=False,
+        include_slide_embeddings=False,
+        annotations=fixture.annotations,
+    )
+
+    assert [
+        (artifact.sample_id, artifact.annotation, artifact.path, artifact.metadata["annotation"])
+        for artifact in tile_artifacts
+    ] == [
+        (
+            "slide-a",
+            "tumor",
+            fixture.output_dir / "tile_embeddings" / "tumor" / "slide-a.pt",
+            "tumor",
+        ),
+        (
+            "slide-a",
+            "stroma",
+            fixture.output_dir / "tile_embeddings" / "stroma" / "slide-a.pt",
+            "stroma",
+        ),
+    ]
+
+
+def test_run_pipeline_single_gpu_reconciles_per_class_tile_embeddings(
+    monkeypatch,
+    per_annotation_tile_bags,
+):
+    """Single-GPU final reconciliation keeps each annotation row and tile path distinct."""
+    import slide2vec.inference as inference
+
+    fixture = per_annotation_tile_bags
+    monkeypatch.setattr(
+        tiling_pipeline,
+        "prepare_tiled_slides",
+        lambda *args, **kwargs: (
+            fixture.slides,
+            fixture.tiling_results,
+            fixture.process_list_path,
+        ),
+    )
+    monkeypatch.setattr(
+        embedding_pipeline,
+        "compute_tile_embeddings_for_slide",
+        lambda *args, **kwargs: np.array([[1.0, 2.0]], dtype=np.float32),
+    )
+
+    model = SimpleNamespace(
+        name="uni2",
+        level="tile",
+        _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
+        _load_backend=lambda: SimpleNamespace(),
+    )
+    result = inference.run_pipeline(
+        model,
+        slides=[fixture.slide],
+        preprocessing=DEFAULT_PREPROCESSING,
+        execution=ExecutionOptions(output_dir=fixture.output_dir, num_gpus=1),
+    )
+
+    assert [(artifact.annotation, artifact.path) for artifact in result.tile_artifacts] == [
+        (
+            "tumor",
+            fixture.output_dir / "tile_embeddings" / "tumor" / "slide-a.pt",
+        ),
+        (
+            "stroma",
+            fixture.output_dir / "tile_embeddings" / "stroma" / "slide-a.pt",
+        ),
+    ]
+    recorded = pd.read_csv(fixture.process_list_path).set_index("annotation")
+    assert [
+        (annotation, recorded.loc[annotation, "feature_status"], recorded.loc[annotation, "feature_path"])
+        for annotation in ["tumor", "stroma"]
+    ] == [
+        (
+            "tumor",
+            "success",
+            str(
+                (
+                    fixture.output_dir
+                    / "tile_embeddings"
+                    / "tumor"
+                    / "slide-a.pt"
+                ).resolve()
+            ),
+        ),
+        (
+            "stroma",
+            "success",
+            str(
+                (
+                    fixture.output_dir
+                    / "tile_embeddings"
+                    / "stroma"
+                    / "slide-a.pt"
+                ).resolve()
+            ),
+        ),
+    ]
 
 
 # --- Issue #156: per-annotation slide embeddings (top-seam) ---

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -645,50 +645,7 @@ def test_collect_distributed_pipeline_artifacts_reconciles_per_class_tile_paths(
         output_dir=fixture.output_dir,
     )
 
-    assert [(artifact.annotation, artifact.path) for artifact in tile_artifacts] == [
-        (
-            "tumor",
-            fixture.output_dir / "tile_embeddings" / "tumor" / "slide-a.pt",
-        ),
-        (
-            "stroma",
-            fixture.output_dir / "tile_embeddings" / "stroma" / "slide-a.pt",
-        ),
-    ]
-    recorded = pd.read_csv(fixture.process_list_path).set_index("annotation")
-    assert [
-        (
-            annotation,
-            recorded.loc[annotation, "feature_status"],
-            recorded.loc[annotation, "feature_path"],
-        )
-        for annotation in ["tumor", "stroma"]
-    ] == [
-        (
-            "tumor",
-            "success",
-            str(
-                (
-                    fixture.output_dir
-                    / "tile_embeddings"
-                    / "tumor"
-                    / "slide-a.pt"
-                ).resolve()
-            ),
-        ),
-        (
-            "stroma",
-            "success",
-            str(
-                (
-                    fixture.output_dir
-                    / "tile_embeddings"
-                    / "stroma"
-                    / "slide-a.pt"
-                ).resolve()
-            ),
-        ),
-    ]
+    _assert_per_annotation_tile_reconciliation(fixture, tile_artifacts)
 
 
 def test_collect_distributed_pipeline_artifacts_fans_out_per_class_annotations_to_stage(
@@ -5287,6 +5244,35 @@ def per_annotation_tile_bags(tmp_path: Path):
     )
 
 
+def _assert_per_annotation_tile_reconciliation(fixture, tile_artifacts) -> None:
+    expected_paths = {
+        annotation: (
+            fixture.output_dir
+            / "tile_embeddings"
+            / annotation
+            / "slide-a.pt"
+        )
+        for annotation in fixture.annotations
+    }
+    assert [(artifact.annotation, artifact.path) for artifact in tile_artifacts] == [
+        (annotation, expected_paths[annotation])
+        for annotation in fixture.annotations
+    ]
+
+    recorded = pd.read_csv(fixture.process_list_path).set_index("annotation")
+    assert [
+        (
+            annotation,
+            recorded.loc[annotation, "feature_status"],
+            recorded.loc[annotation, "feature_path"],
+        )
+        for annotation in fixture.annotations
+    ] == [
+        (annotation, "success", str(expected_paths[annotation].resolve()))
+        for annotation in fixture.annotations
+    ]
+
+
 def _fake_tiling_result_loader(monkeypatch):
     """Make tiling_io.load_tiling_result return a minimal in-memory result (no file IO)."""
     def _fake_load_tiling_result(*, coordinates_npz_path, coordinates_meta_path):
@@ -5489,46 +5475,7 @@ def test_run_pipeline_single_gpu_reconciles_per_class_tile_embeddings(
         execution=ExecutionOptions(output_dir=fixture.output_dir, num_gpus=1),
     )
 
-    assert [(artifact.annotation, artifact.path) for artifact in result.tile_artifacts] == [
-        (
-            "tumor",
-            fixture.output_dir / "tile_embeddings" / "tumor" / "slide-a.pt",
-        ),
-        (
-            "stroma",
-            fixture.output_dir / "tile_embeddings" / "stroma" / "slide-a.pt",
-        ),
-    ]
-    recorded = pd.read_csv(fixture.process_list_path).set_index("annotation")
-    assert [
-        (annotation, recorded.loc[annotation, "feature_status"], recorded.loc[annotation, "feature_path"])
-        for annotation in ["tumor", "stroma"]
-    ] == [
-        (
-            "tumor",
-            "success",
-            str(
-                (
-                    fixture.output_dir
-                    / "tile_embeddings"
-                    / "tumor"
-                    / "slide-a.pt"
-                ).resolve()
-            ),
-        ),
-        (
-            "stroma",
-            "success",
-            str(
-                (
-                    fixture.output_dir
-                    / "tile_embeddings"
-                    / "stroma"
-                    / "slide-a.pt"
-                ).resolve()
-            ),
-        ),
-    ]
+    _assert_per_annotation_tile_reconciliation(fixture, result.tile_artifacts)
 
 
 # --- Issue #156: per-annotation slide embeddings (top-seam) ---


### PR DESCRIPTION
## Summary
- carry normalized annotation identity in tile artifacts and metadata
- resolve persisted tile bags from annotation-specific namespaces in local and distributed collection
- reconcile process-list success and feature paths by `(sample_id, annotation)`

## Root cause
Tile persistence namespaced bags by annotation, but final collection reopened a flat tile path and tile artifact metadata did not retain annotation identity. Reconciliation then keyed updates by sample alone, allowing sibling annotation rows to collapse.

## Validation
- `python -m pytest -q tests/test_regression_inference.py::test_collect_pipeline_artifacts_reloads_per_class_tile_embeddings tests/test_regression_inference.py::test_run_pipeline_single_gpu_reconciles_per_class_tile_embeddings tests/test_regression_inference.py::test_collect_distributed_pipeline_artifacts_reconciles_per_class_tile_paths` — 3 passed
- `python -m pytest -q tests/test_regression_inference.py` — 151 passed
- `/code-review main` — Standards and Spec clean after fixes
- full-suite verification remains baseline-blocked by #245: `test_embed_images_dense_num_gpus_one_runs_in_process` times out after multiprocessing `PermissionError: [Errno 1] Operation not permitted`

Closes #243