### PR TITLE
Align slide2vec with hs2p 4.4.0

### DIFF
--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -63,10 +63,12 @@ embedding directory, and the tiling artifacts are namespaced the same way:
            ├── tumor/<sample_id>.png
            └── stroma/<sample_id>.png
 
-The ``tissue`` class (and the ``merged`` ``output_mode``) carry no class label
-and collapse to the flat root shown earlier — there is no ``tissue/``
-subdirectory. ``process_list.csv`` has one row per ``(sample_id, annotation)``
-pair, each recording that class's own ``feature_path``.
+The ``tissue`` class and structural ``merged`` output collapse to the flat root
+shown earlier — there is no ``tissue/`` or ``merged/`` subdirectory. hs2p 4.4
+stores merged artifacts as ``annotation=None`` plus ``output_mode="merged"``,
+while ``process_list.csv`` keeps the readable ``merged`` label. Per-class mode
+has one row per ``(sample_id, annotation)`` pair, each recording that class's
+own ``feature_path``.
 
 
 Embedding Files
@@ -371,6 +373,13 @@ tiling pipeline. It contains several sections:
 These files can be reused across runs via
 :attr:`~slide2vec.PreprocessingConfig.read_coordinates_from` to skip
 tiling when only the encoder changes.
+
+Artifacts written with hs2p 4.3 remain loadable, but ``resume`` and
+``read_coordinates_from`` still validate artifact compatibility. hs2p 4.4
+changed ``auto`` backend priority to cucim → vips → openslide → asap, so a 4.3
+artifact created with ``backend="auto"`` may resolve to a different decoder and
+be rejected or recomputed instead of silently reused. Pin the original explicit
+backend when stable reuse across that boundary is required.
 
 
 Process List

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -15,7 +15,8 @@ Backends
 
 The ``backend`` field controls which slide-reading library is used:
 
-- ``"auto"`` — tries cucim → openslide → vips in order and picks the first available one
+- ``"auto"`` — tries cucim → vips → openslide → asap and picks the first backend
+  that can open the path
 - ``"cucim"`` — NVIDIA cuCIM (fastest for SVS/TIFF on GPU-equipped machines)
 - ``"openslide"`` — broad format support, CPU-only
 - ``"vips"`` — libvips, good for large TIFF files
@@ -28,6 +29,15 @@ slide. Since hs2p no longer silently falls back to another reader, set ``mask_ba
 explicitly (e.g. ``"openslide"``) when a mask cannot be decoded by the slide backend — for
 example a deflate-compressed label TIFF that cuCIM can open but not decode. It defaults to
 ``"auto"`` and is ignored for slides with no source mask.
+
+The ``auto`` priority can change which decoder is selected when hs2p or the
+installed backend set changes. Set ``backend`` and ``mask_backend`` explicitly
+when decoder selection must remain stable across upgrades.
+
+Tile TAR export uses the portable Pillow encoder (``jpeg_backend="pil"``) by
+default. ``jpeg_backend="turbojpeg"`` remains an explicit performance opt-in;
+when its optional upstream dependency is unavailable, hs2p reports the
+actionable dependency error rather than silently choosing another encoder.
 
 
 Pooled Tile Geometry
@@ -141,7 +151,9 @@ raster**: each class occupies a distinct integer pixel value. The ``masks`` bloc
 maps that vocabulary and is deep-merged over the default, so you only state what
 you add:
 
-- ``pixel_mapping`` — ``{class_name: integer pixel value in the raster}``
+- ``pixel_mapping`` — ``{class_name: integer pixel value in the raster}``. Values
+  must be distinct integers in ``[0, 255]``; ``merged`` is reserved for structural
+  merged output and cannot be used as a class name.
 - ``min_coverage`` — ``{class_name: float | null}``; the minimum fraction of a
   tile that must be covered by that class to keep it. ``null`` means *don't
   sample that class*. The ``tissue`` entry is the single source of truth for the
@@ -231,6 +243,12 @@ a class name — its :attr:`~slide2vec.EmbeddedSlide.annotation` is ``"merged"``
 the inner ``embed_slides`` key is ``"merged"``, and on disk it lands at the flat
 output root (``tile_embeddings/<sample_id>.pt``) with **no** ``<class>/``
 subdirectory, exactly like the default ``tissue`` case:
+
+In hs2p 4.4 artifacts this structural output is represented as
+``annotation=None`` plus ``output_mode="merged"``. The human-readable
+``process_list.csv`` row and in-memory bag label remain ``"merged"``; slide2vec
+keeps those process and artifact identities separate so resume and distributed
+coordination continue to use the flat structural path.
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.3.0",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.0",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -88,7 +88,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.3.0",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.0",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -132,7 +132,7 @@ def _masks_to_plain_dict(node: Any) -> dict[str, Any]:
 class PreprocessingConfig:
     """Configuration for slide tiling and preprocessing."""
 
-    #: Slide reading backend. ``"auto"`` tries cucim → openslide → vips in order.
+    #: Slide reading backend. ``"auto"`` tries cucim → vips → openslide → asap.
     #: Explicit choices: ``"cucim"``, ``"openslide"``, ``"vips"``, ``"asap"``.
     backend: str = "auto"
     #: Source-mask reading backend, resolved independently from the *mask* path
@@ -169,8 +169,9 @@ class PreprocessingConfig:
     adaptive_batching: bool = False
     #: Group adjacent tiles into supertile batches for faster I/O.
     use_supertiles: bool = True
-    #: JPEG decode library — ``"turbojpeg"`` (default) or ``"pillow"``.
-    jpeg_backend: str = "turbojpeg"
+    #: JPEG encoder for extracted tile archives — portable ``"pil"`` (default) or
+    #: explicitly requested ``"turbojpeg"``.
+    jpeg_backend: str = "pil"
     #: Number of CuCIM reader threads.
     num_cucim_workers: int = 4
     #: Skip slides already present in the output directory when ``True``.
@@ -415,7 +416,8 @@ class DenseOptions:
     target_size: int
     #: Relative spacing tolerance for pyramid level selection.
     tolerance: float = 0.05
-    #: Slide reading backend. ``"auto"`` resolves per slide (cucim → openslide → vips).
+    #: Slide reading backend. ``"auto"`` resolves per slide
+    #: (cucim → vips → openslide → asap).
     backend: str = "auto"
     #: Padding mode used to pad the tile up to the encoder's patch multiple.
     #: One of ``"reflect"`` / ``"replicate"`` / ``"constant"`` / ``"zero"``.

--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 import numpy as np
 import torch
-from hs2p.fileops import is_flattened_annotation
 
 from slide2vec.runtime.model_settings import output_torch_dtype
 
@@ -209,15 +208,32 @@ def _write_metadata(path: Path, metadata: dict[str, Any]) -> None:
     )
 
 
+def normalize_artifact_annotation(annotation: str | None) -> str | None:
+    """Return the annotation component used for slide2vec artifact placement.
+
+    ``"merged"`` is a process-list sentinel, not an hs2p 4.4 artifact annotation:
+    structural merged output is ``annotation=None`` plus ``output_mode="merged"``.
+    Accepting the sentinel here keeps 4.3 process lists reusable without delegating
+    process identity to hs2p's artifact-annotation helper.
+    """
+    if annotation in (None, "tissue", "merged"):
+        return None
+    return str(annotation)
+
+
+def structural_artifact_annotation(annotation: str | None) -> str | None:
+    """Translate only the structural merged process sentinel to artifact identity."""
+    return None if annotation == "merged" else annotation
+
+
 def tile_embeddings_subdir(annotation: str | None) -> str:
     """Namespace the ``tile_embeddings`` output dir per annotation class.
 
-    Reuses hs2p's flatten rule (the single source of truth): ``None`` and the sentinel
-    ``"tissue"`` collapse to the flat ``tile_embeddings`` root, so the default tissue-only
-    path is byte-for-byte unchanged; any real class label gets its own
-    ``tile_embeddings/<class>`` subdirectory.
+    Structural ``None`` and the process sentinels ``"tissue"``/``"merged"`` collapse to
+    the flat root; a genuine class gets ``tile_embeddings/<class>``.
     """
-    if is_flattened_annotation(annotation):
+    annotation = normalize_artifact_annotation(annotation)
+    if annotation is None:
         return "tile_embeddings"
     return f"tile_embeddings/{annotation}"
 
@@ -225,19 +241,18 @@ def tile_embeddings_subdir(annotation: str | None) -> str:
 def slide_embeddings_subdir(annotation: str | None) -> str:
     """Namespace the ``slide_embeddings`` output dir per annotation class.
 
-    Reuses hs2p's flatten rule (the single source of truth, shared with
-    :func:`tile_embeddings_subdir`): ``None`` and the sentinel ``"tissue"`` collapse to the
-    flat ``slide_embeddings`` root, so the default tissue-only path is byte-for-byte
-    unchanged; any real class label gets its own ``slide_embeddings/<class>`` subdirectory.
+    Uses the same structural/process identity rule as :func:`tile_embeddings_subdir`.
     """
-    if is_flattened_annotation(annotation):
+    annotation = normalize_artifact_annotation(annotation)
+    if annotation is None:
         return "slide_embeddings"
     return f"slide_embeddings/{annotation}"
 
 
 def slide_latents_subdir(annotation: str | None) -> str:
     """Namespace the ``slide_latents`` output dir per annotation class (mirrors slide embeddings)."""
-    if is_flattened_annotation(annotation):
+    annotation = normalize_artifact_annotation(annotation)
+    if annotation is None:
         return "slide_latents"
     return f"slide_latents/{annotation}"
 
@@ -245,13 +260,10 @@ def slide_latents_subdir(annotation: str | None) -> str:
 def hierarchical_embeddings_subdir(annotation: str | None) -> str:
     """Namespace the ``hierarchical_embeddings`` output dir per annotation class.
 
-    Reuses hs2p's flatten rule (the single source of truth, shared with
-    :func:`tile_embeddings_subdir` and :func:`slide_embeddings_subdir`): ``None`` and the
-    sentinel ``"tissue"`` collapse to the flat ``hierarchical_embeddings`` root, so the
-    default tissue-only path is byte-for-byte unchanged; any real class label gets its own
-    ``hierarchical_embeddings/<class>`` subdirectory.
+    Uses the same structural/process identity rule as :func:`tile_embeddings_subdir`.
     """
-    if is_flattened_annotation(annotation):
+    annotation = normalize_artifact_annotation(annotation)
+    if annotation is None:
         return "hierarchical_embeddings"
     return f"hierarchical_embeddings/{annotation}"
 
@@ -273,12 +285,10 @@ def _validate_path_component(value: str, *, field: str) -> str:
 def dense_embeddings_subdir(annotation: str | None) -> str:
     """Namespace the ``dense_embeddings`` output dir per annotation class.
 
-    Reuses hs2p's flatten rule (the single source of truth, shared with
-    :func:`tile_embeddings_subdir` and the other pooled subdir helpers): ``None`` and the
-    sentinel ``"tissue"`` collapse to the flat ``dense_embeddings`` root; any real class
-    label gets its own ``dense_embeddings/<class>`` subdirectory.
+    Uses the same structural/process identity rule as :func:`tile_embeddings_subdir`.
     """
-    if is_flattened_annotation(annotation):
+    annotation = normalize_artifact_annotation(annotation)
+    if annotation is None:
         return "dense_embeddings"
     annotation_component = _validate_path_component(annotation, field="annotation")
     return f"dense_embeddings/{annotation_component}"
@@ -330,6 +340,7 @@ def write_dense_region(
 ) -> DenseRegionArtifact:
     """Persist one ROI's ``(d, gh, gw)`` grid + its geometry sidecar (see
     :func:`_write_dense_grid` for the write order this shares with every dense artifact)."""
+    annotation = structural_artifact_annotation(annotation)
     payload_path, metadata_path = region_dense_paths(
         output_dir, sample_id=sample_id, annotation=annotation, x=x, y=y
     )
@@ -476,9 +487,7 @@ def _build_tile_embedding_metadata(
     }
     if metadata:
         tile_metadata.update(metadata)
-    tile_metadata["annotation"] = (
-        None if is_flattened_annotation(annotation) else str(annotation)
-    )
+    tile_metadata["annotation"] = normalize_artifact_annotation(annotation)
     return tile_metadata
 
 
@@ -578,6 +587,7 @@ def write_slide_embeddings(
     annotation: str | None = None,
 ) -> SlideEmbeddingArtifact:
     output_format = _validate_output_format(output_format)
+    annotation = structural_artifact_annotation(annotation)
     artifact_path, metadata_path = _setup_artifact_paths(
         output_dir, slide_embeddings_subdir(annotation), sample_id, output_format
     )
@@ -665,6 +675,7 @@ def write_hierarchical_embeddings(
     annotation: str | None = None,
 ) -> HierarchicalEmbeddingArtifact:
     output_format = _validate_output_format(output_format)
+    annotation = structural_artifact_annotation(annotation)
     artifact_path, metadata_path = _setup_artifact_paths(
         output_dir, hierarchical_embeddings_subdir(annotation), sample_id, output_format
     )

--- a/slide2vec/configs/default.yaml
+++ b/slide2vec/configs/default.yaml
@@ -22,10 +22,10 @@ tiling:
   gpu_decode: false # GPU-accelerated batch decoding via device="cuda" in cucim read_region; set true to opt in when the runtime is configured for it (experimental, may not be stable across all environments)
   adaptive_batching: false # when true, vary batch size to align with super tile boundaries (avoids redundant reads but batch size fluctuates)
   use_supertiles: true # group tiles into 8x8/4x4/2x2 super tile reads to reduce WSI read calls (on-the-fly path only)
-  jpeg_backend: "turbojpeg" # JPEG encoder for tar extraction: "turbojpeg" (faster) or "pil" (compatible with older ground truth fixtures)
+  jpeg_backend: "pil" # Portable JPEG encoder for tar extraction; set "turbojpeg" explicitly to opt in to its upstream dependency
   read_coordinates_from: # path to an existing directory containing pre-extracted `.coordinates.npz` / `.coordinates.meta.json` artifacts to reuse instead of starting tiling from scratch
   read_tiles_from: # path to an existing directory containing pre-extracted `.tiles.tar` tile stores to reuse instead of starting tiling from scratch
-  backend: "auto" # backend to use for slide reading; "auto" lets hs2p resolve the best backend per slide, preferring cuCIM when available
+  backend: "auto" # backend to use for slide reading; "auto" tries cucim -> vips -> openslide -> asap. Pin a backend for stable decoder selection across upgrades.
   mask_backend: "auto" # backend for reading source masks (precomputed tissue / annotation), resolved independently from the mask path; "auto" probes openability like `backend`. Set explicitly (e.g. "openslide") when a mask needs a different decoder than its slide — hs2p (>=4.3.0) no longer silently falls back
   independent_sampling: true # selection strategy when annotation sampling is active. true: sample each class independently against its own binary mask (independent selection); false: sample once over the union of active classes, then post-filter per class by coverage (joint selection). Ignored when the masks vocabulary is left at the tissue-only default.
   masks:

--- a/slide2vec/runtime/artifacts_collect.py
+++ b/slide2vec/runtime/artifacts_collect.py
@@ -5,11 +5,11 @@ from typing import Sequence
 
 import pandas as pd
 from hs2p import SlideSpec
-from hs2p.fileops import is_flattened_annotation
 
 from slide2vec.api import EmbeddedSlide, ExecutionOptions, PreprocessingConfig
 from slide2vec.artifacts import (
     HierarchicalEmbeddingArtifact,
+    normalize_artifact_annotation,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
 )
@@ -100,17 +100,12 @@ def _has_tiles(num_tiles) -> bool:
 def _normalized_row_annotation(annotation) -> str | None:
     """Collapse a process-list ``annotation`` cell to the per-class key (``None`` for the flat path).
 
-    Mirrors the in-memory single-GPU path: ``None``/NaN and hs2p's flat-layout sentinels
-    (:func:`hs2p.fileops.is_flattened_annotation` — the single source of truth, which flattens
-    ``None``/``"tissue"``/``"merged"``) land flat — so the distributed reconcile keys those rows
-    to the flat embedding path with no per-class subdir.
+    Mirrors the in-memory single-GPU path: structural/process annotations land flat,
+    while genuine classes keep their namespace.
     """
     if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
         return None
-    annotation = str(annotation)
-    if is_flattened_annotation(annotation):
-        return None
-    return annotation
+    return normalize_artifact_annotation(str(annotation))
 
 
 def _annotations_parallel_to_slides(

--- a/slide2vec/runtime/dense_shard.py
+++ b/slide2vec/runtime/dense_shard.py
@@ -35,6 +35,7 @@ from slide2vec.artifacts import (
     DenseRegionArtifact,
     load_metadata,
     region_dense_paths,
+    structural_artifact_annotation,
     write_dense_region,
 )
 
@@ -113,7 +114,9 @@ def dense_artifact_from_disk(out_dir, spec) -> DenseRegionArtifact:
         metadata_path=sidecar_path,
         feature_dim=int(meta["feature_dim"]),
         grid_shape=(grid_shape[0], grid_shape[1]),
-        annotation=spec.annotation,
+        annotation=structural_artifact_annotation(
+            meta.get("annotation", spec.annotation)
+        ),
     )
 
 
@@ -184,7 +187,7 @@ def _region_metadata(
     return {
         "artifact_type": "dense_embeddings",
         "sample_id": spec.sample_id,
-        "annotation": spec.annotation,
+        "annotation": structural_artifact_annotation(spec.annotation),
         "x": int(spec.x),
         "y": int(spec.y),
         "format": "pt",

--- a/slide2vec/runtime/distributed.py
+++ b/slide2vec/runtime/distributed.py
@@ -17,8 +17,8 @@ from typing import Any, Callable, Sequence
 import numpy as np
 import torch
 from hs2p import SlideSpec
-from hs2p.fileops import is_flattened_annotation
 
+from slide2vec.artifacts import normalize_artifact_annotation
 from slide2vec.progress import emit_progress_event, read_progress_events
 from slide2vec.runtime.hierarchical import num_tiles
 
@@ -31,18 +31,10 @@ _WORK_UNIT_PREFIX = "\x00s2v-unit\x00"
 def normalize_work_unit_annotation(annotation: str | None) -> str | None:
     """Collapse flat-layout annotations to ``None`` so flat units key by bare ``sample_id``.
 
-    Mirrors the in-memory single-GPU path and the distributed reconcile
-    (:func:`slide2vec.runtime.artifacts_collect._normalized_row_annotation`): hs2p's flat-layout
-    sentinels (:func:`hs2p.fileops.is_flattened_annotation`, the single source of truth — it
-    flattens ``None``/``"tissue"``/``"merged"``) all collapse to ``None``. Only genuine per-class
-    annotations survive as a composite key.
+    Mirrors artifact placement: structural ``None`` and process sentinels collapse to
+    ``None``. Only genuine per-class annotations survive as a composite key.
     """
-    if annotation is None:
-        return None
-    annotation = str(annotation)
-    if is_flattened_annotation(annotation):
-        return None
-    return annotation
+    return normalize_artifact_annotation(annotation)
 
 
 def encode_work_unit(sample_id: str, annotation: str | None) -> str:

--- a/slide2vec/runtime/embedding.py
+++ b/slide2vec/runtime/embedding.py
@@ -20,12 +20,14 @@ from slide2vec.runtime.model_settings import resolve_output_precision
 
 
 def tiling_result_annotation(tiling_result) -> str | None:
-    """Annotation class carried by a tiling result (from its process-list row).
+    """Human-readable process annotation carried by a tiling result.
 
-    ``None``/``"tissue"`` mean the flat tissue-only layout (see
-    :func:`slide2vec.artifacts.tile_embeddings_subdir`); any other label namespaces the
-    tile-embedding artifacts under a per-class subdirectory.
+    hs2p 4.4 represents structural merged output as ``annotation=None`` plus
+    ``output_mode="merged"`` while keeping ``"merged"`` in ``process_list.csv``. Rebuild
+    that informative label for public in-memory results without changing artifact identity.
     """
+    if getattr(tiling_result, "output_mode", None) == "merged":
+        return "merged"
     return getattr(tiling_result, "annotation", None)
 
 

--- a/slide2vec/runtime/persist_callbacks.py
+++ b/slide2vec/runtime/persist_callbacks.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Sequence
 
 import pandas as pd
 from hs2p import SlideSpec
-from hs2p.fileops import is_flattened_annotation
 
 from slide2vec.api import EmbeddedSlide, ExecutionOptions, PreprocessingConfig
 from slide2vec.artifacts import (
@@ -13,6 +12,7 @@ from slide2vec.artifacts import (
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
     hierarchical_embeddings_subdir,
+    normalize_artifact_annotation,
     slide_embeddings_subdir,
     slide_latents_subdir,
     tile_embeddings_subdir,
@@ -80,9 +80,7 @@ def _normalized_resume_annotation(annotation) -> str | None:
     """
     if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
         return None
-    if is_flattened_annotation(str(annotation)):
-        return None
-    return str(annotation)
+    return normalize_artifact_annotation(str(annotation))
 
 
 def _row_annotation(row) -> str | None:

--- a/slide2vec/runtime/persistence.py
+++ b/slide2vec/runtime/persistence.py
@@ -6,7 +6,6 @@ from typing import Any, Sequence
 import numpy as np
 import pandas as pd
 from hs2p import SlideSpec
-from hs2p.fileops import is_flattened_annotation
 
 from slide2vec.artifacts import (
     HierarchicalEmbeddingArtifact,
@@ -15,6 +14,7 @@ from slide2vec.artifacts import (
     hierarchical_embeddings_subdir,
     load_array,
     load_metadata,
+    normalize_artifact_annotation,
     slide_embeddings_subdir,
     slide_latents_subdir,
     tile_embeddings_subdir,
@@ -274,19 +274,12 @@ def update_process_list_after_embedding(
 def _normalized_annotation(annotation: Any) -> str | None:
     """Collapse the flat-layout sentinels (``None``/``"tissue"``/``"merged"``) to a single ``None`` key.
 
-    Keying the per-class feature-path map on this normalized value lets the flat tissue-only
-    path and a real class share one matching rule without the sentinel leaking into lookups.
-    Flattening is decided solely by :func:`hs2p.fileops.is_flattened_annotation` (the single
-    source of truth), which flattens ``None``/``"tissue"``/``"merged"`` to the flat root, so
-    ``"merged"`` (hs2p's merged output-mode label, which carries no class) resolves to the flat
-    embedding path rather than being left unmatched.
+    Keying the per-class feature-path map on this normalized value lets structural/process
+    rows and genuine classes share one matching rule without a sentinel leaking into paths.
     """
     if annotation is None or (isinstance(annotation, float) and pd.isna(annotation)):
         return None
-    annotation = str(annotation)
-    if is_flattened_annotation(annotation):
-        return None
-    return annotation
+    return normalize_artifact_annotation(str(annotation))
 
 
 def _row_annotation_series(df: pd.DataFrame) -> pd.Series:

--- a/slide2vec/runtime/serialization.py
+++ b/slide2vec/runtime/serialization.py
@@ -185,7 +185,7 @@ def deserialize_preprocessing(payload: dict[str, Any]) -> PreprocessingConfig:
         gpu_decode=bool(payload.get("gpu_decode", False)),
         adaptive_batching=bool(payload.get("adaptive_batching", False)),
         use_supertiles=bool(payload.get("use_supertiles", True)),
-        jpeg_backend=str(payload.get("jpeg_backend", "turbojpeg")),
+        jpeg_backend=str(payload.get("jpeg_backend", "pil")),
         num_cucim_workers=int(payload.get("num_cucim_workers", 4)),
         resume=bool(payload["resume"]) if "resume" in payload else False,
         segmentation=dict(payload["segmentation"]) if "segmentation" in payload else {},

--- a/slide2vec/utils/tiling_io.py
+++ b/slide2vec/utils/tiling_io.py
@@ -58,6 +58,7 @@ BASE_PROCESS_COLUMNS = (
 BASE_TILING_ORDERED_COLUMNS = (
     "sample_id",
     "annotation",
+    "output_mode",
     "image_path",
     "mask_path",
     "requested_backend",
@@ -78,6 +79,7 @@ BASE_TILING_ORDERED_COLUMNS = (
 BASE_EMBEDDING_ORDERED_COLUMNS = (
     "sample_id",
     "annotation",
+    "output_mode",
     "image_path",
     "mask_path",
     "requested_backend",
@@ -211,6 +213,16 @@ def _load_base_process_df(process_list_path: str | Path) -> pd.DataFrame:
         df["mask_backend"] = [None] * len(df)
     if "annotation" not in df.columns:
         df["annotation"] = ["tissue"] * len(df)
+    reconstructed_output_mode = df["annotation"].map(
+        lambda annotation: "merged" if str(annotation) == "merged" else None
+    )
+    if "output_mode" not in df.columns:
+        df["output_mode"] = reconstructed_output_mode
+    else:
+        df["output_mode"] = df["output_mode"].where(
+            df["output_mode"].notna(),
+            reconstructed_output_mode,
+        )
     if "tiles_tar_path" not in df.columns:
         df["tiles_tar_path"] = [None] * len(df)
     if "mask_preview_path" not in df.columns:
@@ -264,13 +276,20 @@ def load_tiling_result_from_row(row):
     if annotation is not None and pd.isna(annotation):
         annotation = None
     annotation = annotation if annotation is None else str(annotation)
-    # The merged output mode (hs2p's CoordinateOutputMode.MERGED) emits a single per-slide
-    # coordinate set over the union of tiles passing any active class threshold. hs2p labels
-    # that process-list row "merged" so it is not mistaken for plain tissue. The informative
-    # label is preserved verbatim here — artifact placement is decided downstream solely by
-    # hs2p.fileops.is_flattened_annotation (which flattens None/"tissue"/"merged" to the flat
-    # output root), so "merged" still lands flat without erasing its self-describing label.
-    setattr(tiling_result, "annotation", annotation)
+    output_mode = row.get("output_mode")
+    if output_mode is None or pd.isna(output_mode):
+        output_mode = getattr(tiling_result, "output_mode", None)
+    if output_mode is not None and pd.isna(output_mode):
+        output_mode = None
+    output_mode = output_mode if output_mode is None else str(output_mode)
+    # hs2p 4.4 deliberately separates the human-readable process row ("merged") from
+    # structural artifact identity (annotation=None, output_mode="merged"). Reconstruct
+    # output_mode for 4.3 process lists, but never copy the process sentinel into the
+    # TilingResult's artifact annotation.
+    if output_mode is None and annotation == "merged":
+        output_mode = "merged"
+    setattr(tiling_result, "output_mode", output_mode)
+    setattr(tiling_result, "annotation", None if output_mode == "merged" else annotation)
     setattr(tiling_result, "tiles_tar_path", _optional_path(row.get("tiles_tar_path")))
     setattr(tiling_result, "mask_preview_path", _optional_path(row.get("mask_preview_path")))
     setattr(tiling_result, "tiling_preview_path", _optional_path(row.get("tiling_preview_path")))

--- a/tests/test_dense_shard.py
+++ b/tests/test_dense_shard.py
@@ -322,6 +322,42 @@ def test_run_dense_shard_namespaces_annotation_subdir(fake_backend, tmp_path):
     assert not (tmp_path / "dense_embeddings" / "s0").exists()  # not the flat root
 
 
+def test_run_dense_shard_keeps_merged_structural_identity_on_fresh_and_resume(
+    fake_backend,
+    tmp_path,
+):
+    region = _spec(0, 0, annotation="merged")
+    encoder = _encoder()
+
+    fresh = run_dense_shard(
+        [region],
+        model=encoder,
+        out_dir=tmp_path,
+        dense=_dense(),
+        batch_size=1,
+        device="cpu",
+        num_workers=0,
+    )
+    resumed = run_dense_shard(
+        [region],
+        model=encoder,
+        out_dir=tmp_path,
+        dense=_dense(),
+        batch_size=1,
+        device="cpu",
+        num_workers=0,
+    )
+
+    expected_path = tmp_path / "dense_embeddings" / "s0" / "0_0.pt"
+    metadata = json.loads(expected_path.with_suffix(".meta.json").read_text())
+    assert fresh[0].path == expected_path.resolve()
+    assert fresh[0].annotation is None
+    assert metadata["annotation"] is None
+    assert resumed[0].path == expected_path.resolve()
+    assert resumed[0].annotation is None
+    assert fake_backend.open_count == 1
+
+
 def test_run_dense_shard_sidecar_records_extraction_geometry_only(fake_backend, tmp_path):
     """The sidecar carries the extraction geometry + encode params slide2vec owns — and no
     caller ``extra`` passthrough (D7)."""

--- a/tests/test_dense_stage.py
+++ b/tests/test_dense_stage.py
@@ -190,7 +190,10 @@ def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend,
 
     artifacts = dense_stage.embed_regions_dense(
         model,
-        [_regions(coords=((0, 0), (64, 0))), _regions(sample_id="s1", image_path="s1.tif", coords=((0, 0),))],
+        [
+            _regions(coords=((0, 0), (64, 0)), annotation="merged"),
+            _regions(sample_id="s1", image_path="s1.tif", coords=((0, 0),)),
+        ],
         dense=_dense(), execution=execution,
     )
 
@@ -204,11 +207,15 @@ def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend,
     # All three ROIs travelled to the npz, slide-ordered.
     assert captured["coords"].tolist() == [[0, 0], [64, 0], [0, 0]]
     assert [s["sample_id"] for s in captured["request"]["slides"]] == ["s0", "s1"]
+    assert [s["annotation"] for s in captured["request"]["slides"]] == ["merged", None]
     assert captured["request"]["dense"]["target_size"] == 64
     # Collection returns one artifact per input ROI, read back off disk (nobody gathered grids).
     assert len(artifacts) == 3
     assert (expected_output_dir / "dense_embeddings" / "s0" / "0_0.pt").exists()
     assert (expected_output_dir / "dense_embeddings" / "s1" / "0_0.pt").exists()
+    merged_artifacts = [artifact for artifact in artifacts if artifact.sample_id == "s0"]
+    assert [artifact.annotation for artifact in merged_artifacts] == [None, None]
+    assert [artifact.metadata["annotation"] for artifact in merged_artifacts] == [None, None]
 
 
 def test_embed_regions_dense_resume_skips_existing_and_logs(fake_backend, stub_read_plan, tmp_path, caplog):

--- a/tests/test_hs2p_package_cutover.py
+++ b/tests/test_hs2p_package_cutover.py
@@ -1,6 +1,7 @@
 import importlib
 from pathlib import Path
 from types import SimpleNamespace
+import tomllib
 
 import numpy as np
 import pandas as pd
@@ -20,6 +21,27 @@ def test_package_root_exports_api():
     assert hasattr(package, "DenseOptions")
     assert hasattr(package, "SlideRegions")
     assert hasattr(package, "DenseRegionArtifact")
+
+
+def test_dependency_declarations_require_hs2p_4_4_with_consistent_extras():
+    project = tomllib.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )["project"]
+    hs2p_dependencies = [
+        dependency
+        for dependency in (
+            *project["dependencies"],
+            *project["optional-dependencies"]["fm"],
+        )
+        if dependency.startswith("hs2p")
+    ]
+
+    assert hs2p_dependencies == [
+        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.0",
+        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.0",
+    ]
 
 
 def test_load_slide_manifest_requires_hs2p_schema(tmp_path: Path):
@@ -91,6 +113,7 @@ def test_load_tiling_process_df_accepts_hs2p_process_list_columns(tmp_path: Path
     assert list(df.columns) == [
         "sample_id",
         "annotation",
+        "output_mode",
         "image_path",
         "mask_path",
         "requested_backend",
@@ -133,6 +156,60 @@ def test_load_tiling_process_df_backfills_missing_mask_backend_columns(tmp_path:
     assert pd.isna(df.loc[0, "mask_backend"])
 
 
+@pytest.mark.parametrize(
+    ("header_suffix", "row_suffix", "expected_output_mode"),
+    [
+        (",output_mode", ",merged", "merged"),
+        ("", "", "merged"),
+    ],
+    ids=["hs2p-4.4", "hs2p-4.3-reconstructed"],
+)
+def test_load_tiling_process_df_preserves_merged_process_identity(
+    tmp_path: Path,
+    header_suffix: str,
+    row_suffix: str,
+    expected_output_mode: str,
+):
+    helper = importlib.import_module("slide2vec.utils.tiling_io")
+    process_list = tmp_path / "process_list.csv"
+    process_list.write_text(
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,"
+        "tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback"
+        f"{header_suffix}\n"
+        "slide-1,merged,/data/slide-1.svs,/data/slide-1-mask.png,auto,openslide,"
+        "success,4,/tmp/slide-1.coordinates.npz,/tmp/slide-1.coordinates.meta.json,,"
+        f"{row_suffix}\n",
+        encoding="utf-8",
+    )
+
+    df = helper.load_tiling_process_df(process_list)
+
+    assert df.loc[0, ["annotation", "output_mode"]].tolist() == [
+        "merged",
+        expected_output_mode,
+    ]
+
+
+def test_load_tiling_result_preserves_metadata_output_mode_when_row_omits_it(
+    tmp_path: Path,
+    monkeypatch,
+):
+    helper = importlib.import_module("slide2vec.utils.tiling_io")
+    metadata_result = SimpleNamespace(output_mode="classes")
+    monkeypatch.setattr(helper, "load_tiling_result", lambda **kwargs: metadata_result)
+
+    result = helper.load_tiling_result_from_row(
+        {
+            "annotation": "tumor",
+            "coordinates_npz_path": str(tmp_path / "slide-1.coordinates.npz"),
+            "coordinates_meta_path": str(tmp_path / "slide-1.coordinates.meta.json"),
+        }
+    )
+
+    assert result.annotation == "tumor"
+    assert result.output_mode == "classes"
+
+
 def test_load_embedding_process_df_accepts_hs2p_process_list_columns(tmp_path: Path):
     helper = importlib.import_module("slide2vec.utils.tiling_io")
 
@@ -146,6 +223,7 @@ def test_load_embedding_process_df_accepts_hs2p_process_list_columns(tmp_path: P
     assert list(df.columns) == [
         "sample_id",
         "annotation",
+        "output_mode",
         "image_path",
         "mask_path",
         "requested_backend",

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -1351,17 +1351,21 @@ def test_independent_sampling_toggle_selects_selection_strategy():
     assert joint[-2] == "joint_sampling"
 
 
-def test_merged_annotation_label_survives_round_trip_to_flat_root(tmp_path: Path):
-    """A merged tiling row is labelled ``merged`` by hs2p. The informative label must
-    survive the round-trip (no collapse to ``None``), yet artifacts still land at the flat
-    output root because hs2p's ``is_flattened_annotation`` flattens ``"merged"``."""
+def test_merged_process_row_loads_structural_artifact_identity(tmp_path: Path):
+    """hs2p 4.4 labels the process row ``merged`` but stores a structural artifact.
+
+    Loading must retain/reconstruct ``output_mode="merged"`` while restoring the
+    TilingResult's artifact annotation to ``None``. The human-readable process label is
+    derived deliberately rather than passed to artifact routing.
+    """
+    from slide2vec.runtime.embedding import tiling_result_annotation
     from slide2vec.utils.tiling_io import load_tiling_result_from_row
 
     coordinates_meta_path = tmp_path / "slide-a.coordinates.meta.json"
     coordinates_meta_path.write_text("{}", encoding="utf-8")
 
     def fake_load_tiling_result(**kwargs):
-        return SimpleNamespace()
+        return SimpleNamespace(annotation=None, output_mode="merged")
 
     import slide2vec.utils.tiling_io as tiling_io
 
@@ -1371,6 +1375,7 @@ def test_merged_annotation_label_survives_round_trip_to_flat_root(tmp_path: Path
         result = load_tiling_result_from_row(
             {
                 "annotation": "merged",
+                "output_mode": "merged",
                 "coordinates_npz_path": str(tmp_path / "slide-a.coordinates.npz"),
                 "coordinates_meta_path": str(coordinates_meta_path),
             }
@@ -1378,8 +1383,9 @@ def test_merged_annotation_label_survives_round_trip_to_flat_root(tmp_path: Path
     finally:
         tiling_io.load_tiling_result = original
 
-    # The informative label survives the round-trip; it is not blanked to None.
-    assert result.annotation == "merged"
+    assert result.annotation is None
+    assert result.output_mode == "merged"
+    assert tiling_result_annotation(result) == "merged"
     artifact = write_tile_embeddings(
         "slide-a",
         np.arange(8, dtype=np.float32).reshape(2, 4),
@@ -1387,13 +1393,12 @@ def test_merged_annotation_label_survives_round_trip_to_flat_root(tmp_path: Path
         output_format="npz",
         annotation=result.annotation,
     )
-    # ...but placement is decided by is_flattened_annotation, so it still lands flat.
     assert artifact.path == tmp_path / "tile_embeddings" / "slide-a.npz"
 
 
 def test_tissue_annotation_survives_round_trip_to_flat_root(tmp_path: Path):
     """A ``"tissue"`` row keeps its informative label through the round-trip while still
-    resolving to flat-root placement via ``is_flattened_annotation``."""
+    resolving to flat-root artifact placement."""
     from slide2vec.utils.tiling_io import load_tiling_result_from_row
 
     coordinates_meta_path = tmp_path / "slide-t.coordinates.meta.json"
@@ -1430,7 +1435,7 @@ def test_tissue_annotation_survives_round_trip_to_flat_root(tmp_path: Path):
 
 def test_real_class_annotation_survives_round_trip_to_per_class_subdir(tmp_path: Path):
     """A genuine class label (e.g. ``"tumor"``) survives the round-trip and routes to its
-    own per-class subdir, since ``is_flattened_annotation`` does not flatten it."""
+    own per-class subdir."""
     from slide2vec.utils.tiling_io import load_tiling_result_from_row
 
     coordinates_meta_path = tmp_path / "slide-u.coordinates.meta.json"
@@ -1507,6 +1512,45 @@ def test_invalid_masks_block_with_out_of_range_value_fails_fast():
         build_hs2p_configs(preprocessing)
 
 
+def test_masks_boundary_accepts_distinct_integer_value_255():
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    preprocessing = _masks_preprocessing(
+        {
+            "pixel_mapping": {"tumor": 255},
+            "colors": {"tumor": [255, 0, 0]},
+            "min_coverage": {"tumor": 0.5},
+        }
+    )
+
+    sampling = build_hs2p_configs(preprocessing)[-3]
+
+    assert sampling.pixel_mapping["tumor"] == 255
+
+
+@pytest.mark.parametrize(
+    ("pixel_mapping", "message"),
+    [
+        ({"tumor": 256}, r"\[0, 255\]"),
+        ({"merged": 2}, "reserved"),
+    ],
+    ids=["value-256", "reserved-merged"],
+)
+def test_masks_boundary_rejects_unsupported_annotation_values(pixel_mapping, message):
+    from slide2vec.runtime.tiling import build_hs2p_configs
+
+    annotation = next(iter(pixel_mapping))
+    preprocessing = _masks_preprocessing(
+        {
+            "pixel_mapping": pixel_mapping,
+            "min_coverage": {annotation: 0.5},
+        }
+    )
+
+    with pytest.raises(ValueError, match=message):
+        build_hs2p_configs(preprocessing)
+
+
 def test_write_tile_embeddings_namespaces_real_class_under_subdir(tmp_path: Path):
     features = np.arange(8, dtype=np.float32).reshape(2, 4)
     artifact = write_tile_embeddings(
@@ -1532,8 +1576,123 @@ def test_write_tile_embeddings_flattens_tissue_annotation(tmp_path: Path):
         assert artifact.path == tmp_path / "tile_embeddings" / f"sample-{annotation}.npz"
 
 
+def test_structural_merged_artifact_paths_stay_flat_while_classes_are_namespaced():
+    from slide2vec.artifacts import (
+        dense_embeddings_subdir,
+        hierarchical_embeddings_subdir,
+        slide_embeddings_subdir,
+        slide_latents_subdir,
+        tile_embeddings_subdir,
+    )
+
+    helpers = {
+        "tile": tile_embeddings_subdir,
+        "slide": slide_embeddings_subdir,
+        "latent": slide_latents_subdir,
+        "hierarchical": hierarchical_embeddings_subdir,
+        "dense": dense_embeddings_subdir,
+    }
+    expected = {
+        "tile": ("tile_embeddings", "tile_embeddings/tumor"),
+        "slide": ("slide_embeddings", "slide_embeddings/tumor"),
+        "latent": ("slide_latents", "slide_latents/tumor"),
+        "hierarchical": (
+            "hierarchical_embeddings",
+            "hierarchical_embeddings/tumor",
+        ),
+        "dense": ("dense_embeddings", "dense_embeddings/tumor"),
+    }
+
+    assert {
+        name: (helper("merged"), helper("tumor"))
+        for name, helper in helpers.items()
+    } == expected
+
+
+def test_structural_merged_persisted_artifacts_report_none_annotation(tmp_path: Path):
+    from slide2vec.artifacts import (
+        write_dense_region,
+        write_hierarchical_embeddings,
+        write_slide_embeddings,
+    )
+
+    tile = write_tile_embeddings(
+        "slide-a",
+        np.ones((2, 4), dtype=np.float32),
+        output_dir=tmp_path,
+        output_format="npz",
+        annotation="merged",
+    )
+    slide = write_slide_embeddings(
+        "slide-a",
+        np.ones((4,), dtype=np.float32),
+        output_dir=tmp_path,
+        output_format="npz",
+        annotation="merged",
+    )
+    hierarchical = write_hierarchical_embeddings(
+        "slide-a",
+        np.ones((1, 2, 4), dtype=np.float32),
+        output_dir=tmp_path,
+        output_format="npz",
+        annotation="merged",
+    )
+    dense = write_dense_region(
+        np.ones((4, 2, 2), dtype=np.float32),
+        output_dir=tmp_path,
+        sample_id="slide-a",
+        annotation="merged",
+        x=0,
+        y=0,
+        metadata={"feature_dim": 4, "grid_shape": [2, 2]},
+    )
+
+    assert [tile.annotation, slide.annotation, hierarchical.annotation, dense.annotation] == [
+        None,
+        None,
+        None,
+        None,
+    ]
+
+
 def test_preprocessing_config_defaults_backend_to_auto():
     assert DEFAULT_PREPROCESSING.backend == "auto"
+
+
+def test_preprocessing_jpeg_default_is_pil_across_public_shipped_and_serialized_config():
+    from slide2vec.runtime.serialization import (
+        deserialize_preprocessing,
+        serialize_preprocessing,
+    )
+
+    preprocessing = PreprocessingConfig(
+        requested_spacing_um=0.5,
+        requested_tile_size_px=224,
+    )
+    payload = serialize_preprocessing(preprocessing)
+    legacy_payload = {key: value for key, value in payload.items() if key != "jpeg_backend"}
+
+    assert preprocessing.jpeg_backend == "pil"
+    assert str(load_config("default").tiling.jpeg_backend) == "pil"
+    assert payload["jpeg_backend"] == "pil"
+    assert deserialize_preprocessing(legacy_payload).jpeg_backend == "pil"
+
+
+def test_preprocessing_turbojpeg_remains_an_explicit_serialized_opt_in():
+    from slide2vec.runtime.serialization import (
+        deserialize_preprocessing,
+        serialize_preprocessing,
+    )
+
+    preprocessing = PreprocessingConfig(
+        requested_spacing_um=0.5,
+        requested_tile_size_px=224,
+        jpeg_backend="turbojpeg",
+    )
+
+    assert deserialize_preprocessing(
+        serialize_preprocessing(preprocessing)
+    ).jpeg_backend == "turbojpeg"
 
 
 def test_preprocessing_config_defaults_spacing_and_tile_size_to_none():

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -721,8 +721,7 @@ def test_collect_distributed_pipeline_artifacts_keeps_flat_path_for_flattened_an
     annotation,
 ):
     """Issue #166 (parity): tissue / merged / None annotations stay on the flat slide_embeddings
-    path (no per-class subdir) in the distributed reconcile, mirroring is_flattened_annotation.
-    """
+    path (no per-class subdir) in the distributed reconcile."""
     process_list_path = tmp_path / "process_list.csv"
     _write_process_list(
         process_list_path,
@@ -2357,10 +2356,10 @@ def test_tile_slides_forwards_independent_sampling_selection_strategy(monkeypatc
     assert captured["kwargs"]["output_mode"] == "per_annotation"
 
 
-def test_prepare_tiled_slides_preserves_merged_row_label(monkeypatch, tmp_path: Path):
-    """A merged tiling row (hs2p labels it ``merged``) must load with its informative label
-    intact (annotation == "merged"), not blanked to None. Artifact placement still flattens
-    to the output root downstream via hs2p's ``is_flattened_annotation``."""
+def test_prepare_tiled_slides_reconstructs_legacy_merged_output_mode(
+    monkeypatch, tmp_path: Path
+):
+    """A 4.3 merged process row reconstructs hs2p 4.4 structural artifact identity."""
     process_list_path = tmp_path / "process_list.csv"
     process_list_path.write_text(
         "sample_id,annotation,image_path,mask_path,requested_backend,backend,tiling_status,num_tiles,coordinates_npz_path,coordinates_meta_path,error,traceback\n"
@@ -2382,7 +2381,11 @@ def test_prepare_tiled_slides_preserves_merged_row_label(monkeypatch, tmp_path: 
             result = load_tiling_result_from_row(row)
         finally:
             tiling_io.load_tiling_result = original
-        captured["annotation"] = result.annotation
+        captured["identity"] = (
+            result.annotation,
+            result.output_mode,
+            embedding.tiling_result_annotation(result),
+        )
         return result
 
     monkeypatch.setattr(tiling_pipeline, "load_tiling_result_from_row", fake_load)
@@ -2394,10 +2397,7 @@ def test_prepare_tiled_slides_preserves_merged_row_label(monkeypatch, tmp_path: 
         num_workers=0,
     )
 
-    assert captured["annotation"] == "merged"
-    from hs2p.fileops import is_flattened_annotation
-
-    assert is_flattened_annotation(captured["annotation"]) is True
+    assert captured["identity"] == (None, "merged", "merged")
 
 
 def test_tile_slides_does_not_pre_resolve_backend_auto(monkeypatch, tmp_path: Path):
@@ -5151,6 +5151,7 @@ def _write_process_list(path: Path, rows: list[dict]) -> None:
     columns = [
         "sample_id",
         "annotation",
+        "output_mode",
         "image_path",
         "mask_path",
         "requested_backend",
@@ -5682,6 +5683,55 @@ def test_resume_gate_keys_slide_embeddings_by_sample_id_and_annotation(tmp_path:
 
     assert [tr.annotation for tr in pending_results] == ["stroma"]
     assert len(pending_slides) == 1
+
+
+def test_merged_process_row_resumes_from_flat_structural_artifact(tmp_path: Path):
+    process_list_path = tmp_path / "process_list.csv"
+    _write_process_list(
+        process_list_path,
+        [
+            {
+                "sample_id": "slide-a",
+                "annotation": "merged",
+                "output_mode": "merged",
+                "image_path": "/tmp/slide-a.svs",
+                "mask_path": "/tmp/slide-a-mask.png",
+                "requested_backend": "asap",
+                "backend": "asap",
+                "spacing_at_level_0": None,
+                "tiling_status": "success",
+                "num_tiles": 1,
+                "coordinates_npz_path": "/tmp/slide-a.coordinates.npz",
+                "coordinates_meta_path": "/tmp/slide-a.coordinates.meta.json",
+                "tiles_tar_path": None,
+                "mask_preview_path": None,
+                "tiling_preview_path": None,
+                "error": None,
+                "traceback": None,
+            }
+        ],
+    )
+    df = pd.read_csv(process_list_path)
+    df["feature_status"] = "success"
+    df["aggregation_status"] = "success"
+    df.to_csv(process_list_path, index=False)
+    write_slide_embeddings(
+        "slide-a",
+        np.zeros((8,), dtype=np.float32),
+        output_dir=tmp_path,
+    )
+
+    keys = persist_callbacks.completed_local_embedding_keys(
+        process_list_path,
+        output_dir=tmp_path,
+        output_format="pt",
+        persist_tile_embeddings=False,
+        persist_hierarchical_embeddings=False,
+        include_slide_embeddings=True,
+        save_latents=False,
+    )
+
+    assert keys == {("slide-a", None)}
 
 
 def test_collect_pipeline_artifacts_reloads_per_class_slide_embeddings(tmp_path: Path):


### PR DESCRIPTION
## Summary

- require `hs2p>=4.4.0` consistently and separate the human-readable `merged` process sentinel from structural artifact identity (`annotation=None`, `output_mode="merged"`)
- keep merged tile, slide, hierarchical, dense, resume, work-unit, shard, and distributed paths flat while preserving genuine per-class namespaces
- switch public, shipped, and serialized JPEG defaults to portable `pil`, retaining explicit `turbojpeg`
- document the new backend priority, stable explicit decoder selection, annotation boundaries, and the hs2p 4.3 resume/reuse boundary

## Verification

- `PYTHONPATH=/tmp/slide2vec-hs2p44-target python -m pytest --no-cov -q -m 'not heavy'` — 683 passed, 26 deselected
- dense verification — all 127 tests passed (126 in sandbox; the socket-dependent multiprocessing test passed separately outside the sandbox)
- `sphinx-build -W --keep-going -E -b html docs ...` — passed
- structured `/code-review main`: Standards had no findings; Spec found one dense resume/distributed identity gap, which was fixed and re-reviewed as resolved

Closes #255