### PR TITLE
Make dense-image resume recipe-aware and crash-safe

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -330,8 +330,11 @@ geometry resolution, the same bottom/right padding up to the patch multiple, the
 same whole-image-vs-sliding encode and raised-cosine blending, and the same
 ``feature_kind`` choice between the patch-token grid and the CLS-attention grid.
 The run splits its images across all visible GPUs (``num_gpus=1`` encodes
-in-process) and is resume-aware — an image whose ``.meta.json`` sidecar already
-exists is skipped — so an interrupted run is restarted by re-issuing the call.
+in-process) and is recipe-aware on resume. It skips an image only when both the
+payload and sidecar exist and the sidecar's image identity, encoder/output,
+geometry, dense settings, inference precision, and stored dtype exactly match
+the current call. Missing, legacy, or incompatible pairs are recomputed, so an
+interrupted run is restarted by re-issuing the call.
 
 **target_size is a declaration, not a resize.** Dense extraction encodes through
 the encoder's normalization-only transform, so it never rescales: every image

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -249,9 +249,18 @@ geometry sidecar per input image:
        ├── <sample_id>.pt          ← Tensor of shape (d, grid_h, grid_w)
        └── <sample_id>.meta.json
 
-As with every dense artifact the sidecar is written **last**, after the payload
-has been published atomically, so a payload without its sidecar unambiguously
-means an interrupted image and resume treats the sidecar as the done-marker.
+For dense images, a *compatible artifact* is a payload plus a readable sidecar
+whose ``compatibility`` object exactly matches the current image identity and
+canonical extraction recipe. Sidecar presence alone is not enough. Missing
+payloads or sidecars, legacy/incomplete compatibility records, and recipe
+differences are recomputed; unreadable or malformed sidecars are errors.
+
+Replacement follows a strict sidecar-last contract. Before recomputing an
+incompatible artifact, slide2vec removes its old sidecar done-marker. The new
+payload is written to a sibling temporary file and atomically moved into place,
+then the new sidecar is published last. If the process stops before or after
+payload replacement, no trusted sidecar remains paired with the changed
+payload.
 
 **dense_image_embeddings**
 
@@ -279,14 +288,35 @@ means an interrupted image and resume treats the sidecar as the done-marker.
      "feature_kind": "patch_features",
      "attention_blocks": [-1],
      "attention_include_registers": false,
+     "compatibility": {
+       "sample_id": "ocelot-001",
+       "image_path": "/data/ocelot/001.jpg",
+       "encoder_name": "virchow2",
+       "output_variant": "cls_patch_mean",
+       "target_size": [1024, 1024],
+       "patch_size": [14, 14],
+       "encoded_size": [1036, 1036],
+       "pad": [12, 12],
+       "grid_shape": [74, 74],
+       "pad_mode": "reflect",
+       "image_pad_value": null,
+       "window_size": 224,
+       "overlap": 0.0,
+       "feature_kind": "patch_features",
+       "attention_blocks": [-1],
+       "attention_include_registers": false,
+       "precision": "fp32",
+       "dtype": "float32"
+     }
    }
 
-The geometry fields are the whole extraction contract: ``target_size`` is what
-the caller declared, ``encoded_size`` is that padded up to the encoder's patch
-multiple, ``pad`` is the bottom/right padding applied, and ``grid_shape`` is the
-token grid the payload holds. ``encoder_input_regime`` is ``"declared"`` — unlike
-a pooled image embedding, this run *stated* its geometry and it was validated
-before any image was read.
+The compatibility identity covers the sample ID and normalized source path;
+encoder name and resolved output variant; target, patch, encoded, padding, and
+grid geometry; padding/window/overlap and attention settings; inference
+precision; and stored dtype. GPU count, batch size, workers, prefetching, output
+directory, and other execution mechanics are deliberately excluded.
+``encoder_input_regime`` is ``"declared"`` — unlike a pooled image embedding,
+this run *stated* its geometry and it was validated before any image was read.
 
 
 Coordinate Files

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -850,8 +850,9 @@ class Model:
         — whole-image, or by sliding the encoder's native field and blending the token grids
         — and written to ``dense_image_embeddings/<sample_id>.pt`` plus a geometry sidecar.
         The run splits its images across all visible GPUs (``execution.num_gpus``);
-        ``num_gpus=1`` encodes fully in-process. Resume is automatic — images whose sidecar
-        already exists are skipped. Returns one
+        ``num_gpus=1`` encodes fully in-process. Resume is automatic: an image is skipped
+        only when its payload exists and its sidecar records the same normalized source
+        identity and complete extraction recipe. Returns one
         :class:`~slide2vec.artifacts.DenseImageArtifact` per input image, in input order.
 
         It differs from :meth:`embed_regions_dense` in exactly one respect: there is no

--- a/slide2vec/artifacts.py
+++ b/slide2vec/artifacts.py
@@ -365,7 +365,8 @@ def dense_image_paths(output_dir: str | Path, *, sample_id: str) -> tuple[Path, 
     ``dense_image_embeddings/<sample_id>.pt`` plus ``<sample_id>.meta.json``. Flat, like the
     pooled image layout and unlike the per-slide dense one: a pre-cropped image has no slide
     directory to live under and no ``(x, y)`` to be named by, so the caller's ``sample_id``
-    is the whole identity and the resume check needs nothing else.
+    determines the paths. Resume additionally validates the payload and the complete
+    compatibility record in the sidecar.
     """
     output_root = Path(output_dir).expanduser().resolve()
     sample_component = _validate_path_component(sample_id, field="sample_id")

--- a/slide2vec/distributed/dense_image_worker.py
+++ b/slide2vec/distributed/dense_image_worker.py
@@ -30,6 +30,7 @@ def main(argv=None) -> int:
     from slide2vec.runtime.dense_stage import resolve_output_torch_dtype
     from slide2vec.runtime.image_specs import image_specs_from_request
     from slide2vec.runtime.serialization import (
+        deserialize_dense_image_recipe,
         deserialize_dense_image_options,
         deserialize_execution,
     )
@@ -47,6 +48,7 @@ def main(argv=None) -> int:
 
     model = model_from_request(request, rank=rank)
     dense = deserialize_dense_image_options(request["dense"])
+    recipe = deserialize_dense_image_recipe(request["recipe"])
     execution = deserialize_execution(request["execution"])
     # Each rank declares the dense contract for itself rather than trusting the parent to
     # have done it (the declaration is idempotent): that is what supplies the variable-input
@@ -64,6 +66,7 @@ def main(argv=None) -> int:
             loaded=loaded,
             out_dir=output_dir,
             dense=dense,
+            recipe=recipe,
             batch_size=int(execution.batch_size),
             precision=execution.precision,
             output_dtype=resolve_output_torch_dtype(execution),

--- a/slide2vec/runtime/dense_image_recipe.py
+++ b/slide2vec/runtime/dense_image_recipe.py
@@ -1,0 +1,191 @@
+"""Canonical compatibility identity for dense image artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from slide2vec.encoders.registry import resolve_encoder_output
+from slide2vec.runtime.model_settings import resolve_output_precision
+
+
+def _int_pair(value: Any, *, field: str) -> tuple[int, int]:
+    try:
+        first, second = value
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be a two-element sequence") from exc
+    return int(first), int(second)
+
+
+def malformed_dense_image_compatibility_fields(
+    recorded: dict[str, Any],
+    expected: dict[str, Any],
+) -> tuple[str, ...]:
+    """Return present fields whose JSON shape differs from the canonical record."""
+
+    def is_int(value: Any) -> bool:
+        return isinstance(value, int) and not isinstance(value, bool)
+
+    malformed: list[str] = []
+    for field, value in recorded.items():
+        if field not in expected:
+            continue
+        reference = expected[field]
+        valid = True
+        if field == "window_size":
+            valid = value is None or is_int(value)
+        elif field == "image_pad_value":
+            valid = value is None or (
+                isinstance(value, (int, float)) and not isinstance(value, bool)
+            )
+        elif reference is None:
+            valid = value is None
+        elif isinstance(reference, bool):
+            valid = isinstance(value, bool)
+        elif isinstance(reference, str):
+            valid = isinstance(value, str)
+        elif isinstance(reference, list):
+            valid = isinstance(value, list) and all(is_int(item) for item in value)
+            if valid and field != "attention_blocks":
+                valid = len(value) == len(reference)
+        elif isinstance(reference, (int, float)):
+            valid = isinstance(value, (int, float)) and not isinstance(value, bool)
+        if not valid:
+            malformed.append(field)
+    return tuple(sorted(malformed))
+
+
+@dataclass(frozen=True, kw_only=True)
+class DenseImageRecipe:
+    """Request-wide extraction facts that determine a dense image payload."""
+
+    encoder_name: str
+    output_variant: str
+    target_size: tuple[int, int]
+    patch_size: tuple[int, int]
+    encoded_size: tuple[int, int]
+    pad: tuple[int, int]
+    grid_shape: tuple[int, int]
+    pad_mode: str
+    image_pad_value: float | None
+    window_size: int | None
+    overlap: float
+    feature_kind: str
+    attention_blocks: tuple[int, ...]
+    attention_include_registers: bool
+    precision: str
+    dtype: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "encoder_name": self.encoder_name,
+            "output_variant": self.output_variant,
+            "target_size": list(self.target_size),
+            "patch_size": list(self.patch_size),
+            "encoded_size": list(self.encoded_size),
+            "pad": list(self.pad),
+            "grid_shape": list(self.grid_shape),
+            "pad_mode": self.pad_mode,
+            "image_pad_value": self.image_pad_value,
+            "window_size": self.window_size,
+            "overlap": self.overlap,
+            "feature_kind": self.feature_kind,
+            "attention_blocks": list(self.attention_blocks),
+            "attention_include_registers": self.attention_include_registers,
+            "precision": self.precision,
+            "dtype": self.dtype,
+        }
+
+    def for_image(self, spec) -> dict[str, Any]:
+        """Add the normalized source identity to this request-wide recipe."""
+        return {
+            "sample_id": str(spec.sample_id),
+            "image_path": str(Path(spec.image_path).expanduser().resolve()),
+            **self.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "DenseImageRecipe":
+        return cls(
+            encoder_name=str(payload["encoder_name"]),
+            output_variant=str(payload["output_variant"]),
+            target_size=_int_pair(payload["target_size"], field="target_size"),
+            patch_size=_int_pair(payload["patch_size"], field="patch_size"),
+            encoded_size=_int_pair(payload["encoded_size"], field="encoded_size"),
+            pad=_int_pair(payload["pad"], field="pad"),
+            grid_shape=_int_pair(payload["grid_shape"], field="grid_shape"),
+            pad_mode=str(payload["pad_mode"]),
+            image_pad_value=(
+                None
+                if payload["image_pad_value"] is None
+                else float(payload["image_pad_value"])
+            ),
+            window_size=(
+                None if payload["window_size"] is None else int(payload["window_size"])
+            ),
+            overlap=float(payload["overlap"]),
+            feature_kind=str(payload["feature_kind"]),
+            attention_blocks=tuple(int(value) for value in payload["attention_blocks"]),
+            attention_include_registers=bool(payload["attention_include_registers"]),
+            precision=str(payload["precision"]),
+            dtype=str(payload["dtype"]),
+        )
+
+
+def resolve_dense_image_recipe(*, model, contract, dense, execution) -> DenseImageRecipe:
+    """Resolve the complete request-wide identity before loading the encoder."""
+    if execution.precision is None:
+        raise ValueError(
+            "Dense image inference precision must be resolved before building its recipe"
+        )
+    plan = contract.plan
+    if plan is None:
+        raise ValueError("Dense image extraction requires a declared encoder-input plan")
+    output = resolve_encoder_output(
+        model.name,
+        requested_output_variant=getattr(model, "_output_variant", None),
+    )
+    # The plan intentionally exposes encoded geometry but not its patch/grid decomposition;
+    # resolve it from the registry-backed tile encoder without constructing the model.
+    from slide2vec.encoders.registry import resolve_patch_size
+    from slide2vec.runtime.dense_regions import (
+        compute_dense_geometry,
+        validate_dense_request_settings,
+    )
+
+    patch_h, patch_w = resolve_patch_size(plan.tile_encoder_name)
+    geometry = compute_dense_geometry(
+        target_size=plan.target_size_px,
+        patch_size=(patch_h, patch_w),
+    )
+    validate_dense_request_settings(
+        geometry,
+        pad_mode=dense.pad_mode,
+        window_size=dense.window_size,
+        overlap=dense.overlap,
+        feature_kind=dense.feature_kind,
+        attention_blocks=dense.attention_blocks,
+        attention_include_registers=dense.attention_include_registers,
+    )
+    output_precision = resolve_output_precision(execution.output_dtype, execution.precision)
+    return DenseImageRecipe(
+        encoder_name=str(model.name),
+        output_variant=str(output["output_variant"]),
+        target_size=geometry.target_size,
+        patch_size=geometry.patch_size,
+        encoded_size=geometry.encoded_size,
+        pad=geometry.pad,
+        grid_shape=geometry.grid_shape,
+        pad_mode=str(dense.pad_mode),
+        image_pad_value=(
+            None if dense.image_pad_value is None else float(dense.image_pad_value)
+        ),
+        window_size=None if dense.window_size is None else int(dense.window_size),
+        overlap=float(dense.overlap),
+        feature_kind=str(dense.feature_kind),
+        attention_blocks=tuple(int(block) for block in dense.attention_blocks),
+        attention_include_registers=bool(dense.attention_include_registers),
+        precision=execution.precision,
+        dtype={"fp16": "float16", "fp32": "float32"}[output_precision],
+    )

--- a/slide2vec/runtime/dense_image_shard.py
+++ b/slide2vec/runtime/dense_image_shard.py
@@ -22,13 +22,16 @@ heterogeneous — here it is declared, uniform, and checked while stacking (see
 of large images is the bottleneck this path has and can be parallelized per item when
 explicitly configured.
 
-Writes are atomic and sidecar-last (see :func:`~slide2vec.artifacts.write_dense_image`), so a
-payload without a sidecar unambiguously means an interrupted image and resume trusts the
-sidecar as the done-marker.
+An exactly compatible sidecar is the done-marker; presence alone is insufficient. Before
+replacing an incompatible pair this loop removes the old marker, then atomically replaces
+the payload, then publishes the new sidecar last (see
+:func:`~slide2vec.artifacts.write_dense_image`). Interruption at any boundary therefore
+leaves no trusted marker paired with a changed payload.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Sequence
 
@@ -42,6 +45,10 @@ from slide2vec.artifacts import (
 )
 from slide2vec.data.dataset import DeclaredGeometryCollator, ImageFileDataset
 from slide2vec.runtime.batching import dataloader_kwargs, uses_cuda_runtime
+from slide2vec.runtime.dense_image_recipe import (
+    DenseImageRecipe,
+    malformed_dense_image_compatibility_fields,
+)
 from slide2vec.runtime.dense_regions import DenseGridEncoder
 from slide2vec.runtime.preprocessing import apply_transforms_itemwise
 from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
@@ -53,15 +60,56 @@ if TYPE_CHECKING:
     from slide2vec.runtime.types import LoadedModel
 
 
-def dense_image_needs_encode(out_dir, spec: "ImageSpec") -> bool:
-    """Resume predicate: an image needs encoding iff its sidecar is absent.
+@dataclass(frozen=True, kw_only=True)
+class DenseImageResumeDecision:
+    needs_encode: bool
+    differing_fields: tuple[str, ...] = ()
 
-    The sidecar is written last, so its presence is the done-marker; a ``.pt`` with no
-    sidecar is a crashed write and is re-encoded. Unlike the pooled image path there is no
-    format to disambiguate — a dense grid is always a ``.pt`` payload.
-    """
-    _, sidecar_path = dense_image_paths(out_dir, sample_id=spec.sample_id)
-    return not sidecar_path.exists()
+
+def dense_image_resume_decision(
+    out_dir, spec: "ImageSpec", recipe: DenseImageRecipe
+) -> DenseImageResumeDecision:
+    """Classify one on-disk pair against the current image extraction identity."""
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id=spec.sample_id)
+    missing = tuple(
+        name
+        for name, path in (("payload", payload_path), ("sidecar", sidecar_path))
+        if not path.exists()
+    )
+    if missing:
+        return DenseImageResumeDecision(needs_encode=True, differing_fields=missing)
+
+    metadata = load_metadata(sidecar_path)
+    if not isinstance(metadata, dict):
+        raise ValueError(f"Malformed dense image sidecar {sidecar_path}: expected a JSON object")
+    recorded = metadata.get("compatibility")
+    if recorded is None:
+        return DenseImageResumeDecision(
+            needs_encode=True, differing_fields=("compatibility",)
+        )
+    if not isinstance(recorded, dict):
+        raise ValueError(
+            f"Malformed dense image sidecar {sidecar_path}: "
+            "'compatibility' must be a JSON object"
+        )
+    expected = recipe.for_image(spec)
+    malformed = malformed_dense_image_compatibility_fields(recorded, expected)
+    if malformed:
+        raise ValueError(
+            f"Malformed dense image sidecar {sidecar_path}: invalid compatibility "
+            f"fields: {', '.join(malformed)}"
+        )
+
+    differing = tuple(
+        sorted(
+            key
+            for key in set(recorded) | set(expected)
+            if key not in recorded or key not in expected or recorded[key] != expected[key]
+        )
+    )
+    return DenseImageResumeDecision(
+        needs_encode=bool(differing), differing_fields=differing
+    )
 
 
 def dense_image_artifact_from_disk(out_dir, spec: "ImageSpec") -> DenseImageArtifact:
@@ -82,8 +130,7 @@ def dense_image_metadata(
     spec: "ImageSpec",
     *,
     loaded: "LoadedModel",
-    dense: "DenseImageOptions",
-    encoder: DenseGridEncoder,
+    recipe: DenseImageRecipe,
     grid: "np.ndarray",
 ) -> dict:
     """The geometry sidecar: what was encoded, and with which dense recipe.
@@ -94,30 +141,32 @@ def dense_image_metadata(
     *did* state its geometry — ``target_size`` — and it was validated before any image was
     read, so the sidecar records a request that was honored rather than a size observed.
     """
-    geometry = encoder.geometry
-    return {
+    compatibility = recipe.for_image(spec)
+    metadata = {
         "artifact_type": "dense_image_embeddings",
-        "sample_id": spec.sample_id,
-        "image_path": str(spec.image_path),
+        "sample_id": compatibility["sample_id"],
+        "image_path": compatibility["image_path"],
         "format": "pt",
-        "dtype": str(grid.dtype),
+        "dtype": compatibility["dtype"],
         "feature_dim": int(grid.shape[0]),
-        "grid_shape": [int(geometry.grid_shape[0]), int(geometry.grid_shape[1])],
-        "target_size": [int(geometry.target_size[0]), int(geometry.target_size[1])],
-        "patch_size": [int(geometry.patch_size[0]), int(geometry.patch_size[1])],
-        "encoded_size": [int(geometry.encoded_size[0]), int(geometry.encoded_size[1])],
-        "pad": [int(geometry.pad[0]), int(geometry.pad[1])],
-        "encoder_name": loaded.name,
+        "grid_shape": compatibility["grid_shape"],
+        "target_size": compatibility["target_size"],
+        "patch_size": compatibility["patch_size"],
+        "encoded_size": compatibility["encoded_size"],
+        "pad": compatibility["pad"],
+        "encoder_name": compatibility["encoder_name"],
         "encoder_level": loaded.level,
         "encoder_input_regime": "declared",
-        "pad_mode": dense.pad_mode,
-        "image_pad_value": dense.image_pad_value,
-        "window_size": dense.window_size,
-        "overlap": float(dense.overlap),
-        "feature_kind": dense.feature_kind,
-        "attention_blocks": [int(block) for block in dense.attention_blocks],
-        "attention_include_registers": bool(dense.attention_include_registers),
+        "pad_mode": compatibility["pad_mode"],
+        "image_pad_value": compatibility["image_pad_value"],
+        "window_size": compatibility["window_size"],
+        "overlap": compatibility["overlap"],
+        "feature_kind": compatibility["feature_kind"],
+        "attention_blocks": compatibility["attention_blocks"],
+        "attention_include_registers": compatibility["attention_include_registers"],
+        "compatibility": compatibility,
     }
+    return metadata
 
 
 def run_dense_image_shard(
@@ -126,6 +175,7 @@ def run_dense_image_shard(
     loaded: "LoadedModel",
     out_dir,
     dense: "DenseImageOptions",
+    recipe: DenseImageRecipe,
     batch_size: int,
     precision: str = "fp32",
     output_dtype: "torch.dtype | None" = None,
@@ -135,16 +185,26 @@ def run_dense_image_shard(
 ) -> list[DenseImageArtifact]:
     """Encode + persist one shard's images, one grid payload + one sidecar per image.
 
-    Skips any image already complete on disk (see :func:`dense_image_needs_encode`), encodes
-    the rest through the shared dense kernel, and writes each batch's grids before the next
-    batch is encoded — which is what makes a killed rank resumable at image granularity
-    rather than losing the whole shard. Returns one
+    Skips only images whose payload and sidecar exactly match ``recipe``, invalidates every
+    incompatible done-marker, encodes the rest through the shared dense kernel, and writes
+    each batch's grids before the next batch is encoded — which is what makes a killed rank
+    resumable at image granularity rather than losing the whole shard. Returns one
     :class:`~slide2vec.artifacts.DenseImageArtifact` per input image in input order — freshly
     written or (when skipped) read back off disk. ``on_batch`` is invoked with each encoded
     batch's image count for per-batch progress.
     """
     images = list(images)
-    pending = [spec for spec in images if dense_image_needs_encode(out_dir, spec)]
+    pending = [
+        spec
+        for spec in images
+        if dense_image_resume_decision(out_dir, spec, recipe).needs_encode
+    ]
+    for spec in pending:
+        # The sidecar is the only done-marker. Remove any stale marker before the first
+        # operation that can fail so an interrupted replacement can never be resumed as a
+        # complete pair, regardless of whether the old or new payload is still present.
+        _, sidecar_path = dense_image_paths(out_dir, sample_id=spec.sample_id)
+        sidecar_path.unlink(missing_ok=True)
     written: dict[str, DenseImageArtifact] = {}
     if pending:
         encoder = DenseGridEncoder.resolve(
@@ -201,7 +261,10 @@ def run_dense_image_shard(
                         output_dir=out_dir,
                         sample_id=spec.sample_id,
                         metadata=dense_image_metadata(
-                            spec, loaded=loaded, dense=dense, encoder=encoder, grid=grid
+                            spec,
+                            loaded=loaded,
+                            recipe=recipe,
+                            grid=grid,
                         ),
                     )
                 if on_batch is not None:

--- a/slide2vec/runtime/dense_image_stage.py
+++ b/slide2vec/runtime/dense_image_stage.py
@@ -4,12 +4,14 @@ The glue that turns a caller's :class:`~slide2vec.api.ImageSpec` list into persi
 grids. Deliberately the same five steps as the dense ROI stage, over the same machinery,
 because only the source of the pixels differs:
 
-1. **declare** the dense encoder-input contract — the caller states a supervision
+1. **declare** the dense encoder-input contract and canonical extraction recipe — the caller states a supervision
    ``target_size``, and the geometry the backbone will actually see (the padded image, or one
-   patch-aligned window of it) is validated here, before anything is decoded or launched;
+   patch-aligned window of it) is validated here; all compatibility invariants are fixed
+   before anything is decoded or launched;
 2. **normalize** the images into resolved, uniquely-named specs;
-3. **resume-filter** them — drop images whose sidecar already exists, before sharding, so no
-   rank draws an all-done shard and idles; the skip count is logged;
+3. **resume-filter** them — drop only payload+sidecar pairs whose recorded image identity
+   and recipe exactly match, before sharding, so no rank draws an all-done shard and idles;
+   the skip count and every recomputation difference are logged;
 4. **dispatch**: ``num_gpus=1`` runs
    :func:`~slide2vec.runtime.dense_image_shard.run_dense_image_shard` fully in-process (no
    torchrun); ``num_gpus>1`` writes a JSON request and launches
@@ -35,8 +37,12 @@ from slide2vec.artifacts import DenseImageArtifact
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.dense_image_shard import (
     dense_image_artifact_from_disk,
-    dense_image_needs_encode,
+    dense_image_resume_decision,
     run_dense_image_shard,
+)
+from slide2vec.runtime.dense_image_recipe import (
+    DenseImageRecipe,
+    resolve_dense_image_recipe,
 )
 from slide2vec.runtime.dense_stage import resolve_output_torch_dtype
 from slide2vec.runtime.distributed import (
@@ -48,6 +54,7 @@ from slide2vec.runtime.distributed_stage import validate_multi_gpu_execution
 from slide2vec.runtime.image_specs import build_image_specs_request, normalize_image_specs
 from slide2vec.runtime.serialization import (
     serialize_dense_image_options,
+    serialize_dense_image_recipe,
     serialize_execution,
     serialize_model,
 )
@@ -56,10 +63,19 @@ logger = logging.getLogger(__name__)
 
 
 def partition_dense_images_by_resume(
-    specs: Sequence[ImageSpec], out_dir
+    specs: Sequence[ImageSpec], out_dir, recipe: DenseImageRecipe
 ) -> tuple[list[ImageSpec], int]:
-    """Split the spec list into (needs-encode, already-on-disk-count) by sidecar existence."""
-    remaining = [spec for spec in specs if dense_image_needs_encode(out_dir, spec)]
+    """Split images by exact payload+sidecar compatibility with the current request."""
+    remaining: list[ImageSpec] = []
+    for spec in specs:
+        decision = dense_image_resume_decision(out_dir, spec, recipe)
+        if decision.needs_encode:
+            remaining.append(spec)
+            logger.info(
+                "resume: recomputing dense image %r; differing fields: %s",
+                spec.sample_id,
+                ", ".join(decision.differing_fields),
+            )
     return remaining, len(specs) - len(remaining)
 
 
@@ -74,7 +90,13 @@ def embed_images_dense(
     # Declare the effective encoder input before anything is decoded, sharded or launched: an
     # image geometry this encoder cannot accept must fail here, not on the first forward pass
     # of a torchrun rank. Idempotent, so every rank re-declares for itself (dense_image_worker).
-    model._declare_dense_encoder_input(dense, emit_run_info=True)
+    contract = model._declare_dense_encoder_input(dense, emit_run_info=True)
+    recipe = resolve_dense_image_recipe(
+        model=model,
+        contract=contract,
+        dense=dense,
+        execution=execution,
+    )
     specs = normalize_image_specs(
         images,
         method_name="embed_images_dense()",
@@ -83,7 +105,7 @@ def embed_images_dense(
     out_dir = Path(execution.output_dir).expanduser().resolve()
     execution = execution.with_output_dir(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
-    remaining, skipped = partition_dense_images_by_resume(specs, out_dir)
+    remaining, skipped = partition_dense_images_by_resume(specs, out_dir, recipe)
     if skipped:
         logger.info(
             "resume: %s/%s images already on disk, encoding %s",
@@ -99,18 +121,34 @@ def embed_images_dense(
     if remaining:
         if execution.num_gpus == 1:
             _run_dense_images_in_process(
-                model, remaining, dense=dense, execution=execution, out_dir=out_dir
+                model,
+                remaining,
+                dense=dense,
+                recipe=recipe,
+                execution=execution,
+                out_dir=out_dir,
             )
         else:
             _run_dense_images_distributed(
-                model, remaining, dense=dense, execution=execution, out_dir=out_dir
+                model,
+                remaining,
+                dense=dense,
+                recipe=recipe,
+                execution=execution,
+                out_dir=out_dir,
             )
     emit_progress("dense.images.finished", total=len(specs))
     return [dense_image_artifact_from_disk(out_dir, spec) for spec in specs]
 
 
 def _run_dense_images_in_process(
-    model, specs: Sequence[ImageSpec], *, dense: DenseImageOptions, execution, out_dir
+    model,
+    specs: Sequence[ImageSpec],
+    *,
+    dense: DenseImageOptions,
+    recipe: DenseImageRecipe,
+    execution,
+    out_dir,
 ) -> None:
     # Loaded under the dense contract declared by embed_images_dense, which supplies the
     # variable-input constructor settings this geometry needs. The shard builds its own
@@ -127,6 +165,7 @@ def _run_dense_images_in_process(
         loaded=loaded,
         out_dir=out_dir,
         dense=dense,
+        recipe=recipe,
         batch_size=int(execution.batch_size),
         precision=execution.precision,
         output_dtype=resolve_output_torch_dtype(execution),
@@ -140,7 +179,13 @@ def _run_dense_images_in_process(
 
 
 def _run_dense_images_distributed(
-    model, specs: Sequence[ImageSpec], *, dense: DenseImageOptions, execution, out_dir
+    model,
+    specs: Sequence[ImageSpec],
+    *,
+    dense: DenseImageOptions,
+    recipe: DenseImageRecipe,
+    execution,
+    out_dir,
 ) -> None:
     validate_multi_gpu_execution(model, execution)
     progress_events_path = out_dir / "logs" / "dense_image_worker.progress.jsonl"
@@ -150,6 +195,7 @@ def _run_dense_images_distributed(
         request = {
             "model": serialize_model(model),
             "dense": serialize_dense_image_options(dense),
+            "recipe": serialize_dense_image_recipe(recipe),
             "execution": serialize_execution(execution),
             "output_dir": str(out_dir),
             "progress_events_path": str(progress_events_path),

--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -44,7 +44,7 @@ import torch.nn.functional as F
 from PIL import Image
 
 from slide2vec.data.tile_reader import WSIRegionReader
-from slide2vec.runtime.dense_sliding import encode_dense_sliding
+from slide2vec.runtime.dense_sliding import encode_dense_sliding, resolve_window_geometry
 from slide2vec.runtime.model_settings import output_torch_dtype, resolve_output_precision
 from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
 from slide2vec.runtime.tiling import resolve_slide_backend
@@ -125,6 +125,44 @@ def compute_dense_geometry(
         grid_shape=(encoded_h // patch_h, encoded_w // patch_w),
         pad=(encoded_h - target_h, encoded_w - target_w),
     )
+
+
+def validate_dense_request_settings(
+    geometry: DenseGridGeometry,
+    *,
+    pad_mode: str,
+    window_size: int | None,
+    overlap: float,
+    feature_kind: str,
+    attention_blocks: tuple[int, ...],
+    attention_include_registers: bool,
+) -> None:
+    """Validate request-wide dense settings without constructing an encoder."""
+    if pad_mode not in _PAD_MODES:
+        raise ValueError(
+            f"unsupported pad_mode {pad_mode!r}; expected one of {sorted(_PAD_MODES)}"
+        )
+    if feature_kind not in {"patch_features", "cls_attention"}:
+        raise ValueError(
+            f"unsupported feature_kind {feature_kind!r}; "
+            "expected 'patch_features' or 'cls_attention'"
+        )
+    if window_size is not None:
+        if int(window_size) <= 0:
+            raise ValueError("window_size must be positive")
+        if not 0.0 <= float(overlap) < 1.0:
+            raise ValueError("overlap must be in [0, 1)")
+        resolve_window_geometry(
+            geometry, window_size=int(window_size), overlap=float(overlap)
+        )
+    if feature_kind == "cls_attention" and not attention_blocks:
+        raise ValueError(
+            "attention_blocks must contain at least one block for cls_attention"
+        )
+    if not all(isinstance(block, int) for block in attention_blocks):
+        raise ValueError("attention_blocks must contain only integers")
+    if not isinstance(attention_include_registers, bool):
+        raise ValueError("attention_include_registers must be a boolean")
 
 
 def pad_image_to_encoded(
@@ -229,15 +267,21 @@ class DenseGridEncoder:
         output_dtype: "torch.dtype | None" = None,
         dense_transform: Callable | None = None,
     ) -> "DenseGridEncoder":
-        if pad_mode not in _PAD_MODES:
-            raise ValueError(
-                f"unsupported pad_mode {pad_mode!r}; expected one of {sorted(_PAD_MODES)}"
-            )
+        geometry = compute_dense_geometry(
+            target_size=target_size, patch_size=model.patch_size
+        )
+        validate_dense_request_settings(
+            geometry,
+            pad_mode=pad_mode,
+            window_size=window_size,
+            overlap=overlap,
+            feature_kind=feature_kind,
+            attention_blocks=attention_blocks,
+            attention_include_registers=attention_include_registers,
+        )
         return cls(
             model=model,
-            geometry=compute_dense_geometry(
-                target_size=target_size, patch_size=model.patch_size
-            ),
+            geometry=geometry,
             dense_transform=(
                 model.get_normalization_transform()
                 if dense_transform is None

--- a/slide2vec/runtime/serialization.py
+++ b/slide2vec/runtime/serialization.py
@@ -8,6 +8,7 @@ from slide2vec.api import (
     ExecutionOptions,
     PreprocessingConfig,
 )
+from slide2vec.runtime.dense_image_recipe import DenseImageRecipe
 
 
 def serialize_model(model) -> dict[str, Any]:
@@ -127,6 +128,16 @@ def serialize_dense_image_options(dense: DenseImageOptions) -> dict[str, Any]:
         "attention_blocks": list(dense.attention_blocks),
         "attention_include_registers": dense.attention_include_registers,
     }
+
+
+def serialize_dense_image_recipe(recipe: DenseImageRecipe) -> dict[str, Any]:
+    """Return the canonical recipe in its JSON representation."""
+    return recipe.to_dict()
+
+
+def deserialize_dense_image_recipe(payload: dict[str, Any]) -> DenseImageRecipe:
+    """Rebuild the exact canonical recipe resolved by the parent."""
+    return DenseImageRecipe.from_dict(payload)
 
 
 def deserialize_dense_image_options(payload: dict[str, Any]) -> DenseImageOptions:

--- a/tests/test_dense_image_resume.py
+++ b/tests/test_dense_image_resume.py
@@ -1,0 +1,329 @@
+"""Recipe-aware resume for dense image artifacts (issue #257)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from slide2vec.api import DenseImageOptions, ExecutionOptions, ImageSpec, Model
+from slide2vec.artifacts import dense_image_paths
+from slide2vec.runtime.dense_image_stage import partition_dense_images_by_resume
+from slide2vec.runtime.dense_image_recipe import resolve_dense_image_recipe
+from slide2vec.runtime.image_specs import (
+    build_image_specs_request,
+    image_specs_from_request,
+)
+from slide2vec.runtime.serialization import (
+    deserialize_dense_image_recipe,
+    serialize_dense_image_recipe,
+)
+
+
+def _resolved_recipe(tmp_path, **dense_kwargs):
+    model = Model(name="virchow2")
+    dense = DenseImageOptions(**{"target_size": 224, **dense_kwargs})
+    return resolve_dense_image_recipe(
+        model=model,
+        contract=model._declare_dense_encoder_input(dense, emit_run_info=False),
+        dense=dense,
+        execution=ExecutionOptions(output_dir=tmp_path, precision="fp32"),
+    )
+
+
+def _publish_pair(out_dir: Path, spec: ImageSpec, compatibility: dict) -> None:
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id=spec.sample_id)
+    payload_path.parent.mkdir(parents=True, exist_ok=True)
+    payload_path.write_bytes(b"complete payload")
+    sidecar_path.write_text(
+        json.dumps(
+            {
+                "feature_dim": 8,
+                "grid_shape": [2, 2],
+                "compatibility": compatibility,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_dense_image_recipe_contains_the_complete_canonical_identity(tmp_path):
+    model = Model(name="virchow2", output_variant="cls")
+    dense = DenseImageOptions(
+        target_size=(60, 92),
+        pad_mode="constant",
+        image_pad_value=0.25,
+        window_size=31,
+        overlap=0.25,
+        feature_kind="cls_attention",
+        attention_blocks=(-2, -1),
+        attention_include_registers=True,
+    )
+    contract = model._declare_dense_encoder_input(dense, emit_run_info=False)
+
+    first = resolve_dense_image_recipe(
+        model=model,
+        contract=contract,
+        dense=dense,
+        execution=ExecutionOptions(
+            output_dir=tmp_path / "one",
+            precision="bf16",
+            output_dtype="fp16",
+            num_gpus=1,
+            batch_size=2,
+            num_workers_per_gpu=0,
+            prefetch_factor=1,
+        ),
+    )
+    assert first.to_dict() == {
+        "encoder_name": "virchow2",
+        "output_variant": "cls",
+        "target_size": [60, 92],
+        "patch_size": [14, 14],
+        "encoded_size": [70, 98],
+        "pad": [10, 6],
+        "grid_shape": [5, 7],
+        "pad_mode": "constant",
+        "image_pad_value": 0.25,
+        "window_size": 31,
+        "overlap": 0.25,
+        "feature_kind": "cls_attention",
+        "attention_blocks": [-2, -1],
+        "attention_include_registers": True,
+        "precision": "bf16",
+        "dtype": "float16",
+    }
+
+
+def test_dense_image_recipe_excludes_execution_mechanics(tmp_path):
+    model = Model(name="virchow2")
+    dense = DenseImageOptions(target_size=224)
+    contract = model._declare_dense_encoder_input(dense, emit_run_info=False)
+    first = resolve_dense_image_recipe(
+        model=model,
+        contract=contract,
+        dense=dense,
+        execution=ExecutionOptions(
+            output_dir=tmp_path / "one",
+            precision="fp32",
+            num_gpus=1,
+            batch_size=2,
+            num_workers_per_gpu=0,
+            prefetch_factor=1,
+        ),
+    )
+    second = resolve_dense_image_recipe(
+        model=model,
+        contract=contract,
+        dense=dense,
+        execution=ExecutionOptions(
+            output_dir=tmp_path / "two",
+            precision="fp32",
+            num_gpus=8,
+            batch_size=128,
+            num_workers_per_gpu=12,
+            prefetch_factor=16,
+        ),
+    )
+
+    assert first == second
+
+
+def test_dense_image_recipe_round_trips_exactly_through_json(tmp_path):
+    model = Model(name="virchow2")
+    dense = DenseImageOptions(target_size=(60, 92), window_size=31, overlap=0.25)
+    recipe = resolve_dense_image_recipe(
+        model=model,
+        contract=model._declare_dense_encoder_input(dense, emit_run_info=False),
+        dense=dense,
+        execution=ExecutionOptions(
+            output_dir=tmp_path, precision="fp16", output_dtype="fp32"
+        ),
+    )
+
+    payload = json.loads(json.dumps(serialize_dense_image_recipe(recipe)))
+
+    assert deserialize_dense_image_recipe(payload) == recipe
+
+
+def test_current_image_specs_round_trip_exactly_through_json(tmp_path):
+    specs = [
+        ImageSpec(
+            sample_id="sample-1",
+            image_path=str((tmp_path / "images" / "sample-1.png").resolve()),
+        )
+    ]
+    payload = json.loads(json.dumps(build_image_specs_request(specs)))
+
+    assert image_specs_from_request(payload) == specs
+
+
+def test_resume_skips_only_a_complete_exactly_compatible_pair(tmp_path):
+    source = (tmp_path / "source.png").resolve()
+    spec = ImageSpec(sample_id="sample-1", image_path=str(source))
+    recipe = _resolved_recipe(tmp_path)
+    _publish_pair(tmp_path / "out", spec, recipe.for_image(spec))
+
+    remaining, skipped = partition_dense_images_by_resume(
+        [spec], tmp_path / "out", recipe
+    )
+
+    assert remaining == []
+    assert skipped == 1
+
+
+@pytest.mark.parametrize(
+    ("condition", "differing_fields"),
+    [
+        ("missing-pair", "payload, sidecar"),
+        ("missing-payload", "payload"),
+        ("missing-sidecar", "sidecar"),
+        ("legacy", "compatibility"),
+        ("incomplete", "patch_size"),
+        ("mismatch", "overlap"),
+    ],
+)
+def test_noncompatible_pairs_recompute_and_log_fields(
+    tmp_path, caplog, condition, differing_fields
+):
+    out_dir = tmp_path / "out"
+    recipe = _resolved_recipe(tmp_path)
+    spec = ImageSpec(
+        sample_id=condition,
+        image_path=str((tmp_path / "images" / f"{condition}.png").resolve()),
+    )
+    if condition != "missing-pair":
+        recorded = recipe.for_image(spec)
+        if condition == "legacy":
+            _publish_pair(out_dir, spec, recorded)
+            sidecar = dense_image_paths(out_dir, sample_id=spec.sample_id)[1]
+            sidecar.write_text(
+                json.dumps({"feature_dim": 8, "grid_shape": [2, 2]}),
+                encoding="utf-8",
+            )
+        else:
+            if condition == "incomplete":
+                recorded.pop("patch_size")
+            elif condition == "mismatch":
+                recorded["overlap"] = 0.5
+            _publish_pair(out_dir, spec, recorded)
+            if condition == "missing-payload":
+                dense_image_paths(out_dir, sample_id=spec.sample_id)[0].unlink()
+            elif condition == "missing-sidecar":
+                dense_image_paths(out_dir, sample_id=spec.sample_id)[1].unlink()
+
+    with caplog.at_level("INFO", logger="slide2vec.runtime.dense_image_stage"):
+        remaining, skipped = partition_dense_images_by_resume([spec], out_dir, recipe)
+
+    assert remaining == [spec]
+    assert skipped == 0
+    assert (
+        f"'{condition}'; differing fields: {differing_fields}" in caplog.text
+    )
+
+
+@pytest.mark.parametrize(
+    ("condition", "error_type", "message"),
+    [
+        ("unreadable-json", json.JSONDecodeError, None),
+        ("non-object-sidecar", ValueError, "expected a JSON object"),
+        ("non-object-compatibility", ValueError, "'compatibility' must be a JSON object"),
+        ("malformed-field", ValueError, "target_size"),
+        ("non-integral-window", ValueError, "window_size"),
+    ],
+)
+def test_unreadable_or_malformed_sidecar_hard_fails(
+    tmp_path, condition, error_type, message
+):
+    out_dir = tmp_path / "out"
+    spec = ImageSpec(
+        sample_id="sample-1", image_path=str((tmp_path / "source.png").resolve())
+    )
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id=spec.sample_id)
+    payload_path.parent.mkdir(parents=True)
+    payload_path.write_bytes(b"complete payload")
+    recipe = _resolved_recipe(
+        tmp_path, window_size=32 if condition == "non-integral-window" else None
+    )
+    if condition == "unreadable-json":
+        text = "{"
+    elif condition == "non-object-sidecar":
+        text = "[]"
+    elif condition == "non-object-compatibility":
+        text = json.dumps({"compatibility": []})
+    else:
+        malformed = recipe.for_image(spec)
+        if condition == "non-integral-window":
+            malformed["window_size"] = 32.5
+        else:
+            malformed["target_size"] = "224x224"
+        text = json.dumps({"compatibility": malformed})
+    sidecar_path.write_text(text, encoding="utf-8")
+
+    with pytest.raises(error_type, match=message):
+        partition_dense_images_by_resume(
+            [spec], out_dir, recipe
+        )
+
+
+def test_every_recorded_compatibility_field_participates_in_resume(tmp_path):
+    recipe = _resolved_recipe(
+        tmp_path,
+        target_size=(224, 238),
+        pad_mode="constant",
+        image_pad_value=0.25,
+        window_size=112,
+        overlap=0.25,
+        feature_kind="cls_attention",
+        attention_blocks=(-2, -1),
+        attention_include_registers=True,
+    )
+    fields = tuple(recipe.for_image(
+        ImageSpec(sample_id="template", image_path=tmp_path / "template.png")
+    ))
+    assert fields == (
+        "sample_id",
+        "image_path",
+        "encoder_name",
+        "output_variant",
+        "target_size",
+        "patch_size",
+        "encoded_size",
+        "pad",
+        "grid_shape",
+        "pad_mode",
+        "image_pad_value",
+        "window_size",
+        "overlap",
+        "feature_kind",
+        "attention_blocks",
+        "attention_include_registers",
+        "precision",
+        "dtype",
+    )
+
+    for field in fields:
+        spec = ImageSpec(
+            sample_id=field,
+            image_path=str((tmp_path / "images" / f"{field}.png").resolve()),
+        )
+        recorded = recipe.for_image(spec)
+        value = recorded[field]
+        if isinstance(value, bool):
+            recorded[field] = not value
+        elif isinstance(value, str):
+            recorded[field] = f"{value}-different"
+        elif isinstance(value, list):
+            recorded[field] = [value[0] + 1, *value[1:]]
+        else:
+            recorded[field] = value + 1
+        out_dir = tmp_path / field
+        _publish_pair(out_dir, spec, recorded)
+
+        remaining, skipped = partition_dense_images_by_resume(
+            [spec], out_dir, recipe
+        )
+
+        assert remaining == [spec], field
+        assert skipped == 0, field

--- a/tests/test_dense_image_shard.py
+++ b/tests/test_dense_image_shard.py
@@ -18,6 +18,8 @@ migrate onto — for both ``feature_kind`` values.
 from __future__ import annotations
 
 import json
+import os
+from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
@@ -33,6 +35,7 @@ from slide2vec.api import DenseImageOptions, ImageSpec  # noqa: E402
 from slide2vec.artifacts import dense_image_paths, write_dense_image  # noqa: E402
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
 from slide2vec.runtime.dense_image_shard import run_dense_image_shard  # noqa: E402
+from slide2vec.runtime.dense_image_recipe import DenseImageRecipe  # noqa: E402
 from slide2vec.runtime.dense_regions import (  # noqa: E402
     compute_dense_geometry,
     pad_image_to_encoded,
@@ -75,6 +78,40 @@ def _spec(tmp_path, sample_id: str, *, width: int = 64, height: int = 64) -> Ima
 
 def _dense(**kwargs) -> DenseImageOptions:
     return DenseImageOptions(**{"target_size": 64, **kwargs})
+
+
+def _recipe(
+    *,
+    target_size=(64, 64),
+    pad_mode="reflect",
+    image_pad_value=None,
+    window_size=None,
+    overlap=0.0,
+    feature_kind="patch_features",
+    attention_blocks=(-1,),
+    attention_include_registers=False,
+    precision="fp32",
+    dtype="float32",
+) -> DenseImageRecipe:
+    geometry = compute_dense_geometry(target_size=target_size, patch_size=(16, 16))
+    return DenseImageRecipe(
+        encoder_name="fake-encoder",
+        output_variant="default",
+        target_size=geometry.target_size,
+        patch_size=geometry.patch_size,
+        encoded_size=geometry.encoded_size,
+        pad=geometry.pad,
+        grid_shape=geometry.grid_shape,
+        pad_mode=pad_mode,
+        image_pad_value=image_pad_value,
+        window_size=window_size,
+        overlap=overlap,
+        feature_kind=feature_kind,
+        attention_blocks=attention_blocks,
+        attention_include_registers=attention_include_registers,
+        precision=precision,
+        dtype=dtype,
+    )
 
 
 def _dense_dir(out_dir) -> Path:
@@ -140,6 +177,7 @@ def test_run_dense_image_shard_writes_payload_and_sidecar_per_image(tmp_path):
         loaded=_loaded(enc),
         out_dir=tmp_path / "out",
         dense=_dense(),
+        recipe=_recipe(),
         batch_size=2,
         num_workers=0,
     )
@@ -175,6 +213,7 @@ def test_grid_matches_the_direct_dense_composition(tmp_path, feature_kind, windo
         loaded=_loaded(enc),
         out_dir=tmp_path / "out",
         dense=_dense(feature_kind=feature_kind, window_size=window_size),
+        recipe=_recipe(feature_kind=feature_kind, window_size=window_size),
         batch_size=batch_size,
         num_workers=0,
     )
@@ -218,6 +257,9 @@ def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
 
     artifacts = run_dense_image_shard(
         specs, loaded=_loaded(enc), out_dir=tmp_path / "out", dense=dense,
+        recipe=_recipe(
+            target_size=(60, 60), window_size=32, overlap=0.25
+        ),
         batch_size=1, num_workers=0,
     )
 
@@ -244,6 +286,26 @@ def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
         "feature_kind": "patch_features",
         "attention_blocks": [-1],
         "attention_include_registers": False,
+        "compatibility": {
+            "sample_id": "a",
+            "image_path": str(Path(specs[0].image_path).resolve()),
+            "encoder_name": "fake-encoder",
+            "output_variant": "default",
+            "target_size": [60, 60],
+            "patch_size": [16, 16],
+            "encoded_size": [64, 64],
+            "pad": [4, 4],
+            "grid_shape": [4, 4],
+            "pad_mode": "reflect",
+            "image_pad_value": None,
+            "window_size": 32,
+            "overlap": 0.25,
+            "feature_kind": "patch_features",
+            "attention_blocks": [-1],
+            "attention_include_registers": False,
+            "precision": "fp32",
+            "dtype": "float32",
+        },
     }
 
 
@@ -262,6 +324,7 @@ def test_run_dense_image_shard_supports_non_square_images(tmp_path):
         loaded=_loaded(enc),
         out_dir=tmp_path / "out",
         dense=_dense(target_size=(64, 96)),
+        recipe=_recipe(target_size=(64, 96)),
         batch_size=1,
         num_workers=0,
     )
@@ -282,6 +345,7 @@ def test_run_dense_image_shard_rejects_images_that_are_not_the_declared_size(tmp
     with pytest.raises(ValueError, match=r"'small': \(32, 32\)"):
         run_dense_image_shard(
             specs, loaded=_loaded(enc), out_dir=tmp_path / "out", dense=_dense(),
+            recipe=_recipe(),
             batch_size=1, num_workers=0,
         )
 
@@ -302,6 +366,7 @@ def test_off_size_images_are_named_even_when_a_batch_is_mixed(tmp_path):
     with pytest.raises(ValueError) as excinfo:
         run_dense_image_shard(
             specs, loaded=_loaded(enc), out_dir=tmp_path / "out", dense=_dense(),
+            recipe=_recipe(),
             batch_size=3, num_workers=0,
         )
 
@@ -316,12 +381,16 @@ def test_run_dense_image_shard_skips_images_with_existing_sidecar(tmp_path):
     specs = [_spec(tmp_path, name) for name in ("a", "b", "c")]
     out_dir = tmp_path / "out"
 
-    first = run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=out_dir,
-                                  dense=_dense(), batch_size=2, num_workers=0)
+    first = run_dense_image_shard(
+        specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
+        recipe=_recipe(), batch_size=2, num_workers=0
+    )
     mtimes = {a.sample_id: a.path.stat().st_mtime_ns for a in first}
 
-    second = run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=out_dir,
-                                   dense=_dense(), batch_size=2, num_workers=0)
+    second = run_dense_image_shard(
+        specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
+        recipe=_recipe(), batch_size=2, num_workers=0
+    )
 
     assert [a.sample_id for a in second] == [a.sample_id for a in first]
     assert {a.sample_id: a.path.stat().st_mtime_ns for a in second} == mtimes
@@ -332,19 +401,221 @@ def test_run_dense_image_shard_reencodes_payload_missing_its_sidecar(tmp_path):
     enc = _encoder()
     specs = [_spec(tmp_path, name) for name in ("a", "b")]
     out_dir = tmp_path / "out"
-    run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
-                          batch_size=2, num_workers=0)
+    run_dense_image_shard(
+        specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
+        recipe=_recipe(), batch_size=2, num_workers=0
+    )
 
     _, sidecar_path = dense_image_paths(out_dir, sample_id="b")
     payload_path, _ = dense_image_paths(out_dir, sample_id="b")
     sidecar_path.unlink()
     payload_mtime = payload_path.stat().st_mtime_ns
 
-    run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
-                          batch_size=2, num_workers=0)
+    run_dense_image_shard(
+        specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
+        recipe=_recipe(), batch_size=2, num_workers=0
+    )
 
     assert sidecar_path.exists()
     assert payload_path.stat().st_mtime_ns != payload_mtime
+
+
+def test_incompatible_recompute_invalidates_done_marker_before_encoding(tmp_path):
+    enc = _encoder()
+    spec = _spec(tmp_path, "a")
+    out_dir = tmp_path / "out"
+    original_recipe = _recipe(overlap=0.0)
+    run_dense_image_shard(
+        [spec],
+        loaded=_loaded(enc),
+        out_dir=out_dir,
+        dense=_dense(),
+        recipe=original_recipe,
+        batch_size=1,
+        num_workers=0,
+    )
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id="a")
+    original_payload = payload_path.read_bytes()
+
+    Path(spec.image_path).unlink()
+    with pytest.raises(FileNotFoundError):
+        run_dense_image_shard(
+            [spec],
+            loaded=_loaded(enc),
+            out_dir=out_dir,
+            dense=_dense(overlap=0.25),
+            recipe=replace(original_recipe, overlap=0.25),
+            batch_size=1,
+            num_workers=0,
+        )
+
+    assert payload_path.read_bytes() == original_payload
+    assert not sidecar_path.exists()
+
+
+def test_interruption_after_payload_replacement_leaves_no_trusted_sidecar(
+    tmp_path, monkeypatch
+):
+    enc = _encoder()
+    spec = _spec(tmp_path, "a")
+    out_dir = tmp_path / "out"
+    original_recipe = _recipe(dtype="float32")
+    run_dense_image_shard(
+        [spec],
+        loaded=_loaded(enc),
+        out_dir=out_dir,
+        dense=_dense(),
+        recipe=original_recipe,
+        batch_size=1,
+        num_workers=0,
+    )
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id="a")
+    assert torch.load(payload_path, weights_only=True).dtype == torch.float32
+
+    def _fail_sidecar(*args, **kwargs):
+        raise RuntimeError("failure before sidecar publication")
+
+    monkeypatch.setattr(Path, "write_text", _fail_sidecar)
+    replacement_recipe = replace(original_recipe, dtype="float16")
+    with pytest.raises(RuntimeError, match="failure before sidecar publication"):
+        run_dense_image_shard(
+            [spec],
+            loaded=_loaded(enc),
+            out_dir=out_dir,
+            dense=_dense(),
+            recipe=replacement_recipe,
+            batch_size=1,
+            output_dtype=torch.float16,
+            num_workers=0,
+        )
+
+    assert torch.load(payload_path, weights_only=True).dtype == torch.float16
+    assert not sidecar_path.exists()
+
+
+def test_payload_temp_write_failure_leaves_old_payload_without_sidecar(
+    tmp_path, monkeypatch
+):
+    enc = _encoder()
+    spec = _spec(tmp_path, "a")
+    out_dir = tmp_path / "out"
+    original_recipe = _recipe(dtype="float32")
+    run_dense_image_shard(
+        [spec],
+        loaded=_loaded(enc),
+        out_dir=out_dir,
+        dense=_dense(),
+        recipe=original_recipe,
+        batch_size=1,
+        num_workers=0,
+    )
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id="a")
+    original_payload = payload_path.read_bytes()
+
+    def _fail_payload_write(*args, **kwargs):
+        raise OSError("payload temp write failed")
+
+    monkeypatch.setattr(torch, "save", _fail_payload_write)
+    with pytest.raises(OSError, match="payload temp write failed"):
+        run_dense_image_shard(
+            [spec],
+            loaded=_loaded(enc),
+            out_dir=out_dir,
+            dense=_dense(),
+            recipe=replace(original_recipe, dtype="float16"),
+            batch_size=1,
+            output_dtype=torch.float16,
+            num_workers=0,
+        )
+
+    assert payload_path.read_bytes() == original_payload
+    assert not sidecar_path.exists()
+    assert not any(".tmp-" in path.name for path in payload_path.parent.iterdir())
+
+
+def test_payload_publish_failure_leaves_old_payload_without_sidecar(
+    tmp_path, monkeypatch
+):
+    enc = _encoder()
+    spec = _spec(tmp_path, "a")
+    out_dir = tmp_path / "out"
+    original_recipe = _recipe(dtype="float32")
+    run_dense_image_shard(
+        [spec],
+        loaded=_loaded(enc),
+        out_dir=out_dir,
+        dense=_dense(),
+        recipe=original_recipe,
+        batch_size=1,
+        num_workers=0,
+    )
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id="a")
+    original_payload = payload_path.read_bytes()
+    original_replace = os.replace
+
+    def _fail_payload_replace(source, destination):
+        if Path(destination) == payload_path:
+            raise OSError("payload publish failed")
+        return original_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", _fail_payload_replace)
+    with pytest.raises(OSError, match="payload publish failed"):
+        run_dense_image_shard(
+            [spec],
+            loaded=_loaded(enc),
+            out_dir=out_dir,
+            dense=_dense(),
+            recipe=replace(original_recipe, dtype="float16"),
+            batch_size=1,
+            output_dtype=torch.float16,
+            num_workers=0,
+        )
+
+    assert payload_path.read_bytes() == original_payload
+    assert not sidecar_path.exists()
+    assert not any(".tmp-" in path.name for path in payload_path.parent.iterdir())
+
+
+def test_sidecar_publish_failure_leaves_new_payload_without_sidecar(
+    tmp_path, monkeypatch
+):
+    enc = _encoder()
+    spec = _spec(tmp_path, "a")
+    out_dir = tmp_path / "out"
+    original_recipe = _recipe(dtype="float32")
+    run_dense_image_shard(
+        [spec],
+        loaded=_loaded(enc),
+        out_dir=out_dir,
+        dense=_dense(),
+        recipe=original_recipe,
+        batch_size=1,
+        num_workers=0,
+    )
+    payload_path, sidecar_path = dense_image_paths(out_dir, sample_id="a")
+    original_replace = os.replace
+
+    def _fail_sidecar_replace(source, destination):
+        if Path(destination) == sidecar_path:
+            raise OSError("sidecar publish failed")
+        return original_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", _fail_sidecar_replace)
+    with pytest.raises(OSError, match="sidecar publish failed"):
+        run_dense_image_shard(
+            [spec],
+            loaded=_loaded(enc),
+            out_dir=out_dir,
+            dense=_dense(),
+            recipe=replace(original_recipe, dtype="float16"),
+            batch_size=1,
+            output_dtype=torch.float16,
+            num_workers=0,
+        )
+
+    assert torch.load(payload_path, weights_only=True).dtype == torch.float16
+    assert not sidecar_path.exists()
+    assert not any(".tmp-" in path.name for path in payload_path.parent.iterdir())
 
 
 def test_multi_rank_matches_single_rank(tmp_path):
@@ -353,13 +624,17 @@ def test_multi_rank_matches_single_rank(tmp_path):
     specs = [_spec(tmp_path, f"image-{i}") for i in range(7)]
 
     single_dir = tmp_path / "single"
-    run_dense_image_shard(specs, loaded=_loaded(enc), out_dir=single_dir, dense=_dense(),
-                          batch_size=3, num_workers=0)
+    run_dense_image_shard(
+        specs, loaded=_loaded(enc), out_dir=single_dir, dense=_dense(),
+        recipe=_recipe(), batch_size=3, num_workers=0
+    )
 
     multi_dir = tmp_path / "multi"
     for shard in plan_contiguous_shards(specs, 3):
-        run_dense_image_shard(shard, loaded=_loaded(enc), out_dir=multi_dir, dense=_dense(),
-                              batch_size=3, num_workers=0)
+        run_dense_image_shard(
+            shard, loaded=_loaded(enc), out_dir=multi_dir, dense=_dense(),
+            recipe=_recipe(), batch_size=3, num_workers=0
+        )
 
     def _files(root):
         base = _dense_dir(root)
@@ -381,6 +656,7 @@ def test_run_dense_image_shard_honors_the_on_disk_grid_dtype(tmp_path):
         loaded=_loaded(_encoder()),
         out_dir=tmp_path / "out",
         dense=_dense(),
+        recipe=_recipe(dtype="float16"),
         batch_size=1,
         output_dtype=torch.float16,
         num_workers=0,
@@ -400,6 +676,7 @@ def test_payload_size_is_independent_of_batch_size(tmp_path):
         out_dir = tmp_path / f"out-{batch_size}"
         artifacts = run_dense_image_shard(
             specs, loaded=_loaded(enc), out_dir=out_dir, dense=_dense(),
+            recipe=_recipe(),
             batch_size=batch_size, num_workers=0,
         )
         sizes[batch_size] = [artifact.path.stat().st_size for artifact in artifacts]

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -50,14 +50,21 @@ class _FakeModel:
 
     def __init__(self, encoder) -> None:
         self._loaded = _loaded(encoder)
-        self.name = "fake-encoder"
+        self.name = "uni"
         self._output_variant = None
         self._requested_device = "cpu"
         self.allow_non_recommended_settings = False
         self.declared: list = []
 
     def _declare_dense_encoder_input(self, dense, *, emit_run_info):
+        from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
         self.declared.append(dense)
+        return EncoderInputContract.declared_dense(
+            self.name,
+            target_size_px=dense.target_size,
+            window_size=dense.window_size,
+        )
 
     def _load_backend(self):
         assert self.declared, "the dense image path must declare its geometry before loading"
@@ -133,6 +140,7 @@ def test_embed_images_dense_num_gpus_gt_one_launches_the_worker(tmp_path, monkey
     the parent itself encodes nothing and collects the artifacts back off disk."""
     from slide2vec.runtime.dense_image_shard import run_dense_image_shard
     from slide2vec.runtime.image_specs import image_specs_from_request
+    from slide2vec.runtime.serialization import deserialize_dense_image_recipe
     from slide2vec.runtime.sharding import plan_contiguous_shards
 
     caller_dir = tmp_path / "caller"
@@ -145,9 +153,11 @@ def test_embed_images_dense_num_gpus_gt_one_launches_the_worker(tmp_path, monkey
         request = json.loads(Path(request_path).read_text())
         captured.update(module=module, num_gpus=num_gpus, output_dir=output_dir, request=request)
         specs = image_specs_from_request(request)
+        recipe = deserialize_dense_image_recipe(request["recipe"])
         for shard in plan_contiguous_shards(specs, num_gpus):
             run_dense_image_shard(shard, loaded=rank_loaded, out_dir=Path(output_dir),
-                                  dense=_dense(), batch_size=2, num_workers=0)
+                                  dense=_dense(), recipe=recipe,
+                                  batch_size=2, num_workers=0)
 
     monkeypatch.setattr(dense_image_stage, "run_torchrun_worker", _fake_run)
     monkeypatch.setattr(dense_image_stage, "validate_multi_gpu_execution", lambda *a, **k: None)
@@ -167,6 +177,7 @@ def test_embed_images_dense_num_gpus_gt_one_launches_the_worker(tmp_path, monkey
     expected_output_dir = (caller_dir / "output").resolve()
     assert Path(captured["output_dir"]) == expected_output_dir
     assert captured["request"]["dense"]["target_size"] == 64
+    assert captured["request"]["recipe"]["encoder_name"] == "uni"
     assert [image["sample_id"] for image in captured["request"]["images"]] == ["a", "b", "c"]
     assert all(Path(image["image_path"]).is_absolute() for image in captured["request"]["images"])
     assert len(artifacts) == 3
@@ -228,6 +239,37 @@ def test_embed_images_dense_requires_at_least_one_image(tmp_path):
     execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
     with pytest.raises(ValueError, match="At least one image"):
         dense_image_stage.embed_images_dense(model, [], dense=_dense(), execution=execution)
+
+
+@pytest.mark.parametrize(
+    ("dense", "message"),
+    [
+        (_dense(pad_mode="invalid"), "pad_mode"),
+        (_dense(feature_kind="invalid"), "feature_kind"),
+        (_dense(window_size=32, overlap=1.0), "overlap"),
+        (
+            _dense(feature_kind="cls_attention", attention_blocks=()),
+            "attention_blocks",
+        ),
+    ],
+)
+def test_invalid_dense_image_recipe_fails_before_backend_load(
+    tmp_path, monkeypatch, dense, message
+):
+    model = _FakeModel(_encoder())
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("request-wide validation must precede model loading"),
+    )
+    execution = ExecutionOptions(
+        output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+    )
+
+    with pytest.raises(ValueError, match=message):
+        dense_image_stage.embed_images_dense(
+            model, _images(tmp_path, ["a"]), dense=dense, execution=execution
+        )
 
 
 def test_dense_image_options_round_trip_through_the_request():
@@ -320,13 +362,29 @@ def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
     from slide2vec.distributed import dense_image_worker
     from slide2vec.runtime.image_specs import build_image_specs_request
     from slide2vec.runtime.serialization import (
+        serialize_dense_image_recipe,
         serialize_dense_image_options,
         serialize_execution,
     )
+    from slide2vec.runtime.dense_image_recipe import resolve_dense_image_recipe
 
     specs = _images(tmp_path, ["a", "b", "c", "d"])
     loaded = _loaded(_encoder())
     declared: list = []
+    parent_model = _FakeModel(_encoder())
+    dense = _dense()
+    recipe = resolve_dense_image_recipe(
+        model=parent_model,
+        contract=parent_model._declare_dense_encoder_input(dense, emit_run_info=False),
+        dense=dense,
+        execution=ExecutionOptions(
+            output_dir=tmp_path / "out",
+            num_gpus=2,
+            precision="fp32",
+            batch_size=2,
+            num_workers_per_gpu=1,
+        ),
+    )
 
     monkeypatch.setattr(
         api.Model, "from_preset",
@@ -338,7 +396,8 @@ def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
 
     request = {
         "model": {"name": "fake", "output_variant": None, "allow_non_recommended_settings": False},
-        "dense": serialize_dense_image_options(_dense()),
+        "dense": serialize_dense_image_options(dense),
+        "recipe": serialize_dense_image_recipe(recipe),
         "execution": serialize_execution(
             ExecutionOptions(
                 output_dir=tmp_path / "out",


### PR DESCRIPTION
## Summary

- resolve one canonical dense-image extraction recipe in the parent and round-trip it to distributed workers
- skip only complete payload/sidecar pairs whose image identity and full recipe match exactly
- invalidate stale done-markers before atomically replacing payloads and publishing sidecars last
- hard-fail malformed sidecars, log recomputation differences, and document the compatibility/replacement contract

## Why

Dense-image resume previously trusted sidecar existence, so a stale artifact could be reused after the encoder, geometry, precision, or stored dtype changed. Replacing an incompatible payload also left the old sidecar visible until the final write.

## Validation

- TDD red/green slices for canonical identity, serialization, compatibility decisions, malformed sidecars, and crash boundaries
- `108 passed, 1 deselected` across dense-image, dense-region, and dense-extraction focused tests (the deselected exact-zero multi-rank CPU assertion also fails on `main` with ~1e-6 batch-shape drift)
- `703 passed, 31 deselected` in the non-heavy full suite after deselecting five confirmed baseline failures reproduced on `main`
- `git diff --check` and Python byte-compilation pass
- final two-axis Standards and Spec re-review: no findings

Closes #257