### PR TITLE
Make raster dense-image runs spacing-aware

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -318,7 +318,11 @@ coordinate and no spacing→level plan.
            ImageSpec(sample_id="ocelot-001", image_path="/data/ocelot/001.jpg"),
            ImageSpec(sample_id="ocelot-002", image_path="/data/ocelot/002.jpg"),
        ],
-       dense=DenseImageOptions(target_size=1024, window_size=224),
+       dense=DenseImageOptions(
+           target_size=1024,
+           spacing_um=0.5,
+           window_size=224,
+       ),
        execution=ExecutionOptions(output_dir="outputs/ocelot", num_gpus=2),
    )
 
@@ -336,10 +340,28 @@ geometry, dense settings, inference precision, and stored dtype exactly match
 the current call. Missing, legacy, or incompatible pairs are recomputed, so an
 interrupted run is restarted by re-issuing the call.
 
+**Raster reader regime and physical scale.** Raster dense runs accept exactly
+``.png``, ``.jpg``, and ``.jpeg`` suffixes, case-insensitively. Every raster uses
+the existing Pillow ``convert("RGB")`` decoder; ``backend="auto"`` resolves to
+that reader. A positive, finite numeric ``spacing_um`` is an **asserted spacing**:
+it states that every supplied pixel array is already at that µm/px scale and is
+checked against the encoder's supported spacings by the normal
+recommended-settings policy. It never resizes or otherwise changes pixels.
+``spacing_um=None`` is **unknown spacing**, not an inferred default. A
+spacing-constrained encoder rejects unknown spacing unless
+``allow_non_recommended_settings=True`` (one warning for the run); a
+spacing-agnostic encoder accepts it normally.
+
+``ImageSpec.spacing_at_level_0`` is a level-0 source-metadata override for
+spacing-readable inputs. Raster dense extraction and :meth:`Model.embed_images`
+reject a non-null override rather than silently ignoring it, because a
+pre-cropped PNG/JPEG has no pyramid level-0 read plan.
+
 **target_size is a declaration, not a resize.** Dense extraction encodes through
 the encoder's normalization-only transform, so it never rescales: every image
 must already be exactly ``target_size`` (a non-square ``(height, width)`` pair is
-accepted), and one that is not raises naming the images. Declaring the geometry
+accepted), and one that is not raises with the sample, observed and declared
+dimensions, and the resolved or unknown spacing. Declaring the geometry
 up front is what lets the *effective* encoder input — the padded image, or one
 patch-aligned window of it — be validated, and the encoder's variable-input
 constructor settings resolved, before a single image is decoded (see

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -272,6 +272,17 @@ payload.
      "encoder_name": "virchow2",
      "encoder_level": "tile",
      "encoder_input_regime": "declared",
+     "reader_regime": "raster",
+     "spacing_source": "explicit",
+     "declared_spacing_um": 0.5,
+     "source_spacing_um": 0.5,
+     "effective_spacing_um": 0.5,
+     "requested_backend": "auto",
+     "backend": "pil",
+     "tolerance": null,
+     "read_level": null,
+     "read_tile_size_px": null,
+     "requested_tile_size_px": null,
      "image_path": "/data/ocelot/001.jpg",
      "format": "pt",
      "dtype": "float32",
@@ -293,6 +304,17 @@ payload.
        "image_path": "/data/ocelot/001.jpg",
        "encoder_name": "virchow2",
        "output_variant": "cls_patch_mean",
+       "reader_regime": "raster",
+       "spacing_source": "explicit",
+       "declared_spacing_um": 0.5,
+       "source_spacing_um": 0.5,
+       "effective_spacing_um": 0.5,
+       "requested_backend": "auto",
+       "backend": "pil",
+       "tolerance": null,
+       "read_level": null,
+       "read_tile_size_px": null,
+       "requested_tile_size_px": null,
        "target_size": [1024, 1024],
        "patch_size": [14, 14],
        "encoded_size": [1036, 1036],
@@ -311,12 +333,20 @@ payload.
    }
 
 The compatibility identity covers the sample ID and normalized source path;
+resolved raster reader regime, requested/resolved backend, spacing source, and
+declared/source/effective spacing;
 encoder name and resolved output variant; target, patch, encoded, padding, and
 grid geometry; padding/window/overlap and attention settings; inference
 precision; and stored dtype. GPU count, batch size, workers, prefetching, output
 directory, and other execution mechanics are deliberately excluded.
 ``encoder_input_regime`` is ``"declared"`` — unlike a pooled image embedding,
 this run *stated* its geometry and it was validated before any image was read.
+For raster inputs, ``reader_regime="raster"`` and ``backend="pil"`` record the
+unchanged Pillow RGB path. Explicit spacing repeats the caller's assertion in
+``declared_spacing_um``, ``source_spacing_um``, and ``effective_spacing_um``;
+unknown spacing records all three as ``null`` with
+``spacing_source="unknown"``. Pyramid-plan fields stay ``null`` because no
+level was selected and no spacing-driven resize occurred.
 
 
 Coordinate Files

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -444,13 +444,13 @@ class DenseOptions:
 
 @dataclass(frozen=True, kw_only=True)
 class DenseImageOptions:
-    """Dense ``(d, gh, gw)`` grid extraction over pre-cropped images (issue #235).
+    """Dense ``(d, gh, gw)`` extraction over pre-cropped raster images.
 
-    :class:`DenseOptions` minus everything that only a slide has: there is no spacing, no
-    tolerance and no reading backend here, because the image *is* the region — it is read
-    from disk at the size it was written. What remains is the same supervision geometry and
-    the same dense encode knobs, so a run migrating from ROIs to image/mask pairs keeps its
-    recipe.
+    ``.png``, ``.jpg``, and ``.jpeg`` inputs (case-insensitive) use the existing Pillow RGB
+    reader. ``spacing_um`` is a run-level assertion that the supplied pixels already have
+    that physical scale; it never selects a pyramid level or resizes pixels. ``None`` means
+    unknown spacing, which spacing-constrained encoders reject unless
+    ``allow_non_recommended_settings=True``. Spacing-agnostic encoders accept it normally.
 
     ``target_size`` is a **declaration**, not a resize: the dense transform is
     normalization-only, so every image must already be exactly this size and one that is not
@@ -464,6 +464,14 @@ class DenseImageOptions:
     #: Supervision geometry in pixels the dense grid registers to: a square side length, or
     #: an explicit ``(height, width)`` for non-square images.
     target_size: int | tuple[int, int]
+    #: Asserted positive, finite physical spacing of the supplied raster pixels in µm/px.
+    #: ``None`` means their physical spacing is unknown.
+    spacing_um: float | None = None
+    #: Relative spacing tolerance (reserved for spacing-readable inputs; raster spacing is
+    #: an assertion and never selects or resamples pixels).
+    tolerance: float = 0.05
+    #: Requested reader backend. Raster images always resolve to the Pillow RGB reader.
+    backend: str = "auto"
     #: Padding mode used to pad the image up to the encoder's patch multiple.
     #: One of ``"reflect"`` / ``"replicate"`` / ``"constant"`` / ``"zero"``.
     pad_mode: str = "reflect"
@@ -503,18 +511,21 @@ class SlideRegions:
 
 @dataclass(frozen=True, kw_only=True)
 class ImageSpec:
-    """One pre-cropped image to embed: ``(sample_id, image_path)``.
+    """One named image source: ``(sample_id, image_path, spacing_at_level_0)``.
 
     The input unit of :meth:`Model.embed_images` — the Given-geometry counterpart of
-    :class:`SlideRegions`. There is no slide, no coordinate and no spacing here: the caller
-    holds an image file it never asked slide2vec to produce (a public patch benchmark
-    sample), and names it. ``sample_id`` is the artifact's whole identity, so it must be
-    unique within a run and a valid filename component; slide2vec never derives it from the
-    path, because two directories can hold the same filename.
+    :class:`SlideRegions`. ``spacing_at_level_0`` represents caller metadata for
+    spacing-readable image sources. The current raster paths reject a non-null value: a
+    pre-cropped PNG/JPEG has no slide pyramid or level-0 read plan to override. ``sample_id``
+    is the artifact's whole identity, so it must be unique within a run and a valid filename
+    component.
     """
 
     sample_id: str
     image_path: PathLike
+    #: Optional caller override for the source's level-0 spacing. Raster image paths reject
+    #: non-null overrides because they have no slide pyramid or level-0 read plan.
+    spacing_at_level_0: float | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -855,9 +866,13 @@ class Model:
         identity and complete extraction recipe. Returns one
         :class:`~slide2vec.artifacts.DenseImageArtifact` per input image, in input order.
 
-        It differs from :meth:`embed_regions_dense` in exactly one respect: there is no
-        slide, no coordinate and no spacing→level plan, because the image *is* the region.
-        Everything else is shared, including the effective encoder input — the padded image
+        Raster inputs are exactly ``.png``, ``.jpg``, and ``.jpeg`` (case-insensitive) and
+        always use Pillow's RGB decoder. ``dense.spacing_um`` asserts the scale those pixels
+        already have; ``None`` records unknown spacing. Neither case resizes. A raster
+        :class:`ImageSpec` cannot carry ``spacing_at_level_0`` because there is no level-0
+        pyramid spacing to override.
+
+        Everything after reading is shared with the slide path, including the effective encoder input — the padded image
         for a whole-image run, one patch-aligned window for a sliding one — which is declared
         before any image is decoded, so a geometry the encoder cannot accept raises here
         rather than on a torchrun rank's first forward pass.
@@ -896,7 +911,9 @@ class Model:
         encoder input size as run provenance rather than validating it. That also means
         preprocessing runs itemwise before stacking — in-process by default, or in spawned
         loader workers when ``num_workers_per_gpu`` is explicit — because differently sized
-        images cannot be stacked before they are resized.
+        images cannot be stacked before they are resized. ``ImageSpec.spacing_at_level_0``
+        is rejected here rather than ignored because this path has no slide level-0 read
+        plan.
         """
         from slide2vec.runtime.image_stage import embed_images
 

--- a/slide2vec/data/dataset.py
+++ b/slide2vec/data/dataset.py
@@ -88,9 +88,16 @@ class DeclaredGeometryCollator:
     dataset position), so this stays free of any runtime dependency.
     """
 
-    def __init__(self, *, sample_ids, target_size: tuple[int, int]) -> None:
+    def __init__(
+        self,
+        *,
+        sample_ids,
+        target_size: tuple[int, int],
+        spacing_um: float | None,
+    ) -> None:
         self.sample_ids = [str(sample_id) for sample_id in sample_ids]
         self.target_size = (int(target_size[0]), int(target_size[1]))
+        self.spacing_um = None if spacing_um is None else float(spacing_um)
 
     def __call__(self, batch):
         worker_start = time.perf_counter()
@@ -102,11 +109,19 @@ class DeclaredGeometryCollator:
             if tuple(int(size) for size in image.shape[-2:]) != self.target_size
         }
         if offenders:
+            spacing = (
+                "unknown spacing"
+                if self.spacing_um is None
+                else f"resolved spacing {self.spacing_um:g} µm/px"
+            )
+            details = "; ".join(
+                f"Image {sample_id!r} has observed size {observed}, but target_size "
+                f"declares {self.target_size}, at {spacing}"
+                for sample_id, observed in offenders.items()
+            )
             raise ValueError(
-                f"images {offenders} are not the declared target_size {self.target_size} "
-                "after the normalization-only dense transform (sample_id: observed (h, w)). "
-                "Dense extraction never resizes: state the images' own geometry, or split "
-                "the run so each geometry is declared once."
+                f"{details}. Dense raster extraction never resizes; supply pixels at the "
+                "declared geometry."
             )
         return (
             torch.as_tensor(indices, dtype=torch.long),

--- a/slide2vec/encoders/validation.py
+++ b/slide2vec/encoders/validation.py
@@ -22,6 +22,7 @@ def validate_encoder_config(
     precision: str | None = None,
     output_variant: str | None = None,
     allow_non_recommended: bool = False,
+    require_known_spacing: bool = False,
 ) -> None:
     """Check config against recommended model settings.
 
@@ -44,7 +45,13 @@ def validate_encoder_config(
             )
 
     rec_spacing = info["supported_spacing_um"] if "supported_spacing_um" in info else None
-    if requested_spacing_um is not None and rec_spacing is not None:
+    if requested_spacing_um is None and require_known_spacing and rec_spacing is not None:
+        valid_spacings = rec_spacing if isinstance(rec_spacing, list) else [rec_spacing]
+        supported_text = ", ".join(f"{s:g}" for s in valid_spacings)
+        mismatches.append(
+            f"requested_spacing_um=unknown (recommended: [{supported_text}])"
+        )
+    elif requested_spacing_um is not None and rec_spacing is not None:
         valid_spacings = rec_spacing if isinstance(rec_spacing, list) else [rec_spacing]
         if not any(abs(float(requested_spacing_um) - float(s)) <= 1e-8 for s in valid_spacings):
             supported_text = ", ".join(f"{s:g}" for s in valid_spacings)

--- a/slide2vec/runtime/dense_image_recipe.py
+++ b/slide2vec/runtime/dense_image_recipe.py
@@ -62,6 +62,17 @@ class DenseImageRecipe:
 
     encoder_name: str
     output_variant: str
+    reader_regime: str
+    spacing_source: str
+    declared_spacing_um: float | None
+    source_spacing_um: float | None
+    effective_spacing_um: float | None
+    requested_backend: str
+    backend: str
+    tolerance: float | None
+    read_level: int | None
+    read_tile_size_px: int | None
+    requested_tile_size_px: int | None
     target_size: tuple[int, int]
     patch_size: tuple[int, int]
     encoded_size: tuple[int, int]
@@ -81,6 +92,17 @@ class DenseImageRecipe:
         return {
             "encoder_name": self.encoder_name,
             "output_variant": self.output_variant,
+            "reader_regime": self.reader_regime,
+            "spacing_source": self.spacing_source,
+            "declared_spacing_um": self.declared_spacing_um,
+            "source_spacing_um": self.source_spacing_um,
+            "effective_spacing_um": self.effective_spacing_um,
+            "requested_backend": self.requested_backend,
+            "backend": self.backend,
+            "tolerance": self.tolerance,
+            "read_level": self.read_level,
+            "read_tile_size_px": self.read_tile_size_px,
+            "requested_tile_size_px": self.requested_tile_size_px,
             "target_size": list(self.target_size),
             "patch_size": list(self.patch_size),
             "encoded_size": list(self.encoded_size),
@@ -110,6 +132,41 @@ class DenseImageRecipe:
         return cls(
             encoder_name=str(payload["encoder_name"]),
             output_variant=str(payload["output_variant"]),
+            reader_regime=str(payload["reader_regime"]),
+            spacing_source=str(payload["spacing_source"]),
+            declared_spacing_um=(
+                None
+                if payload["declared_spacing_um"] is None
+                else float(payload["declared_spacing_um"])
+            ),
+            source_spacing_um=(
+                None
+                if payload["source_spacing_um"] is None
+                else float(payload["source_spacing_um"])
+            ),
+            effective_spacing_um=(
+                None
+                if payload["effective_spacing_um"] is None
+                else float(payload["effective_spacing_um"])
+            ),
+            requested_backend=str(payload["requested_backend"]),
+            backend=str(payload["backend"]),
+            tolerance=(
+                None if payload["tolerance"] is None else float(payload["tolerance"])
+            ),
+            read_level=(
+                None if payload["read_level"] is None else int(payload["read_level"])
+            ),
+            read_tile_size_px=(
+                None
+                if payload["read_tile_size_px"] is None
+                else int(payload["read_tile_size_px"])
+            ),
+            requested_tile_size_px=(
+                None
+                if payload["requested_tile_size_px"] is None
+                else int(payload["requested_tile_size_px"])
+            ),
             target_size=_int_pair(payload["target_size"], field="target_size"),
             patch_size=_int_pair(payload["patch_size"], field="patch_size"),
             encoded_size=_int_pair(payload["encoded_size"], field="encoded_size"),
@@ -169,9 +226,23 @@ def resolve_dense_image_recipe(*, model, contract, dense, execution) -> DenseIma
         attention_include_registers=dense.attention_include_registers,
     )
     output_precision = resolve_output_precision(execution.output_dtype, execution.precision)
+    spacing_um = (
+        None if dense.spacing_um is None else float(dense.spacing_um)
+    )
     return DenseImageRecipe(
         encoder_name=str(model.name),
         output_variant=str(output["output_variant"]),
+        reader_regime="raster",
+        spacing_source="unknown" if spacing_um is None else "explicit",
+        declared_spacing_um=spacing_um,
+        source_spacing_um=spacing_um,
+        effective_spacing_um=spacing_um,
+        requested_backend=str(dense.backend),
+        backend="pil",
+        tolerance=None,
+        read_level=None,
+        read_tile_size_px=None,
+        requested_tile_size_px=None,
         target_size=geometry.target_size,
         patch_size=geometry.patch_size,
         encoded_size=geometry.encoded_size,

--- a/slide2vec/runtime/dense_image_shard.py
+++ b/slide2vec/runtime/dense_image_shard.py
@@ -8,7 +8,8 @@ very same code path runs in-process for ``num_gpus=1`` and on every torchrun ran
 exercised on CPU.
 
 It differs from the ROI loop in exactly one respect: there is no slide, no coordinate and no
-spacing→level plan, because the image *is* the region and is read from disk. Everything
+spacing→level plan, because the raster image is already at its asserted (or unknown) physical
+spacing and is read through Pillow without resampling. Everything
 after the pixels arrive — geometry, padding, whole-tile vs sliding encode, output dtype — is
 the shared :class:`~slide2vec.runtime.dense_regions.DenseGridEncoder`, so this module owns no
 padding, batching or blending logic of its own.
@@ -135,8 +136,8 @@ def dense_image_metadata(
 ) -> dict:
     """The geometry sidecar: what was encoded, and with which dense recipe.
 
-    The dense ROI sidecar's fields minus the slide's read plan (there is none) plus the
-    encoder identity, which a given-geometry artifact cannot recover from a coordinate.
+    The dense ROI sidecar's fields plus truthful raster provenance: Pillow is the resolved
+    reader, spacing is explicit or unknown, and non-applicable pyramid-plan fields are null.
     ``encoder_input_regime`` is ``"declared"``: unlike the pooled given-image path this run
     *did* state its geometry — ``target_size`` — and it was validated before any image was
     read, so the sidecar records a request that was honored rather than a size observed.
@@ -157,6 +158,17 @@ def dense_image_metadata(
         "encoder_name": compatibility["encoder_name"],
         "encoder_level": loaded.level,
         "encoder_input_regime": "declared",
+        "reader_regime": compatibility["reader_regime"],
+        "spacing_source": compatibility["spacing_source"],
+        "declared_spacing_um": compatibility["declared_spacing_um"],
+        "source_spacing_um": compatibility["source_spacing_um"],
+        "effective_spacing_um": compatibility["effective_spacing_um"],
+        "requested_backend": compatibility["requested_backend"],
+        "backend": compatibility["backend"],
+        "tolerance": compatibility["tolerance"],
+        "read_level": compatibility["read_level"],
+        "read_tile_size_px": compatibility["read_tile_size_px"],
+        "requested_tile_size_px": compatibility["requested_tile_size_px"],
         "pad_mode": compatibility["pad_mode"],
         "image_pad_value": compatibility["image_pad_value"],
         "window_size": compatibility["window_size"],
@@ -237,6 +249,7 @@ def run_dense_image_shard(
             collate_fn=DeclaredGeometryCollator(
                 sample_ids=[spec.sample_id for spec in pending],
                 target_size=encoder.geometry.target_size,
+                spacing_um=recipe.effective_spacing_um,
             ),
             **dataloader_kwargs(
                 device=loaded.device,

--- a/slide2vec/runtime/dense_image_stage.py
+++ b/slide2vec/runtime/dense_image_stage.py
@@ -20,20 +20,22 @@ because only the source of the pixels differs:
 5. **collect** one :class:`~slide2vec.artifacts.DenseImageArtifact` per input image by reading
    the sidecars back off disk (the ranks already persisted them; nobody gathers grids).
 
-There is no step here for the one thing the ROI stage does extra — resolving each slide's
-spacing→level read plan — because there is no slide: the image *is* the region.
+Raster classification and its run-level spacing assertion are resolved before this sequence:
+there is no spacing→level read plan because a PNG/JPEG is already the pixel array to encode.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import math
 from pathlib import Path
 from subprocess import Popen
 from typing import Sequence
 
 from slide2vec.api import DenseImageOptions, ImageSpec
 from slide2vec.artifacts import DenseImageArtifact
+from slide2vec.encoders.validation import validate_encoder_config
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.dense_image_shard import (
     dense_image_artifact_from_disk,
@@ -51,7 +53,12 @@ from slide2vec.runtime.distributed import (
     run_torchrun_worker,
 )
 from slide2vec.runtime.distributed_stage import validate_multi_gpu_execution
-from slide2vec.runtime.image_specs import build_image_specs_request, normalize_image_specs
+from slide2vec.runtime.image_specs import (
+    build_image_specs_request,
+    normalize_image_specs,
+    reject_image_level0_spacing_overrides,
+    validate_raster_image_specs,
+)
 from slide2vec.runtime.serialization import (
     serialize_dense_image_options,
     serialize_dense_image_recipe,
@@ -87,6 +94,26 @@ def embed_images_dense(
     execution,
 ) -> list[DenseImageArtifact]:
     """Extract + persist a dense grid per caller-supplied image across all visible GPUs."""
+    specs = normalize_image_specs(
+        images,
+        method_name="embed_images_dense()",
+        artifact_location="dense_image_embeddings/<sample_id>",
+    )
+    validate_raster_image_specs(specs)
+    reject_image_level0_spacing_overrides(
+        specs, method_name="embed_images_dense()"
+    )
+    spacing_um = None if dense.spacing_um is None else float(dense.spacing_um)
+    if spacing_um is not None and (not math.isfinite(spacing_um) or spacing_um <= 0):
+        raise ValueError(
+            "DenseImageOptions.spacing_um must be a positive, finite value or None."
+        )
+    validate_encoder_config(
+        model.name,
+        requested_spacing_um=spacing_um,
+        allow_non_recommended=bool(model.allow_non_recommended_settings),
+        require_known_spacing=True,
+    )
     # Declare the effective encoder input before anything is decoded, sharded or launched: an
     # image geometry this encoder cannot accept must fail here, not on the first forward pass
     # of a torchrun rank. Idempotent, so every rank re-declares for itself (dense_image_worker).
@@ -96,11 +123,6 @@ def embed_images_dense(
         contract=contract,
         dense=dense,
         execution=execution,
-    )
-    specs = normalize_image_specs(
-        images,
-        method_name="embed_images_dense()",
-        artifact_location="dense_image_embeddings/<sample_id>",
     )
     out_dir = Path(execution.output_dir).expanduser().resolve()
     execution = execution.with_output_dir(out_dir)

--- a/slide2vec/runtime/image_specs.py
+++ b/slide2vec/runtime/image_specs.py
@@ -15,6 +15,36 @@ from typing import Sequence
 
 from slide2vec.api import ImageSpec
 
+RASTER_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg"})
+
+
+def validate_raster_image_specs(specs: Sequence[ImageSpec]) -> None:
+    """Require the closed raster suffix set owned by the Pillow dense-image path."""
+    unsupported = [
+        f"{spec.sample_id!r} ({spec.image_path})"
+        for spec in specs
+        if Path(spec.image_path).suffix.lower() not in RASTER_IMAGE_SUFFIXES
+    ]
+    if unsupported:
+        raise ValueError(
+            "Dense raster image extraction accepts exactly .png, .jpg, and .jpeg "
+            f"(case-insensitive); unsupported inputs: {unsupported}"
+        )
+
+
+def reject_image_level0_spacing_overrides(
+    specs: Sequence[ImageSpec], *, method_name: str
+) -> None:
+    """Reject slide-pyramid spacing overrides on pre-cropped image APIs."""
+    overridden = [
+        spec.sample_id for spec in specs if spec.spacing_at_level_0 is not None
+    ]
+    if overridden:
+        raise ValueError(
+            f"{method_name} does not accept ImageSpec.spacing_at_level_0 for raster "
+            f"images; use the run-level dense spacing assertion instead. Samples: {overridden}"
+        )
+
 
 def normalize_image_specs(
     images: Sequence[ImageSpec], *, method_name: str, artifact_location: str
@@ -30,6 +60,11 @@ def normalize_image_specs(
         ImageSpec(
             sample_id=str(image.sample_id),
             image_path=str(Path(image.image_path).expanduser().resolve()),
+            spacing_at_level_0=(
+                None
+                if image.spacing_at_level_0 is None
+                else float(image.spacing_at_level_0)
+            ),
         )
         for image in images
     ]
@@ -57,7 +92,12 @@ def build_image_specs_request(specs: Sequence[ImageSpec]) -> dict:
     """
     return {
         "images": [
-            {"sample_id": spec.sample_id, "image_path": str(spec.image_path)} for spec in specs
+            {
+                "sample_id": spec.sample_id,
+                "image_path": str(spec.image_path),
+                "spacing_at_level_0": spec.spacing_at_level_0,
+            }
+            for spec in specs
         ]
     }
 
@@ -65,6 +105,14 @@ def build_image_specs_request(specs: Sequence[ImageSpec]) -> dict:
 def image_specs_from_request(request: dict) -> list[ImageSpec]:
     """Inverse of :func:`build_image_specs_request`: request → flat spec list."""
     return [
-        ImageSpec(sample_id=str(image["sample_id"]), image_path=str(image["image_path"]))
+        ImageSpec(
+            sample_id=str(image["sample_id"]),
+            image_path=str(image["image_path"]),
+            spacing_at_level_0=(
+                None
+                if image.get("spacing_at_level_0") is None
+                else float(image["spacing_at_level_0"])
+            ),
+        )
         for image in request["images"]
     ]

--- a/slide2vec/runtime/image_stage.py
+++ b/slide2vec/runtime/image_stage.py
@@ -40,7 +40,11 @@ from slide2vec.runtime.image_shard import (
     image_needs_encode,
     run_image_shard,
 )
-from slide2vec.runtime.image_specs import build_image_specs_request, normalize_image_specs
+from slide2vec.runtime.image_specs import (
+    build_image_specs_request,
+    normalize_image_specs,
+    reject_image_level0_spacing_overrides,
+)
 from slide2vec.runtime.model_settings import resolve_output_precision
 from slide2vec.runtime.serialization import serialize_execution, serialize_model
 
@@ -69,6 +73,7 @@ def embed_images(model, images: Sequence[ImageSpec], *, execution) -> list[Image
         method_name="embed_images()",
         artifact_location="image_embeddings/<sample_id>",
     )
+    reject_image_level0_spacing_overrides(specs, method_name="embed_images()")
     out_dir = Path(execution.output_dir).expanduser().resolve()
     execution = execution.with_output_dir(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here

--- a/slide2vec/runtime/serialization.py
+++ b/slide2vec/runtime/serialization.py
@@ -120,6 +120,9 @@ def serialize_dense_image_options(dense: DenseImageOptions) -> dict[str, Any]:
             if isinstance(dense.target_size, int)
             else [int(size) for size in dense.target_size]
         ),
+        "spacing_um": dense.spacing_um,
+        "tolerance": dense.tolerance,
+        "backend": dense.backend,
         "pad_mode": dense.pad_mode,
         "image_pad_value": dense.image_pad_value,
         "window_size": dense.window_size,
@@ -148,6 +151,13 @@ def deserialize_dense_image_options(payload: dict[str, Any]) -> DenseImageOption
             if isinstance(target_size, int)
             else (int(target_size[0]), int(target_size[1]))
         ),
+        spacing_um=(
+            None
+            if payload.get("spacing_um") is None
+            else float(payload["spacing_um"])
+        ),
+        tolerance=float(payload.get("tolerance", 0.05)),
+        backend=str(payload.get("backend", "auto")),
         pad_mode=str(payload.get("pad_mode", "reflect")),
         image_pad_value=(
             float(payload["image_pad_value"]) if payload.get("image_pad_value") is not None else None

--- a/tests/test_dense_image_resume.py
+++ b/tests/test_dense_image_resume.py
@@ -52,6 +52,7 @@ def test_dense_image_recipe_contains_the_complete_canonical_identity(tmp_path):
     model = Model(name="virchow2", output_variant="cls")
     dense = DenseImageOptions(
         target_size=(60, 92),
+        spacing_um=0.504,
         pad_mode="constant",
         image_pad_value=0.25,
         window_size=31,
@@ -79,6 +80,17 @@ def test_dense_image_recipe_contains_the_complete_canonical_identity(tmp_path):
     assert first.to_dict() == {
         "encoder_name": "virchow2",
         "output_variant": "cls",
+        "reader_regime": "raster",
+        "spacing_source": "explicit",
+        "declared_spacing_um": 0.504,
+        "source_spacing_um": 0.504,
+        "effective_spacing_um": 0.504,
+        "requested_backend": "auto",
+        "backend": "pil",
+        "tolerance": None,
+        "read_level": None,
+        "read_tile_size_px": None,
+        "requested_tile_size_px": None,
         "target_size": [60, 92],
         "patch_size": [14, 14],
         "encoded_size": [70, 98],
@@ -147,11 +159,33 @@ def test_dense_image_recipe_round_trips_exactly_through_json(tmp_path):
     assert deserialize_dense_image_recipe(payload) == recipe
 
 
+def test_unknown_raster_spacing_recipe_records_null_physical_scale(tmp_path):
+    recipe = _resolved_recipe(tmp_path, spacing_um=None)
+
+    assert {
+        key: recipe.to_dict()[key]
+        for key in (
+            "reader_regime",
+            "spacing_source",
+            "declared_spacing_um",
+            "source_spacing_um",
+            "effective_spacing_um",
+        )
+    } == {
+        "reader_regime": "raster",
+        "spacing_source": "unknown",
+        "declared_spacing_um": None,
+        "source_spacing_um": None,
+        "effective_spacing_um": None,
+    }
+
+
 def test_current_image_specs_round_trip_exactly_through_json(tmp_path):
     specs = [
         ImageSpec(
             sample_id="sample-1",
             image_path=str((tmp_path / "images" / "sample-1.png").resolve()),
+            spacing_at_level_0=0.252,
         )
     ]
     payload = json.loads(json.dumps(build_image_specs_request(specs)))
@@ -287,6 +321,17 @@ def test_every_recorded_compatibility_field_participates_in_resume(tmp_path):
         "image_path",
         "encoder_name",
         "output_variant",
+        "reader_regime",
+        "spacing_source",
+        "declared_spacing_um",
+        "source_spacing_um",
+        "effective_spacing_um",
+        "requested_backend",
+        "backend",
+        "tolerance",
+        "read_level",
+        "read_tile_size_px",
+        "requested_tile_size_px",
         "target_size",
         "patch_size",
         "encoded_size",
@@ -312,6 +357,8 @@ def test_every_recorded_compatibility_field_participates_in_resume(tmp_path):
         value = recorded[field]
         if isinstance(value, bool):
             recorded[field] = not value
+        elif value is None:
+            recorded.pop(field)
         elif isinstance(value, str):
             recorded[field] = f"{value}-different"
         elif isinstance(value, list):

--- a/tests/test_dense_image_shard.py
+++ b/tests/test_dense_image_shard.py
@@ -77,7 +77,7 @@ def _spec(tmp_path, sample_id: str, *, width: int = 64, height: int = 64) -> Ima
 
 
 def _dense(**kwargs) -> DenseImageOptions:
-    return DenseImageOptions(**{"target_size": 64, **kwargs})
+    return DenseImageOptions(**{"target_size": 64, "spacing_um": 0.5, **kwargs})
 
 
 def _recipe(
@@ -97,6 +97,17 @@ def _recipe(
     return DenseImageRecipe(
         encoder_name="fake-encoder",
         output_variant="default",
+        reader_regime="raster",
+        spacing_source="explicit",
+        declared_spacing_um=0.5,
+        source_spacing_um=0.5,
+        effective_spacing_um=0.5,
+        requested_backend="auto",
+        backend="pil",
+        tolerance=None,
+        read_level=None,
+        read_tile_size_px=None,
+        requested_tile_size_px=None,
         target_size=geometry.target_size,
         patch_size=geometry.patch_size,
         encoded_size=geometry.encoded_size,
@@ -279,6 +290,17 @@ def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
         "encoder_name": "fake-encoder",
         "encoder_level": "tile",
         "encoder_input_regime": "declared",
+        "reader_regime": "raster",
+        "spacing_source": "explicit",
+        "declared_spacing_um": 0.5,
+        "source_spacing_um": 0.5,
+        "effective_spacing_um": 0.5,
+        "requested_backend": "auto",
+        "backend": "pil",
+        "tolerance": None,
+        "read_level": None,
+        "read_tile_size_px": None,
+        "requested_tile_size_px": None,
         "pad_mode": "reflect",
         "image_pad_value": None,
         "window_size": 32,
@@ -291,6 +313,17 @@ def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
             "image_path": str(Path(specs[0].image_path).resolve()),
             "encoder_name": "fake-encoder",
             "output_variant": "default",
+            "reader_regime": "raster",
+            "spacing_source": "explicit",
+            "declared_spacing_um": 0.5,
+            "source_spacing_um": 0.5,
+            "effective_spacing_um": 0.5,
+            "requested_backend": "auto",
+            "backend": "pil",
+            "tolerance": None,
+            "read_level": None,
+            "read_tile_size_px": None,
+            "requested_tile_size_px": None,
             "target_size": [60, 60],
             "patch_size": [16, 16],
             "encoded_size": [64, 64],
@@ -307,6 +340,47 @@ def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
             "dtype": "float32",
         },
     }
+
+
+def test_explicit_spacing_changes_provenance_but_not_raster_pixels(tmp_path):
+    """Raster spacing is an assertion; both runs decode the same PIL RGB pixels."""
+    enc = _encoder()
+    spec = _spec(tmp_path, "same-pixels")
+    first_recipe = _recipe()
+    second_recipe = replace(
+        first_recipe,
+        declared_spacing_um=0.75,
+        source_spacing_um=0.75,
+        effective_spacing_um=0.75,
+    )
+
+    first = run_dense_image_shard(
+        [spec],
+        loaded=_loaded(enc),
+        out_dir=tmp_path / "first",
+        dense=_dense(spacing_um=0.5),
+        recipe=first_recipe,
+        batch_size=1,
+        num_workers=0,
+    )[0]
+    second = run_dense_image_shard(
+        [spec],
+        loaded=_loaded(enc),
+        out_dir=tmp_path / "second",
+        dense=_dense(spacing_um=0.75),
+        recipe=second_recipe,
+        batch_size=1,
+        num_workers=0,
+    )[0]
+
+    torch.testing.assert_close(
+        torch.load(first.path, weights_only=True),
+        torch.load(second.path, weights_only=True),
+        rtol=0,
+        atol=0,
+    )
+    assert json.loads(first.metadata_path.read_text())["effective_spacing_um"] == 0.5
+    assert json.loads(second.metadata_path.read_text())["effective_spacing_um"] == 0.75
 
 
 def test_run_dense_image_shard_supports_non_square_images(tmp_path):
@@ -342,12 +416,47 @@ def test_run_dense_image_shard_rejects_images_that_are_not_the_declared_size(tmp
     enc = _encoder()
     specs = [_spec(tmp_path, "small", width=32, height=32)]
 
-    with pytest.raises(ValueError, match=r"'small': \(32, 32\)"):
+    with pytest.raises(ValueError) as excinfo:
         run_dense_image_shard(
             specs, loaded=_loaded(enc), out_dir=tmp_path / "out", dense=_dense(),
             recipe=_recipe(),
             batch_size=1, num_workers=0,
         )
+
+    assert str(excinfo.value) == (
+        "Image 'small' has observed size (32, 32), but target_size declares "
+        "(64, 64), at resolved spacing 0.5 µm/px. Dense raster extraction never "
+        "resizes; supply pixels at the declared geometry."
+    )
+
+
+def test_strict_geometry_error_reports_unknown_spacing(tmp_path):
+    enc = _encoder()
+    specs = [_spec(tmp_path, "small", width=32, height=32)]
+    unknown_recipe = replace(
+        _recipe(),
+        spacing_source="unknown",
+        declared_spacing_um=None,
+        source_spacing_um=None,
+        effective_spacing_um=None,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        run_dense_image_shard(
+            specs,
+            loaded=_loaded(enc),
+            out_dir=tmp_path / "out",
+            dense=_dense(spacing_um=None),
+            recipe=unknown_recipe,
+            batch_size=1,
+            num_workers=0,
+        )
+
+    assert str(excinfo.value) == (
+        "Image 'small' has observed size (32, 32), but target_size declares "
+        "(64, 64), at unknown spacing. Dense raster extraction never resizes; "
+        "supply pixels at the declared geometry."
+    )
 
 
 def test_off_size_images_are_named_even_when_a_batch_is_mixed(tmp_path):
@@ -371,7 +480,9 @@ def test_off_size_images_are_named_even_when_a_batch_is_mixed(tmp_path):
         )
 
     message = str(excinfo.value)
-    assert "'short': (48, 64)" in message and "'narrow': (64, 32)" in message
+    assert "Image 'short' has observed size (48, 64)" in message
+    assert "Image 'narrow' has observed size (64, 32)" in message
+    assert message.count("resolved spacing 0.5 µm/px") == 2
     assert "right" not in message  # the conforming image is not accused
 
 

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -48,9 +48,9 @@ def _loaded(encoder: TimmTileEncoder) -> LoadedModel:
 class _FakeModel:
     """Minimal ``Model`` stand-in: refuses a backend until the dense contract is declared."""
 
-    def __init__(self, encoder) -> None:
+    def __init__(self, encoder, *, name="uni") -> None:
         self._loaded = _loaded(encoder)
-        self.name = "uni"
+        self.name = name
         self._output_variant = None
         self._requested_device = "cpu"
         self.allow_non_recommended_settings = False
@@ -84,7 +84,20 @@ def _images(tmp_path, names, *, width=64, height=64) -> list[ImageSpec]:
 
 
 def _dense(**kwargs) -> DenseImageOptions:
-    return DenseImageOptions(**{"target_size": 64, **kwargs})
+    return DenseImageOptions(**{"target_size": 64, "spacing_um": 0.5, **kwargs})
+
+
+def _skip_dense_image_encoding(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dense_image_stage,
+        "partition_dense_images_by_resume",
+        lambda normalized, out_dir, recipe: ([], len(normalized)),
+    )
+    monkeypatch.setattr(
+        dense_image_stage,
+        "dense_image_artifact_from_disk",
+        lambda out_dir, spec: spec,
+    )
 
 
 def test_embed_images_dense_num_gpus_one_runs_in_process(tmp_path, monkeypatch):
@@ -241,6 +254,159 @@ def test_embed_images_dense_requires_at_least_one_image(tmp_path):
         dense_image_stage.embed_images_dense(model, [], dense=_dense(), execution=execution)
 
 
+def test_embed_images_dense_rejects_raster_level0_spacing_override(tmp_path, monkeypatch):
+    model = _FakeModel(_encoder())
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("override validation must precede backend loading"),
+    )
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    spec = ImageSpec(
+        sample_id="raster",
+        image_path=tmp_path / "image.png",
+        spacing_at_level_0=0.25,
+    )
+
+    with pytest.raises(ValueError, match=r"spacing_at_level_0.*raster"):
+        dense_image_stage.embed_images_dense(
+            model, [spec], dense=_dense(), execution=execution
+        )
+
+
+def test_dense_image_raster_suffixes_are_exact_and_case_insensitive(tmp_path, monkeypatch):
+    """This issue's reader regime is exactly PNG/JPEG; spacing-readable inputs are #259."""
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    accepted = [
+        ImageSpec(sample_id=f"accepted-{index}", image_path=tmp_path / f"image{suffix}")
+        for index, suffix in enumerate((".png", ".PNG", ".jpg", ".JPG", ".jpeg", ".JPEG"))
+    ]
+    monkeypatch.setattr(
+        dense_image_stage,
+        "partition_dense_images_by_resume",
+        lambda specs, out_dir, recipe: ([], len(specs)),
+    )
+    monkeypatch.setattr(
+        dense_image_stage,
+        "dense_image_artifact_from_disk",
+        lambda out_dir, spec: spec,
+    )
+
+    assert [
+        spec.sample_id
+        for spec in dense_image_stage.embed_images_dense(
+            model, accepted, dense=_dense(), execution=execution
+        )
+    ] == [spec.sample_id for spec in accepted]
+
+    for suffix in (".tif", ".tiff", ".svs", ".png.tmp", ""):
+        with pytest.raises(ValueError, match=r"raster.*\.png.*\.jpg.*\.jpeg"):
+            dense_image_stage.embed_images_dense(
+                model,
+                [ImageSpec(sample_id="unsupported", image_path=tmp_path / f"image{suffix}")],
+                dense=_dense(),
+                execution=execution,
+            )
+
+
+def test_non_recommended_numeric_raster_spacing_is_rejected(tmp_path, monkeypatch):
+    specs = _images(tmp_path, ["a", "b"])
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    model = _FakeModel(_encoder())
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("spacing validation must precede backend loading"),
+    )
+
+    with pytest.raises(ValueError, match=r"requested_spacing_um=0\.75.*recommended"):
+        dense_image_stage.embed_images_dense(
+            model, specs, dense=_dense(spacing_um=0.75), execution=execution
+        )
+
+
+@pytest.mark.parametrize("spacing_um", [0.0, -0.5, float("nan"), float("inf")])
+def test_numeric_raster_spacing_must_be_positive_and_finite(
+    tmp_path, monkeypatch, spacing_um
+):
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    model = _FakeModel(_encoder(), name="dinov2-vitb14")
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("spacing validation must precede backend loading"),
+    )
+
+    with pytest.raises(ValueError, match=r"spacing_um must be a positive, finite"):
+        dense_image_stage.embed_images_dense(
+            model,
+            _images(tmp_path, ["sample"]),
+            dense=_dense(spacing_um=spacing_um),
+            execution=execution,
+        )
+
+
+def test_allowed_non_recommended_numeric_raster_spacing_warns_once(
+    tmp_path, monkeypatch, caplog
+):
+    specs = _images(tmp_path, ["a", "b"])
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    model = _FakeModel(_encoder())
+    model.allow_non_recommended_settings = True
+    _skip_dense_image_encoding(monkeypatch)
+
+    with caplog.at_level("WARNING", logger="slide2vec"):
+        dense_image_stage.embed_images_dense(
+            model, specs, dense=_dense(spacing_um=0.75), execution=execution
+        )
+
+    assert caplog.text.count("allow_non_recommended_settings=True") == 1
+
+
+def test_unknown_raster_spacing_is_rejected_for_constrained_encoder(tmp_path):
+    specs = _images(tmp_path, ["a", "b"])
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    constrained = _FakeModel(_encoder(), name="uni")
+
+    with pytest.raises(ValueError, match=r"requested_spacing_um=unknown.*recommended"):
+        dense_image_stage.embed_images_dense(
+            constrained, specs, dense=_dense(spacing_um=None), execution=execution
+        )
+
+
+def test_allowed_unknown_raster_spacing_warns_once(tmp_path, monkeypatch, caplog):
+    specs = _images(tmp_path, ["a", "b"])
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    constrained = _FakeModel(_encoder(), name="uni")
+    constrained.allow_non_recommended_settings = True
+    _skip_dense_image_encoding(monkeypatch)
+
+    with caplog.at_level("WARNING", logger="slide2vec"):
+        dense_image_stage.embed_images_dense(
+            constrained, specs, dense=_dense(spacing_um=None), execution=execution
+        )
+
+    assert caplog.text.count("requested_spacing_um=unknown") == 1
+
+
+def test_unknown_raster_spacing_is_accepted_for_agnostic_encoder(
+    tmp_path, monkeypatch, caplog
+):
+    specs = _images(tmp_path, ["a", "b"])
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    agnostic = _FakeModel(_encoder(), name="dinov2-vitb14")
+    _skip_dense_image_encoding(monkeypatch)
+
+    with caplog.at_level("WARNING", logger="slide2vec"):
+        artifacts = dense_image_stage.embed_images_dense(
+            agnostic, specs, dense=_dense(spacing_um=None), execution=execution
+        )
+
+    assert [artifact.sample_id for artifact in artifacts] == ["a", "b"]
+    assert caplog.text == ""
+
+
 @pytest.mark.parametrize(
     ("dense", "message"),
     [
@@ -273,7 +439,7 @@ def test_invalid_dense_image_recipe_fails_before_backend_load(
 
 
 def test_dense_image_options_round_trip_through_the_request():
-    """Every dense knob crosses to the ranks, including a non-square target size."""
+    """Every dense knob crosses to the ranks, including raster spacing/reader settings."""
     from slide2vec.runtime.serialization import (
         deserialize_dense_image_options,
         serialize_dense_image_options,
@@ -281,6 +447,9 @@ def test_dense_image_options_round_trip_through_the_request():
 
     dense = DenseImageOptions(
         target_size=(64, 96),
+        spacing_um=0.504,
+        tolerance=0.025,
+        backend="auto",
         pad_mode="constant",
         image_pad_value=0.5,
         window_size=32,
@@ -291,6 +460,14 @@ def test_dense_image_options_round_trip_through_the_request():
     )
     payload = json.loads(json.dumps(serialize_dense_image_options(dense)))
     assert deserialize_dense_image_options(payload) == dense
+
+
+def test_dense_image_options_default_to_unknown_spacing_and_auto_reader():
+    dense = DenseImageOptions(target_size=224)
+
+    assert dense.spacing_um is None
+    assert dense.tolerance == 0.05
+    assert dense.backend == "auto"
 
 
 def test_model_embed_images_dense_delegates_and_requires_output_dir(monkeypatch, tmp_path):

--- a/tests/test_image_stage.py
+++ b/tests/test_image_stage.py
@@ -214,6 +214,24 @@ def test_embed_images_requires_at_least_one_image(tmp_path):
         image_stage.embed_images(model, [], execution=execution)
 
 
+def test_embed_images_rejects_raster_level0_spacing_override(tmp_path, monkeypatch):
+    model = _FakeModel(_encoder())
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("override validation must precede backend loading"),
+    )
+    execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    spec = ImageSpec(
+        sample_id="raster",
+        image_path=tmp_path / "image.png",
+        spacing_at_level_0=0.25,
+    )
+
+    with pytest.raises(ValueError, match=r"spacing_at_level_0.*raster"):
+        image_stage.embed_images(model, [spec], execution=execution)
+
+
 def test_image_specs_round_trip_through_request(tmp_path):
     """The request rebuilds the exact spec list the parent sharded (the worker's inverse)."""
     specs = [


### PR DESCRIPTION
## Summary

- add a run-level asserted/unknown raster spacing contract to `DenseImageOptions`, with exact case-insensitive PNG/JPEG classification and distributed serialization
- keep raster decoding on the unchanged Pillow RGB path, reject per-image level-0 overrides, invalid physical spacings, and strict target-size mismatches before encoding
- persist truthful raster reader/spacing provenance in sidecars and compatible-resume recipes, with public API and artifact documentation
- add example-driven coverage for policy warnings/errors, pixel parity, geometry, metadata, serialization, and resume compatibility

## Impact

Callers can now state the physical scale of pre-cropped raster pixels or explicitly record it as unknown. Spacing remains provenance and encoder-policy validation only: it never selects a level, resizes, or otherwise changes raster pixels.

## Validation

- TDD slices: 13 original intended failures across eight acceptance-criteria areas, followed by focused green runs
- review follow-up TDD: invalid `0`, negative, `NaN`, and infinite spacing examples failed before the fix and pass after it
- focused final suite: `83 passed, 1 deselected` (the deselection is an unchanged `main` exact-bit multi-rank baseline)
- baseline-aware complete suite: `730 passed, 14 skipped, 7 deselected`; the deselections cover five failures reproduced unchanged on `main` plus two passing parameter cases sharing one pre-existing test function
- complete-suite baseline before the final review fixes: `5 failed, 725 passed, 14 skipped`; the same five tests fail on `main`
- `python -m compileall -q slide2vec`
- `git diff --check`
- final `/code-review main`: Standards 0 findings; Spec 0 findings

Closes #258