### PR TITLE
Prevent image-transform worker deadlocks

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -125,8 +125,10 @@ records the resulting encoder input size in each sidecar as provenance instead o
 validating it against a request. That also fixes how preprocessing runs: given
 images are heterogeneously sized (2048x1536 beside 96x96) and cannot be stacked
 into one uint8 batch before being resized, so the transform is applied **itemwise
-in the dataloader workers** and only the transformed items are stacked. The
-batched transform spec used by the pooled path stays exclusive to it.
+before stacking**. Auto worker selection stays in-process because the model
+runtime is already initialized; an explicit positive ``num_workers_per_gpu`` uses
+spawned dataloader workers. The batched transform spec used by the pooled path
+stays exclusive to it.
 
 .. autoclass:: slide2vec.ImageSpec
    :members:

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -238,6 +238,7 @@ class ExecutionOptions:
     batch_size: int = 32
     #: DataLoader worker count per GPU rank. ``None`` means auto
     #: (capped by CPU / SLURM limit, then split across the resolved GPU count).
+    #: Image-only routes safely use zero when auto selection happens after model loading.
     num_workers_per_gpu: int | None = None
     #: Tiling worker count. ``None`` means auto (capped by CPU / SLURM limit).
     num_preprocessing_workers: int | None = None
@@ -321,6 +322,12 @@ class ExecutionOptions:
         if self.num_workers_per_gpu is not None:
             return self.num_workers_per_gpu
         return max(1, cpu_worker_limit() // self.num_gpus)
+
+    def resolved_image_num_workers_per_gpu(self) -> int:
+        """Resolve safe post-model-load image-transform workers for this rank."""
+        if self.num_workers_per_gpu is None:
+            return 0
+        return self.resolved_num_workers_per_gpu()
 
     def with_output_dir(self, output_dir: PathLike | None) -> "ExecutionOptions":
         if output_dir is None:
@@ -822,8 +829,9 @@ class Model:
         heterogeneously sized (2048x1536 beside 96x96) and were never requested, so the
         encoder's shipped transform is the contract and slide2vec *records* the resulting
         encoder input size as run provenance rather than validating it. That also means
-        preprocessing runs itemwise in the loader workers — differently sized images cannot
-        be stacked before they are resized.
+        preprocessing runs itemwise before stacking — in-process by default, or in spawned
+        loader workers when ``num_workers_per_gpu`` is explicit — because differently sized
+        images cannot be stacked before they are resized.
         """
         from slide2vec.runtime.image_stage import embed_images
 

--- a/slide2vec/distributed/dense_image_worker.py
+++ b/slide2vec/distributed/dense_image_worker.py
@@ -67,7 +67,7 @@ def main(argv=None) -> int:
             batch_size=int(execution.batch_size),
             precision=execution.precision,
             output_dtype=resolve_output_torch_dtype(execution),
-            num_workers=execution.resolved_num_workers_per_gpu(),
+            num_workers=execution.resolved_image_num_workers_per_gpu(),
             prefetch_factor=int(execution.prefetch_factor),
             on_batch=_on_batch,
         )

--- a/slide2vec/distributed/image_worker.py
+++ b/slide2vec/distributed/image_worker.py
@@ -62,7 +62,7 @@ def main(argv=None) -> int:
             output_precision=resolve_output_precision(execution.output_dtype, execution.precision),
             output_format=execution.output_format,
             precision=execution.precision,
-            num_workers=execution.resolved_num_workers_per_gpu(),
+            num_workers=execution.resolved_image_num_workers_per_gpu(),
             prefetch_factor=int(execution.prefetch_factor),
             on_batch=_on_batch,
         )

--- a/slide2vec/runtime/batching.py
+++ b/slide2vec/runtime/batching.py
@@ -82,15 +82,23 @@ def build_batch_preprocessor_for_tile_images(
     return preprocess
 
 
-def dataloader_kwargs(*, device, num_workers: int, prefetch_factor: int) -> dict[str, Any]:
+def dataloader_kwargs(
+    *,
+    device,
+    num_workers: int,
+    prefetch_factor: int,
+    worker_start_method: str | None = None,
+) -> dict[str, Any]:
     """The DataLoader knobs every embedding route sets, from the values it already holds.
 
-    ``prefetch_factor`` is only legal with worker processes, and pinned host memory only
-    buys anything when the copy is to a CUDA device.
+    ``prefetch_factor`` and ``worker_start_method`` are only legal with worker processes,
+    and pinned host memory only buys anything when the copy is to a CUDA device.
     """
     kwargs: dict[str, Any] = {"num_workers": int(num_workers)}
     if int(num_workers) > 0:
         kwargs["prefetch_factor"] = int(prefetch_factor)
+        if worker_start_method is not None:
+            kwargs["multiprocessing_context"] = worker_start_method
     if uses_cuda_runtime(device):
         kwargs["pin_memory"] = True
     return kwargs

--- a/slide2vec/runtime/dense_image_shard.py
+++ b/slide2vec/runtime/dense_image_shard.py
@@ -13,12 +13,14 @@ after the pixels arrive — geometry, padding, whole-tile vs sliding encode, out
 the shared :class:`~slide2vec.runtime.dense_regions.DenseGridEncoder`, so this module owns no
 padding, batching or blending logic of its own.
 
-Decoding and the normalization-only transform run **itemwise in the loader workers** (the
-same seam :mod:`slide2vec.runtime.image_shard` uses), and only the transformed items are
-stacked. Unlike the pooled given-image path that is not because the geometry is
+Decoding and the normalization-only transform run **itemwise before stacking** (the same
+seam :mod:`slide2vec.runtime.image_shard` uses). Explicit worker counts use spawned loader
+workers; auto selection remains in-process after the model runtime is loaded. Unlike the
+pooled given-image path, itemwise handling is not required because the geometry is
 heterogeneous — here it is declared, uniform, and checked while stacking (see
 :class:`~slide2vec.data.dataset.DeclaredGeometryCollator`) — but because decoding a directory
-of large images is the bottleneck this path has, and it parallelizes per item.
+of large images is the bottleneck this path has and can be parallelized per item when
+explicitly configured.
 
 Writes are atomic and sidecar-last (see :func:`~slide2vec.artifacts.write_dense_image`), so a
 payload without a sidecar unambiguously means an interrupted image and resume trusts the
@@ -161,8 +163,8 @@ def run_dense_image_shard(
         )
         dataset = ImageFileDataset(
             [spec.image_path for spec in pending],
-            # partial, not a closure: the recipe is pickled into the loader workers. Only
-            # the transform crosses — never the encoder — so a worker carries no weights.
+            # partial, not a closure: when explicit spawned workers are used, only this
+            # transform recipe crosses — never the encoder — so a worker carries no weights.
             partial(apply_transforms_itemwise, transforms=encoder.dense_transform),
         )
         dataloader = torch.utils.data.DataLoader(
@@ -180,6 +182,7 @@ def run_dense_image_shard(
                 device=loaded.device,
                 num_workers=int(num_workers),
                 prefetch_factor=int(prefetch_factor),
+                worker_start_method="spawn",
             ),
         )
         with torch.inference_mode(), slide_encode_autocast_ctx(loaded.device, precision):

--- a/slide2vec/runtime/dense_image_stage.py
+++ b/slide2vec/runtime/dense_image_stage.py
@@ -130,7 +130,10 @@ def _run_dense_images_in_process(
         batch_size=int(execution.batch_size),
         precision=execution.precision,
         output_dtype=resolve_output_torch_dtype(execution),
-        num_workers=execution.resolved_num_workers_per_gpu(),
+        # The encoder/runtime is already initialized in this parent process. Forking
+        # automatically selected transform workers from it can inherit native thread
+        # state and deadlock; explicit counts remain caller-controlled.
+        num_workers=execution.resolved_image_num_workers_per_gpu(),
         prefetch_factor=int(execution.prefetch_factor),
         on_batch=_on_batch,
     )

--- a/slide2vec/runtime/image_shard.py
+++ b/slide2vec/runtime/image_shard.py
@@ -126,7 +126,7 @@ def _move_batch_to_device(loaded: "LoadedModel") -> Callable:
     """Batch 'preprocessing' for this path: the transform already ran, so only move.
 
     Passing this rather than ``None`` is what keeps the prefetcher from applying
-    ``loaded.transforms`` a second time — here the loader workers already did, per item.
+    ``loaded.transforms`` a second time — the dataset already did so itemwise.
     """
 
     def move(image):
@@ -168,7 +168,7 @@ def run_image_shard(
         loaded.encoder_input_size_px = None
         dataset = ImageFileDataset(
             [spec.image_path for spec in pending],
-            # partial, not a closure: the recipe is pickled into the loader workers.
+            # partial, not a closure: the recipe is picklable by explicit spawned workers.
             partial(apply_transforms_itemwise, transforms=loaded.transforms),
         )
         dataloader = torch.utils.data.DataLoader(
@@ -180,6 +180,7 @@ def run_image_shard(
                 device=loaded.device,
                 num_workers=int(num_workers),
                 prefetch_factor=int(prefetch_factor),
+                worker_start_method="spawn",
             ),
         )
         cast_dtype = autocast_dtype(torch, precision)

--- a/slide2vec/runtime/image_stage.py
+++ b/slide2vec/runtime/image_stage.py
@@ -118,7 +118,10 @@ def _run_images_in_process(model, specs, *, execution, out_dir) -> None:
         output_precision=resolve_output_precision(execution.output_dtype, execution.precision),
         output_format=execution.output_format,
         precision=execution.precision,
-        num_workers=execution.resolved_num_workers_per_gpu(),
+        # The encoder/runtime is already initialized in this parent process. Forking
+        # automatically selected transform workers from it can inherit native thread
+        # state and deadlock; explicit counts remain caller-controlled.
+        num_workers=execution.resolved_image_num_workers_per_gpu(),
         prefetch_factor=int(execution.prefetch_factor),
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import importlib.util
+import multiprocessing
+import os
+from pathlib import Path
+import subprocess
 import sys
 import types
+
+import pytest
 
 
 if importlib.util.find_spec("transformers") is None:
@@ -17,3 +23,59 @@ if importlib.util.find_spec("transformers") is None:
 
     sys.modules.setdefault("transformers", transformers_module)
     sys.modules["transformers.image_processing_utils"] = image_processing_utils
+
+
+@pytest.fixture
+def run_current_test_in_subprocess(request):
+    """Re-run the current pytest case once in an isolated, timeout-bounded process."""
+
+    def run(*, child_env_name: str, timeout: int = 25) -> None:
+        env = os.environ.copy()
+        env[child_env_name] = "1"
+        subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", "--no-cov", request.node.nodeid],
+            cwd=Path(request.config.rootpath),
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    return run
+
+
+@pytest.fixture
+def assert_auto_worker_workflow_completes_in_subprocess(run_current_test_in_subprocess):
+    """Run an auto-worker image workflow in a bounded child and assert clean shutdown."""
+
+    def assert_workflow(*, child_env_name: str, workflow, expected_sample_ids: list[str]) -> None:
+        if os.environ.get(child_env_name) == "1":
+            artifacts = workflow()
+            assert [artifact.sample_id for artifact in artifacts] == expected_sample_ids
+            assert all(artifact.path.exists() for artifact in artifacts)
+            assert multiprocessing.active_children() == []
+            return
+        run_current_test_in_subprocess(child_env_name=child_env_name)
+
+    return assert_workflow
+
+
+@pytest.fixture
+def build_auto_worker_model(tmp_path, monkeypatch):
+    """Build a public Model with a local loaded backend and default image execution."""
+
+    def build(loaded):
+        from slide2vec.api import ExecutionOptions, Model
+
+        model = Model(name="virchow2", device="cpu")
+        monkeypatch.setattr(model, "_load_backend", lambda: loaded)
+        execution = ExecutionOptions(
+            output_dir=tmp_path / "out",
+            num_gpus=1,
+            precision="fp32",
+            num_workers_per_gpu=None,
+        )
+        return model, execution
+
+    return build

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -87,7 +87,12 @@ def test_embed_images_dense_num_gpus_one_runs_in_process(tmp_path, monkeypatch):
         lambda **kwargs: pytest.fail("num_gpus=1 must not launch torchrun"),
     )
     model = _FakeModel(_encoder())
-    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    execution = ExecutionOptions(
+        output_dir=tmp_path / "out",
+        num_gpus=1,
+        precision="fp32",
+        num_workers_per_gpu=0,
+    )
 
     artifacts = dense_image_stage.embed_images_dense(
         model, _images(tmp_path, ["a", "b", "c"]), dense=_dense(), execution=execution
@@ -100,6 +105,27 @@ def test_embed_images_dense_num_gpus_one_runs_in_process(tmp_path, monkeypatch):
     for artifact in artifacts:
         assert artifact.grid_shape == (4, 4)
         assert artifact.metadata_path.exists()
+
+
+def test_embed_images_dense_auto_workers_complete_in_a_subprocess(
+    tmp_path,
+    assert_auto_worker_workflow_completes_in_subprocess,
+    build_auto_worker_model,
+):
+    """Auto workers must not fork after the in-process encoder initialized its runtime."""
+    def workflow():
+        model, execution = build_auto_worker_model(_loaded(_encoder()))
+        return model.embed_images_dense(
+            _images(tmp_path, ["a", "b", "c"]),
+            dense=_dense(),
+            execution=execution,
+        )
+
+    assert_auto_worker_workflow_completes_in_subprocess(
+        child_env_name="SLIDE2VEC_DENSE_IMAGE_AUTO_WORKER_CHILD",
+        workflow=workflow,
+        expected_sample_ids=["a", "b", "c"],
+    )
 
 
 def test_embed_images_dense_num_gpus_gt_one_launches_the_worker(tmp_path, monkeypatch):
@@ -314,7 +340,13 @@ def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
         "model": {"name": "fake", "output_variant": None, "allow_non_recommended_settings": False},
         "dense": serialize_dense_image_options(_dense()),
         "execution": serialize_execution(
-            ExecutionOptions(output_dir=tmp_path / "out", num_gpus=2, precision="fp32", batch_size=2)
+            ExecutionOptions(
+                output_dir=tmp_path / "out",
+                num_gpus=2,
+                precision="fp32",
+                batch_size=2,
+                num_workers_per_gpu=1,
+            )
         ),
         "output_dir": str(tmp_path / "out"),
         "progress_events_path": None,

--- a/tests/test_image_stage.py
+++ b/tests/test_image_stage.py
@@ -84,7 +84,12 @@ def test_embed_images_num_gpus_one_runs_in_process(tmp_path, monkeypatch):
         lambda **kwargs: pytest.fail("num_gpus=1 must not launch torchrun"),
     )
     model = _FakeModel(_encoder())
-    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    execution = ExecutionOptions(
+        output_dir=tmp_path / "out",
+        num_gpus=1,
+        precision="fp32",
+        num_workers_per_gpu=0,
+    )
 
     artifacts = image_stage.embed_images(model, _images(tmp_path, ["a", "b", "c"]), execution=execution)
 
@@ -94,6 +99,26 @@ def test_embed_images_num_gpus_one_runs_in_process(tmp_path, monkeypatch):
     assert sorted(p.name for p in embeddings_dir.glob("*.pt")) == ["a.pt", "b.pt", "c.pt"]
     for artifact in artifacts:
         assert artifact.metadata_path.exists()
+
+
+def test_embed_images_auto_workers_complete_in_a_subprocess(
+    tmp_path,
+    assert_auto_worker_workflow_completes_in_subprocess,
+    build_auto_worker_model,
+):
+    """Auto workers must not fork after the in-process encoder initialized its runtime."""
+    def workflow():
+        model, execution = build_auto_worker_model(_loaded(_encoder()))
+        return model.embed_images(
+            _images(tmp_path, ["a"]),
+            execution=execution,
+        )
+
+    assert_auto_worker_workflow_completes_in_subprocess(
+        child_env_name="SLIDE2VEC_IMAGE_AUTO_WORKER_CHILD",
+        workflow=workflow,
+        expected_sample_ids=["a"],
+    )
 
 
 def test_embed_images_num_gpus_gt_one_launches_image_worker(tmp_path, monkeypatch):
@@ -285,7 +310,13 @@ def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
     request = {
         "model": {"name": "fake", "output_variant": None, "allow_non_recommended_settings": False},
         "execution": serialize_execution(
-            ExecutionOptions(output_dir=tmp_path / "out", num_gpus=2, precision="fp32", batch_size=2)
+            ExecutionOptions(
+                output_dir=tmp_path / "out",
+                num_gpus=2,
+                precision="fp32",
+                batch_size=2,
+                num_workers_per_gpu=1,
+            )
         ),
         "output_dir": str(tmp_path / "out"),
         "progress_events_path": None,

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -661,6 +661,21 @@ def test_execution_options_auto_workers_are_split_across_gpus(monkeypatch):
     assert execution.resolved_num_workers_per_gpu() == 6
 
 
+def test_execution_options_resolve_safe_image_workers_without_losing_explicit_overrides(
+    monkeypatch,
+):
+    import slide2vec.api as api
+
+    monkeypatch.setattr(api, "cpu_worker_limit", lambda: 18)
+    monkeypatch.setattr(api, "slurm_cpu_limit", lambda: 18)
+
+    auto = api.ExecutionOptions(num_gpus=3)
+    explicit = api.ExecutionOptions(num_gpus=3, num_workers_per_gpu=2)
+
+    assert auto.resolved_image_num_workers_per_gpu() == 0
+    assert explicit.resolved_image_num_workers_per_gpu() == 2
+
+
 def test_hf_login_skips_hub_login_when_token_is_already_set(monkeypatch):
     import slide2vec.utils.config as config
 

--- a/tests/test_runtime_batching.py
+++ b/tests/test_runtime_batching.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import torch
 from torchvision.transforms import functional as tvF
 
+from slide2vec.runtime.batching import dataloader_kwargs
 from slide2vec.runtime.preprocessing import apply_transforms_itemwise
 
 
@@ -31,3 +32,22 @@ def test_apply_transforms_itemwise_converts_tensor_samples_for_pil_only_transfor
     transformed = apply_transforms_itemwise(image, ConvertToRgbAndBack())
 
     assert torch.equal(transformed, image)
+
+
+def test_dataloader_kwargs_uses_spawn_only_when_worker_processes_are_enabled():
+    assert dataloader_kwargs(
+        device=torch.device("cpu"),
+        num_workers=2,
+        prefetch_factor=3,
+        worker_start_method="spawn",
+    ) == {
+        "num_workers": 2,
+        "prefetch_factor": 3,
+        "multiprocessing_context": "spawn",
+    }
+    assert dataloader_kwargs(
+        device=torch.device("cpu"),
+        num_workers=0,
+        prefetch_factor=3,
+        worker_start_method="spawn",
+    ) == {"num_workers": 0}


### PR DESCRIPTION
## Summary

- resolve automatically selected dense- and pooled-image transform workers to zero after the model runtime is initialized
- preserve explicit positive worker counts with a safe `spawn` DataLoader context
- retain distributed sharding/output semantics and add bounded public-API subprocess regressions

## Root cause

The image embedding paths loaded the encoder/runtime before constructing a DataLoader. Default worker selection then forked transform workers from a parent with initialized native threads, which could leave sleeping workers and deadlock the run.

## User impact

Default dense-image and pooled-image embedding now complete without post-runtime worker forks. Explicit zero remains supported, while callers that explicitly request worker parallelism keep it through spawned workers.

## Validation

- 140 relevant tests passed across dense/pooled image stages, shards, batching, and core execution options
- bounded public `Model.embed_images_dense(...)` and `Model.embed_images(...)` subprocess regressions passed and reported no active child workers
- explicit spawned distributed dense and pooled worker tests passed with preserved shard outputs
- `git diff --check` passed
- two-axis `main...HEAD` review passed after both Standards judgement calls were resolved; Spec reported no findings

Closes #245