### PR TITLE
Resolve encoder config fields independently

### DIFF
--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -1247,13 +1247,7 @@ def _resolve_direct_api_preprocessing(
     requested_spacing_um = preprocessing.requested_spacing_um
     requested_tile_size_px = preprocessing.requested_tile_size_px
     if requested_spacing_um is None or requested_tile_size_px is None:
-        if not name or name not in encoder_registry:
-            raise ValueError(
-                "Cannot infer preprocessing defaults without a registered model. "
-                "Pass preprocessing.requested_spacing_um and "
-                "preprocessing.requested_tile_size_px explicitly."
-            )
-        resolved_fields = resolve_preprocessing_fields(
+        resolved_fields = _resolve_registered_preprocessing_fields(
             name,
             requested_spacing_um=requested_spacing_um,
             requested_tile_size_px=requested_tile_size_px,
@@ -1270,18 +1264,30 @@ def _resolve_direct_api_preprocessing(
 
 
 def _default_preprocessing_from_registry(name: str | None) -> tuple[int, float]:
-    if not name or name not in encoder_registry:
-        raise ValueError(
-            "Cannot infer preprocessing defaults without a registered model. "
-            "Pass preprocessing.requested_spacing_um and preprocessing.requested_tile_size_px explicitly."
-        )
-
-    resolved_fields = resolve_preprocessing_fields(
+    resolved_fields = _resolve_registered_preprocessing_fields(
         name,
         requested_spacing_um=None,
         requested_tile_size_px=None,
     )
     return int(resolved_fields["tile_size_px"]), float(resolved_fields["spacing_um"])
+
+
+def _resolve_registered_preprocessing_fields(
+    name: str | None,
+    *,
+    requested_spacing_um: float | None,
+    requested_tile_size_px: int | None,
+) -> dict[str, Any]:
+    if not name or name not in encoder_registry:
+        raise ValueError(
+            "Cannot infer preprocessing defaults without a registered model. "
+            "Pass preprocessing.requested_spacing_um and preprocessing.requested_tile_size_px explicitly."
+        )
+    return resolve_preprocessing_fields(
+        name,
+        requested_spacing_um=requested_spacing_um,
+        requested_tile_size_px=requested_tile_size_px,
+    )
 
 
 def _validate_model_config(

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -23,6 +23,7 @@ from slide2vec.configs.resources import load_config
 from slide2vec.encoders.registry import (
     encoder_registry,
     resolve_preprocessing_defaults,
+    resolve_preprocessing_requirements,
 )
 from slide2vec.encoders.validation import validate_encoder_config
 from slide2vec.runtime.model_settings import (
@@ -1233,32 +1234,25 @@ def _resolve_direct_api_preprocessing(
     preprocessing: PreprocessingConfig | None,
 ) -> PreprocessingConfig:
     name = model.name
-    defaults = None
-
-    def ensure_defaults() -> tuple[int, float]:
-        nonlocal defaults
-        if defaults is None:
-            defaults = _default_preprocessing_from_registry(name)
-        return defaults
 
     if preprocessing is None:
-        requested_tile_size_px, requested_spacing_um = ensure_defaults()
+        default_tile_size_px, default_spacing_um = _default_preprocessing_from_registry(name)
         return _resolve_hierarchical_preprocessing(
             PreprocessingConfig(
                 backend="auto",
-                requested_spacing_um=requested_spacing_um,
-                requested_tile_size_px=requested_tile_size_px,
+                requested_spacing_um=default_spacing_um,
+                requested_tile_size_px=default_tile_size_px,
             )
         )
 
     requested_spacing_um = preprocessing.requested_spacing_um
     requested_tile_size_px = preprocessing.requested_tile_size_px
-    if requested_spacing_um is None or requested_tile_size_px is None:
-        default_tile_size_px, default_spacing_um = ensure_defaults()
-        if requested_spacing_um is None:
-            requested_spacing_um = default_spacing_um
+    if requested_spacing_um is None:
+        default_tile_size_px, requested_spacing_um = _default_preprocessing_from_registry(name)
         if requested_tile_size_px is None:
             requested_tile_size_px = default_tile_size_px
+    elif requested_tile_size_px is None:
+        requested_tile_size_px = _default_tile_size_from_registry(name)
     return _resolve_hierarchical_preprocessing(
         replace(
             preprocessing,
@@ -1277,6 +1271,16 @@ def _default_preprocessing_from_registry(name: str | None) -> tuple[int, float]:
 
     defaults = resolve_preprocessing_defaults(name)
     return int(defaults["tile_size_px"]), float(defaults["spacing_um"])
+
+
+def _default_tile_size_from_registry(name: str | None) -> int:
+    if not name or name not in encoder_registry:
+        raise ValueError(
+            "Cannot infer preprocessing defaults without a registered model. "
+            "Pass preprocessing.requested_tile_size_px explicitly."
+        )
+    requirements = resolve_preprocessing_requirements(name)
+    return int(requirements["tile_size_px"])
 
 
 def _validate_model_config(

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -22,8 +22,7 @@ from slide2vec.artifacts import (
 from slide2vec.configs.resources import load_config
 from slide2vec.encoders.registry import (
     encoder_registry,
-    resolve_preprocessing_defaults,
-    resolve_preprocessing_requirements,
+    resolve_preprocessing_fields,
 )
 from slide2vec.encoders.validation import validate_encoder_config
 from slide2vec.runtime.model_settings import (
@@ -1247,12 +1246,20 @@ def _resolve_direct_api_preprocessing(
 
     requested_spacing_um = preprocessing.requested_spacing_um
     requested_tile_size_px = preprocessing.requested_tile_size_px
-    if requested_spacing_um is None:
-        default_tile_size_px, requested_spacing_um = _default_preprocessing_from_registry(name)
-        if requested_tile_size_px is None:
-            requested_tile_size_px = default_tile_size_px
-    elif requested_tile_size_px is None:
-        requested_tile_size_px = _default_tile_size_from_registry(name)
+    if requested_spacing_um is None or requested_tile_size_px is None:
+        if not name or name not in encoder_registry:
+            raise ValueError(
+                "Cannot infer preprocessing defaults without a registered model. "
+                "Pass preprocessing.requested_spacing_um and "
+                "preprocessing.requested_tile_size_px explicitly."
+            )
+        resolved_fields = resolve_preprocessing_fields(
+            name,
+            requested_spacing_um=requested_spacing_um,
+            requested_tile_size_px=requested_tile_size_px,
+        )
+        requested_spacing_um = float(resolved_fields["spacing_um"])
+        requested_tile_size_px = int(resolved_fields["tile_size_px"])
     return _resolve_hierarchical_preprocessing(
         replace(
             preprocessing,
@@ -1269,18 +1276,12 @@ def _default_preprocessing_from_registry(name: str | None) -> tuple[int, float]:
             "Pass preprocessing.requested_spacing_um and preprocessing.requested_tile_size_px explicitly."
         )
 
-    defaults = resolve_preprocessing_defaults(name)
-    return int(defaults["tile_size_px"]), float(defaults["spacing_um"])
-
-
-def _default_tile_size_from_registry(name: str | None) -> int:
-    if not name or name not in encoder_registry:
-        raise ValueError(
-            "Cannot infer preprocessing defaults without a registered model. "
-            "Pass preprocessing.requested_tile_size_px explicitly."
-        )
-    requirements = resolve_preprocessing_requirements(name)
-    return int(requirements["tile_size_px"])
+    resolved_fields = resolve_preprocessing_fields(
+        name,
+        requested_spacing_um=None,
+        requested_tile_size_px=None,
+    )
+    return int(resolved_fields["tile_size_px"]), float(resolved_fields["spacing_um"])
 
 
 def _validate_model_config(

--- a/slide2vec/encoders/registry.py
+++ b/slide2vec/encoders/registry.py
@@ -267,6 +267,36 @@ def resolve_preprocessing_defaults(
     }
 
 
+def resolve_preprocessing_fields(
+    encoder_name: str,
+    *,
+    requested_spacing_um: float | None,
+    requested_tile_size_px: int | None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Fill only missing requested preprocessing fields from encoder metadata.
+
+    Spacing defaults are deliberately resolved only when spacing itself is
+    missing. A missing tile size uses the encoder requirements, which remain
+    valid for encoders that support several spacings.
+    """
+    resolved_spacing_um = requested_spacing_um
+    resolved_tile_size_px = requested_tile_size_px
+    if resolved_spacing_um is None:
+        preprocessing_defaults = resolve_preprocessing_defaults(encoder_name, metadata)
+        resolved_spacing_um = float(preprocessing_defaults["spacing_um"])
+        if resolved_tile_size_px is None:
+            resolved_tile_size_px = int(preprocessing_defaults["tile_size_px"])
+    elif resolved_tile_size_px is None:
+        preprocessing_requirements = resolve_preprocessing_requirements(encoder_name, metadata)
+        resolved_tile_size_px = int(preprocessing_requirements["tile_size_px"])
+
+    return {
+        "spacing_um": float(resolved_spacing_um),
+        "tile_size_px": int(resolved_tile_size_px),
+    }
+
+
 def resolve_encoder_output(
     encoder_name: str,
     *,

--- a/slide2vec/utils/config.py
+++ b/slide2vec/utils/config.py
@@ -4,6 +4,7 @@ import datetime
 import getpass
 
 from pathlib import Path
+from typing import Any
 from omegaconf import OmegaConf
 
 from slide2vec.distributed import is_main_process
@@ -14,31 +15,39 @@ from slide2vec.configs import default_config
 logger = logging.getLogger("slide2vec")
 
 
-def _encoder_derived_cfg(model_name: str) -> dict:
-    """Build OmegaConf defaults derived from encoder registry metadata."""
-    from slide2vec.encoders.registry import encoder_registry, resolve_preprocessing_defaults
+def _encoder_derived_cfg(model_name: str, missing_paths: set[str]) -> dict[str, Any]:
+    """Build only the requested OmegaConf defaults from encoder metadata."""
+    from slide2vec.encoders.registry import (
+        encoder_registry,
+        resolve_preprocessing_defaults,
+        resolve_preprocessing_requirements,
+    )
 
     canonical = canonicalize_model_name(model_name)
     if not canonical or canonical not in encoder_registry:
         return {}
 
     info = encoder_registry.info(canonical)
-    reqs = resolve_preprocessing_defaults(canonical, info)
+    defaults: dict[str, Any] = {"tiling": {"params": {}}, "speed": {}}
+    params = defaults["tiling"]["params"]
 
-    return {
-        "tiling": {
-            "params": {
-                "requested_tile_size_px": reqs["tile_size_px"],
-                "requested_spacing_um": float(reqs["spacing_um"]),
-            }
-        },
-        "speed": {
-            "precision": info["precision"],
-        },
-    }
+    spacing_path = "tiling.params.requested_spacing_um"
+    tile_size_path = "tiling.params.requested_tile_size_px"
+    if spacing_path in missing_paths:
+        reqs = resolve_preprocessing_defaults(canonical, info)
+        params["requested_spacing_um"] = float(reqs["spacing_um"])
+        if tile_size_path in missing_paths:
+            params["requested_tile_size_px"] = int(reqs["tile_size_px"])
+    elif tile_size_path in missing_paths:
+        reqs = resolve_preprocessing_requirements(canonical, info)
+        params["requested_tile_size_px"] = int(reqs["tile_size_px"])
+
+    if "speed.precision" in missing_paths:
+        defaults["speed"]["precision"] = info["precision"]
+    return defaults
 
 
-def _fill_null_encoder_defaults(cfg, encoder_defaults: dict) -> None:
+def _fill_null_encoder_defaults(cfg, encoder_defaults: dict[str, Any]) -> None:
     """Fill null leaves with encoder defaults after user/CLI config merging."""
     defaults_cfg = OmegaConf.create(encoder_defaults)
     for path in (
@@ -108,15 +117,17 @@ def get_cfg_from_args(args):
     default_cfg = OmegaConf.create(default_config)
     model_name = OmegaConf.select(requested_cfg, "model.name")
     cfg = OmegaConf.merge(default_cfg, user_cfg, cli_cfg)
-    if model_name and any(
-        OmegaConf.select(cfg, path) is None
+    missing_paths = {
+        path
         for path in (
             "tiling.params.requested_tile_size_px",
             "tiling.params.requested_spacing_um",
             "speed.precision",
         )
-    ):
-        encoder_defaults = _encoder_derived_cfg(model_name)
+        if OmegaConf.select(cfg, path) is None
+    }
+    if model_name and missing_paths:
+        encoder_defaults = _encoder_derived_cfg(model_name, missing_paths)
         _fill_null_encoder_defaults(cfg, encoder_defaults)
     OmegaConf.resolve(cfg)
     validate_model_recommended_settings(cfg, run_on_cpu=bool(getattr(args, "run_on_cpu", False)))

--- a/slide2vec/utils/config.py
+++ b/slide2vec/utils/config.py
@@ -15,12 +15,17 @@ from slide2vec.configs import default_config
 logger = logging.getLogger("slide2vec")
 
 
-def _encoder_derived_cfg(model_name: str, missing_paths: set[str]) -> dict[str, Any]:
+def _encoder_derived_cfg(
+    model_name: str,
+    *,
+    requested_spacing_um: float | None,
+    requested_tile_size_px: int | None,
+    precision: str | None,
+) -> dict[str, Any]:
     """Build only the requested OmegaConf defaults from encoder metadata."""
     from slide2vec.encoders.registry import (
         encoder_registry,
-        resolve_preprocessing_defaults,
-        resolve_preprocessing_requirements,
+        resolve_preprocessing_fields,
     )
 
     canonical = canonicalize_model_name(model_name)
@@ -31,18 +36,19 @@ def _encoder_derived_cfg(model_name: str, missing_paths: set[str]) -> dict[str, 
     defaults: dict[str, Any] = {"tiling": {"params": {}}, "speed": {}}
     params = defaults["tiling"]["params"]
 
-    spacing_path = "tiling.params.requested_spacing_um"
-    tile_size_path = "tiling.params.requested_tile_size_px"
-    if spacing_path in missing_paths:
-        reqs = resolve_preprocessing_defaults(canonical, info)
-        params["requested_spacing_um"] = float(reqs["spacing_um"])
-        if tile_size_path in missing_paths:
-            params["requested_tile_size_px"] = int(reqs["tile_size_px"])
-    elif tile_size_path in missing_paths:
-        reqs = resolve_preprocessing_requirements(canonical, info)
-        params["requested_tile_size_px"] = int(reqs["tile_size_px"])
+    if requested_spacing_um is None or requested_tile_size_px is None:
+        resolved_fields = resolve_preprocessing_fields(
+            canonical,
+            requested_spacing_um=requested_spacing_um,
+            requested_tile_size_px=requested_tile_size_px,
+            metadata=info,
+        )
+        if requested_spacing_um is None:
+            params["requested_spacing_um"] = resolved_fields["spacing_um"]
+        if requested_tile_size_px is None:
+            params["requested_tile_size_px"] = resolved_fields["tile_size_px"]
 
-    if "speed.precision" in missing_paths:
+    if precision is None:
         defaults["speed"]["precision"] = info["precision"]
     return defaults
 
@@ -117,17 +123,20 @@ def get_cfg_from_args(args):
     default_cfg = OmegaConf.create(default_config)
     model_name = OmegaConf.select(requested_cfg, "model.name")
     cfg = OmegaConf.merge(default_cfg, user_cfg, cli_cfg)
-    missing_paths = {
-        path
-        for path in (
-            "tiling.params.requested_tile_size_px",
-            "tiling.params.requested_spacing_um",
-            "speed.precision",
+    requested_spacing_um = OmegaConf.select(cfg, "tiling.params.requested_spacing_um")
+    requested_tile_size_px = OmegaConf.select(cfg, "tiling.params.requested_tile_size_px")
+    precision = OmegaConf.select(cfg, "speed.precision")
+    if model_name and (
+        requested_spacing_um is None
+        or requested_tile_size_px is None
+        or precision is None
+    ):
+        encoder_defaults = _encoder_derived_cfg(
+            model_name,
+            requested_spacing_um=requested_spacing_um,
+            requested_tile_size_px=requested_tile_size_px,
+            precision=precision,
         )
-        if OmegaConf.select(cfg, path) is None
-    }
-    if model_name and missing_paths:
-        encoder_defaults = _encoder_derived_cfg(model_name, missing_paths)
         _fill_null_encoder_defaults(cfg, encoder_defaults)
     OmegaConf.resolve(cfg)
     validate_model_recommended_settings(cfg, run_on_cpu=bool(getattr(args, "run_on_cpu", False)))

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -260,7 +260,82 @@ def test_get_cfg_from_args_fills_null_spacing_from_model_default(tmp_path: Path)
     assert cfg.tiling.params.requested_tile_size_px == 448
 
 
-def test_get_cfg_from_args_rejects_models_with_ambiguous_spacing_defaults(tmp_path: Path):
+@pytest.mark.parametrize(
+    ("encoder_name", "expected_tile_size_px", "expected_precision"),
+    [
+        ("virchow2", 224, "fp16"),
+        ("midnight", 224, "fp16"),
+        ("musk", 384, "fp16"),
+    ],
+)
+def test_yaml_and_cli_fill_fields_missing_from_explicit_spacing_identically(
+    tmp_path: Path,
+    encoder_name,
+    expected_tile_size_px,
+    expected_precision,
+):
+    pytest.importorskip("omegaconf")
+
+    from slide2vec.utils.config import get_cfg_from_args
+
+    yaml_path = tmp_path / "yaml-config.yaml"
+    yaml_path.write_text(
+        "\n".join(
+            [
+                "csv: /tmp/slides.csv",
+                "output_dir: /tmp/output",
+                "model:",
+                f"  name: {encoder_name}",
+                "tiling:",
+                "  params:",
+                "    requested_spacing_um: 0.5",
+            ]
+        )
+    )
+    cli_path = tmp_path / "cli-config.yaml"
+    cli_path.write_text(
+        "\n".join(
+            [
+                "csv: /tmp/slides.csv",
+                "output_dir: /tmp/output",
+            ]
+        )
+    )
+
+    yaml_cfg = get_cfg_from_args(
+        SimpleNamespace(
+            config_file=str(yaml_path),
+            output_dir=None,
+            opts=[],
+            run_on_cpu=False,
+        )
+    )
+    cli_cfg = get_cfg_from_args(
+        SimpleNamespace(
+            config_file=str(cli_path),
+            output_dir=None,
+            opts=[
+                f"model.name={encoder_name}",
+                "tiling.params.requested_spacing_um=0.5",
+            ],
+            run_on_cpu=False,
+        )
+    )
+
+    expected = (0.5, expected_tile_size_px, expected_precision)
+    assert (
+        yaml_cfg.tiling.params.requested_spacing_um,
+        yaml_cfg.tiling.params.requested_tile_size_px,
+        yaml_cfg.speed.precision,
+    ) == expected
+    assert (
+        cli_cfg.tiling.params.requested_spacing_um,
+        cli_cfg.tiling.params.requested_tile_size_px,
+        cli_cfg.speed.precision,
+    ) == expected
+
+
+def test_yaml_fills_only_missing_precision_without_re_resolving_spacing(tmp_path: Path):
     pytest.importorskip("omegaconf")
 
     from slide2vec.utils.config import get_cfg_from_args
@@ -272,7 +347,48 @@ def test_get_cfg_from_args_rejects_models_with_ambiguous_spacing_defaults(tmp_pa
                 "csv: /tmp/slides.csv",
                 "output_dir: /tmp/output",
                 "model:",
-                    "  name: virchow2",
+                "  name: virchow2",
+                "tiling:",
+                "  params:",
+                "    requested_spacing_um: 0.5",
+                "    requested_tile_size_px: 224",
+                "speed:",
+                "  precision:",
+            ]
+        )
+    )
+
+    cfg = get_cfg_from_args(
+        SimpleNamespace(
+            config_file=str(cfg_path),
+            output_dir=None,
+            opts=[],
+            run_on_cpu=False,
+        )
+    )
+
+    assert cfg.tiling.params.requested_spacing_um == pytest.approx(0.5)
+    assert cfg.tiling.params.requested_tile_size_px == 224
+    assert cfg.speed.precision == "fp16"
+
+
+@pytest.mark.parametrize("encoder_name", ["virchow2", "midnight", "musk"])
+def test_get_cfg_from_args_rejects_models_with_ambiguous_spacing_defaults(
+    tmp_path: Path,
+    encoder_name,
+):
+    pytest.importorskip("omegaconf")
+
+    from slide2vec.utils.config import get_cfg_from_args
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "\n".join(
+            [
+                "csv: /tmp/slides.csv",
+                "output_dir: /tmp/output",
+                "model:",
+                f"  name: {encoder_name}",
                 "tiling:",
                 "  params: {}",
             ]

--- a/tests/test_regression_models.py
+++ b/tests/test_regression_models.py
@@ -427,11 +427,47 @@ def test_model_embed_slide_infers_missing_values_from_explicit_backend_only_prep
     assert captured["preprocessing"].requested_spacing_um == pytest.approx(0.5)
 
 
+@pytest.mark.parametrize(
+    ("encoder_name", "expected_tile_size_px", "expected_precision"),
+    [
+        ("virchow2", 224, "fp16"),
+        ("midnight", 224, "fp16"),
+        ("musk", 384, "fp16"),
+    ],
+)
+def test_model_embed_slides_fills_fields_missing_from_spacing_only_preprocessing(
+    monkeypatch,
+    encoder_name,
+    expected_tile_size_px,
+    expected_precision,
+):
+    model = Model.from_preset(encoder_name)
+    slide = _make_embedded_slide()
+    captured = {}
+
+    def fake_embed_slides(model_arg, slides, **kwargs):
+        captured["preprocessing"] = kwargs["preprocessing"]
+        captured["execution"] = kwargs["execution"]
+        return [slide]
+
+    monkeypatch.setattr("slide2vec.inference.embed_slides", fake_embed_slides)
+
+    model.embed_slides(
+        ["/tmp/slide-a.svs"],
+        preprocessing=PreprocessingConfig(requested_spacing_um=0.5),
+    )
+
+    assert captured["preprocessing"].requested_spacing_um == pytest.approx(0.5)
+    assert captured["preprocessing"].requested_tile_size_px == expected_tile_size_px
+    assert captured["execution"].precision == expected_precision
+
+
+@pytest.mark.parametrize("encoder_name", ["virchow2", "midnight", "musk"])
 def test_model_embed_slides_rejects_ambiguous_default_spacing(
     monkeypatch,
+    encoder_name,
 ):
-    # virchow2 supports multiple spacings; direct API should require an explicit choice.
-    model = Model.from_preset("virchow2")
+    model = Model.from_preset(encoder_name)
     expected = [
         EmbeddedSlide(
             sample_id="slide-a",


### PR DESCRIPTION
## Summary
- resolve requested spacing and tile size independently through one encoder-registry policy
- preserve explicit spacing while deriving only missing tile size and precision for Python, YAML, and CLI configs
- keep preset-only multi-spacing selection deterministic and covered for Virchow2, Midnight, and MUSK

## Root cause
Both configuration frontends invoked the strict coupled preprocessing-default resolver whenever any field was missing. For multi-spacing encoders, resolving tile size or precision therefore re-entered spacing inference even when spacing was explicit.

## Validation
- `python -m pytest -q tests/test_regression_core.py tests/test_regression_models.py tests/test_encoder_registry.py tests/test_tiling_pipeline.py --no-cov` — 146 passed
- changed-source flake checks and `git diff --check`
- two-axis `/code-review main` — no remaining Standards or Spec findings

Closes #247