### PR TITLE
Read spacing-readable dense images through resolved hs2p plans

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -305,8 +305,9 @@ Dense Grids from Images
 When the supervision arrives as image/mask pairs rather than as slides —
 segmentation and detection datasets, exported ROI sets —
 :meth:`Model.embed_images_dense` is the image-sourced counterpart of
-``embed_regions_dense``: the image *is* the region, so there is no slide, no
-coordinate and no spacing→level plan.
+``embed_regions_dense``: the image *is* the region, so there is no ROI
+coordinate plan. Raster inputs need no spacing→level plan; spacing-readable
+inputs use the parent-resolved hs2p plan described below.
 
 .. code-block:: python
 
@@ -340,31 +341,41 @@ geometry, dense settings, inference precision, and stored dtype exactly match
 the current call. Missing, legacy, or incompatible pairs are recomputed, so an
 interrupted run is restarted by re-issuing the call.
 
-**Raster reader regime and physical scale.** Raster dense runs accept exactly
-``.png``, ``.jpg``, and ``.jpeg`` suffixes, case-insensitively. Every raster uses
-the existing Pillow ``convert("RGB")`` decoder; ``backend="auto"`` resolves to
-that reader. A positive, finite numeric ``spacing_um`` is an **asserted spacing**:
-it states that every supplied pixel array is already at that µm/px scale and is
-checked against the encoder's supported spacings by the normal
-recommended-settings policy. It never resizes or otherwise changes pixels.
-``spacing_um=None`` is **unknown spacing**, not an inferred default. A
-spacing-constrained encoder rejects unknown spacing unless
-``allow_non_recommended_settings=True`` (one warning for the run); a
-spacing-agnostic encoder accepts it normally.
+**Reader regimes and physical scale.** One dense-image run uses exactly one
+reader regime; mixing regimes is rejected with samples grouped by regime before
+model loading or pixel decoding. Raster is the exact case-insensitive suffix set
+``.png``, ``.jpg``, and ``.jpeg`` and uses Pillow ``convert("RGB")``. Multiple
+suffixes in that set may share a run. A positive, finite numeric ``spacing_um``
+is an **asserted spacing** for raster pixels: it is checked by the normal
+recommended-settings policy but never changes the pixels. ``spacing_um=None``
+is unknown spacing for raster inputs.
 
-``ImageSpec.spacing_at_level_0`` is a level-0 source-metadata override for
-spacing-readable inputs. Raster dense extraction and :meth:`Model.embed_images`
-reject a non-null override rather than silently ignoring it, because a
-pre-cropped PNG/JPEG has no pyramid level-0 read plan.
+Spacing-readable inputs are the WSI formats declared by the installed hs2p
+readers. Multiple spacing-readable suffixes may share a run. Here numeric
+``spacing_um`` is the requested read scale and ``None`` resolves the encoder's
+single registry default. Encoders with ambiguous or missing defaults, including
+unregistered/custom encoders, require an explicit value. The parent asks hs2p
+to resolve each source's level-0 spacing, concrete backend, native read level
+and spacing, and tolerance result before resume filtering. Ranks consume that
+immutable plan: hs2p reads the complete selected level and area-downsamples only
+when needed. A native level within tolerance is accepted without resize, so its
+native spacing is the effective spacing; an area-downsampled image has the
+requested spacing as its effective spacing. Reads never upsample and an
+explicit backend never silently falls back.
 
-**target_size is a declaration, not a resize.** Dense extraction encodes through
-the encoder's normalization-only transform, so it never rescales: every image
-must already be exactly ``target_size`` (a non-square ``(height, width)`` pair is
-accepted), and one that is not raises with the sample, observed and declared
-dimensions, and the resolved or unknown spacing. Declaring the geometry
-up front is what lets the *effective* encoder input — the padded image, or one
-patch-aligned window of it — be validated, and the encoder's variable-input
-constructor settings resolved, before a single image is decoded (see
+``ImageSpec.spacing_at_level_0`` overrides hs2p's source level-0 metadata for
+spacing-readable inputs. Without it, hs2p metadata is authoritative and missing
+spacing is an error. Raster dense extraction and :meth:`Model.embed_images`
+reject a non-null override rather than silently ignoring it.
+
+**target_size is a declaration, not a resize.** It is checked after the selected
+reader finishes, including any hs2p spacing downsample. Every final image must
+be exactly ``target_size`` (a non-square ``(height, width)`` pair is accepted);
+a mismatch raises with the sample, observed and declared dimensions, and the
+resolved or unknown spacing. It never triggers fit-to-size resizing. Declaring
+the geometry up front is what lets the *effective* encoder input — the padded
+image, or one patch-aligned window of it — be validated, and the encoder's
+variable-input constructor settings resolved, before a single image is decoded (see
 `Variable encoder input for dense runs`_). A dataset whose images differ in size
 is therefore several runs, one per geometry — which is also the only way their
 grids could be batched downstream.

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -276,11 +276,16 @@ payload.
      "spacing_source": "explicit",
      "declared_spacing_um": 0.5,
      "source_spacing_um": 0.5,
+     "spacing_at_level_0": null,
+     "read_spacing_um": null,
      "effective_spacing_um": 0.5,
      "requested_backend": "auto",
      "backend": "pil",
      "tolerance": null,
      "read_level": null,
+     "is_within_tolerance": null,
+     "read_size": null,
+     "output_size": null,
      "read_tile_size_px": null,
      "requested_tile_size_px": null,
      "image_path": "/data/ocelot/001.jpg",
@@ -308,11 +313,16 @@ payload.
        "spacing_source": "explicit",
        "declared_spacing_um": 0.5,
        "source_spacing_um": 0.5,
+       "spacing_at_level_0": null,
+       "read_spacing_um": null,
        "effective_spacing_um": 0.5,
        "requested_backend": "auto",
        "backend": "pil",
        "tolerance": null,
        "read_level": null,
+       "is_within_tolerance": null,
+       "read_size": null,
+       "output_size": null,
        "read_tile_size_px": null,
        "requested_tile_size_px": null,
        "target_size": [1024, 1024],
@@ -333,8 +343,8 @@ payload.
    }
 
 The compatibility identity covers the sample ID and normalized source path;
-resolved raster reader regime, requested/resolved backend, spacing source, and
-declared/source/effective spacing;
+resolved reader regime, requested/resolved backend, spacing source, and the
+declared/source/native-read/effective spacing chain;
 encoder name and resolved output variant; target, patch, encoded, padding, and
 grid geometry; padding/window/overlap and attention settings; inference
 precision; and stored dtype. GPU count, batch size, workers, prefetching, output
@@ -347,6 +357,38 @@ unchanged Pillow RGB path. Explicit spacing repeats the caller's assertion in
 unknown spacing records all three as ``null`` with
 ``spacing_source="unknown"``. Pyramid-plan fields stay ``null`` because no
 level was selected and no spacing-driven resize occurred.
+
+For spacing-readable inputs, the compatibility object records the complete
+parent-resolved hs2p plan. For example, a source whose level-0 spacing is
+``0.252`` µm/px may accept level 1 natively at ``0.504`` within tolerance:
+
+.. code-block:: json
+
+   {
+     "reader_regime": "spacing-readable",
+     "spacing_source": "model_default",
+     "declared_spacing_um": 0.5,
+     "source_spacing_um": 0.252,
+     "spacing_at_level_0": null,
+     "read_spacing_um": 0.504,
+     "effective_spacing_um": 0.504,
+     "requested_backend": "auto",
+     "backend": "vips",
+     "tolerance": 0.05,
+     "read_level": 1,
+     "is_within_tolerance": true,
+     "read_size": [1024, 1024],
+     "output_size": [1024, 1024]
+   }
+
+``declared_spacing_um`` is the explicit or model-default run request.
+``source_spacing_um`` is the authoritative level-0 scale after applying the
+optional ``spacing_at_level_0`` caller override. ``read_spacing_um`` is the
+selected level's native scale. ``effective_spacing_um`` is that native scale
+when no resize occurs, or the declared request after hs2p area downsampling.
+``read_size`` and ``output_size`` use ``[height, width]``. Changes in source
+metadata, the resolved result of ``backend="auto"``, or any other plan field
+invalidate compatible-artifact resume.
 
 
 Coordinate Files

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -444,33 +444,36 @@ class DenseOptions:
 
 @dataclass(frozen=True, kw_only=True)
 class DenseImageOptions:
-    """Dense ``(d, gh, gw)`` extraction over pre-cropped raster images.
+    """Dense ``(d, gh, gw)`` extraction over pre-cropped images.
 
-    ``.png``, ``.jpg``, and ``.jpeg`` inputs (case-insensitive) use the existing Pillow RGB
-    reader. ``spacing_um`` is a run-level assertion that the supplied pixels already have
-    that physical scale; it never selects a pyramid level or resizes pixels. ``None`` means
-    unknown spacing, which spacing-constrained encoders reject unless
-    ``allow_non_recommended_settings=True``. Spacing-agnostic encoders accept it normally.
+    One run has one reader regime. ``.png``, ``.jpg``, and ``.jpeg`` inputs
+    (case-insensitive) use Pillow and treat numeric ``spacing_um`` as an assertion about
+    unchanged pixels. hs2p-supported WSI formats form the spacing-readable regime: hs2p
+    resolves source spacing, backend, pyramid level, tolerance, complete-extent read, and
+    area downsampling at the one requested run-level ``spacing_um``. Omitted spacing resolves
+    the encoder's single registry default for spacing-readable inputs and requires an
+    explicit value when no default is available.
 
-    ``target_size`` is a **declaration**, not a resize: the dense transform is
-    normalization-only, so every image must already be exactly this size and one that is not
-    is an error rather than a silent rescale. Declaring it up front is what lets the
-    effective encoder input be validated (and the encoder's variable-input constructor
-    settings resolved) before a single image is decoded. A run whose images are not all the
-    same size is therefore several runs, one per geometry — which is also the only way their
-    grids could be batched downstream.
+    ``ImageSpec.spacing_at_level_0`` overrides level-0 metadata only for spacing-readable
+    sources. ``target_size`` is always a strict post-read declaration, never a fit-to-size
+    request: each final pixel array must already be exactly this size. Declaring it up front
+    lets the effective encoder input be validated (and variable-input constructor settings
+    resolved) before model loading or pixel decoding. Differing final geometries therefore
+    require separate runs.
     """
 
     #: Supervision geometry in pixels the dense grid registers to: a square side length, or
     #: an explicit ``(height, width)`` for non-square images.
     target_size: int | tuple[int, int]
-    #: Asserted positive, finite physical spacing of the supplied raster pixels in µm/px.
-    #: ``None`` means their physical spacing is unknown.
+    #: Positive, finite run-level spacing in µm/px: asserted for raster pixels and requested
+    #: for spacing-readable reads. ``None`` is unknown for raster and resolves the encoder's
+    #: single registry default for spacing-readable inputs.
     spacing_um: float | None = None
-    #: Relative spacing tolerance (reserved for spacing-readable inputs; raster spacing is
-    #: an assertion and never selects or resamples pixels).
+    #: Relative spacing tolerance used by hs2p for spacing-readable level selection; raster
+    #: reads have no tolerance result.
     tolerance: float = 0.05
-    #: Requested reader backend. Raster images always resolve to the Pillow RGB reader.
+    #: Requested hs2p backend for spacing-readable inputs. ``"auto"`` is resolved in the
+    #: parent; raster images always resolve to Pillow.
     backend: str = "auto"
     #: Padding mode used to pad the image up to the encoder's patch multiple.
     #: One of ``"reflect"`` / ``"replicate"`` / ``"constant"`` / ``"zero"``.
@@ -866,19 +869,26 @@ class Model:
         identity and complete extraction recipe. Returns one
         :class:`~slide2vec.artifacts.DenseImageArtifact` per input image, in input order.
 
-        Raster inputs are exactly ``.png``, ``.jpg``, and ``.jpeg`` (case-insensitive) and
-        always use Pillow's RGB decoder. ``dense.spacing_um`` asserts the scale those pixels
-        already have; ``None`` records unknown spacing. Neither case resizes. A raster
-        :class:`ImageSpec` cannot carry ``spacing_at_level_0`` because there is no level-0
-        pyramid spacing to override.
+        One run uses one reader regime. Raster inputs are exactly ``.png``, ``.jpg``, and
+        ``.jpeg`` (case-insensitive) and always use Pillow's RGB decoder.
+        ``dense.spacing_um`` asserts the scale those unchanged pixels already have; ``None``
+        records unknown spacing. hs2p-supported WSI inputs are spacing-readable:
+        ``dense.spacing_um`` requests one physical read scale, or ``None`` resolves the
+        encoder's single registry default. The parent resolves each source's metadata,
+        concrete backend, native level, tolerance result, and final geometry before resume;
+        hs2p reads that complete level and area-downsamples when required, but never
+        upsamples. ``ImageSpec.spacing_at_level_0`` overrides source metadata only in this
+        spacing-readable regime and is rejected for raster inputs.
 
         Everything after reading is shared with the slide path, including the effective encoder input — the padded image
         for a whole-image run, one patch-aligned window for a sliding one — which is declared
         before any image is decoded, so a geometry the encoder cannot accept raises here
         rather than on a torchrun rank's first forward pass.
 
-        ``dense.target_size`` is a declaration, not a resize request: dense extraction never
-        rescales, so every image must already be that size (a non-square ``(h, w)`` is fine).
+        ``dense.target_size`` is a strict post-read declaration, not a fit-to-size request:
+        every final image must already be that size (a non-square ``(h, w)`` is fine).
+        Spacing-driven area downsampling establishes physical scale; it never repairs a
+        mismatch with the declared geometry.
         """
         from slide2vec.runtime.dense_image_stage import embed_images_dense
 

--- a/slide2vec/distributed/dense_image_worker.py
+++ b/slide2vec/distributed/dense_image_worker.py
@@ -27,6 +27,9 @@ def get_args_parser(add_help: bool = True):
 def main(argv=None) -> int:
     from slide2vec.progress import emit_progress
     from slide2vec.runtime.dense_image_shard import run_dense_image_shard
+    from slide2vec.runtime.dense_image_reading import (
+        dense_image_read_plans_from_request,
+    )
     from slide2vec.runtime.dense_stage import resolve_output_torch_dtype
     from slide2vec.runtime.image_specs import image_specs_from_request
     from slide2vec.runtime.serialization import (
@@ -42,6 +45,7 @@ def main(argv=None) -> int:
     rank = resolve_worker_rank()
 
     specs = image_specs_from_request(request)
+    read_plans = dense_image_read_plans_from_request(request)
     shard = plan_contiguous_shards(specs, rank.world_size)[rank.global_rank]
     if not shard:
         return 0
@@ -67,6 +71,7 @@ def main(argv=None) -> int:
             out_dir=output_dir,
             dense=dense,
             recipe=recipe,
+            read_plans=read_plans,
             batch_size=int(execution.batch_size),
             precision=execution.precision,
             output_dtype=resolve_output_torch_dtype(execution),

--- a/slide2vec/runtime/dense_image_reading.py
+++ b/slide2vec/runtime/dense_image_reading.py
@@ -1,0 +1,260 @@
+"""Parent-resolved read plans for dense extraction over pre-cropped images."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from hs2p.wsi import geometry as hs2p_geometry
+from hs2p.wsi import reader as hs2p_reader
+from hs2p.wsi import wsi as hs2p_wsi
+
+from slide2vec.api import ImageSpec
+
+
+def _optional_float(value: Any) -> float | None:
+    return None if value is None else float(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    return None if value is None else int(value)
+
+
+def _optional_size(value: Any) -> tuple[int, int] | None:
+    if value is None:
+        return None
+    height, width = value
+    return int(height), int(width)
+
+
+@dataclass(frozen=True, kw_only=True)
+class DenseImageReadPlan:
+    """Immutable reader facts resolved by the parent for one dense image."""
+
+    reader_regime: str
+    spacing_source: str
+    declared_spacing_um: float | None
+    source_spacing_um: float | None
+    spacing_at_level_0: float | None
+    read_spacing_um: float | None
+    effective_spacing_um: float | None
+    requested_backend: str
+    backend: str
+    tolerance: float | None
+    read_level: int | None
+    is_within_tolerance: bool | None
+    read_size: tuple[int, int] | None
+    output_size: tuple[int, int] | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "reader_regime": self.reader_regime,
+            "spacing_source": self.spacing_source,
+            "declared_spacing_um": self.declared_spacing_um,
+            "source_spacing_um": self.source_spacing_um,
+            "spacing_at_level_0": self.spacing_at_level_0,
+            "read_spacing_um": self.read_spacing_um,
+            "effective_spacing_um": self.effective_spacing_um,
+            "requested_backend": self.requested_backend,
+            "backend": self.backend,
+            "tolerance": self.tolerance,
+            "read_level": self.read_level,
+            "is_within_tolerance": self.is_within_tolerance,
+            "read_size": (None if self.read_size is None else list(self.read_size)),
+            "output_size": (
+                None if self.output_size is None else list(self.output_size)
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "DenseImageReadPlan":
+        return cls(
+            reader_regime=str(payload["reader_regime"]),
+            spacing_source=str(payload["spacing_source"]),
+            declared_spacing_um=_optional_float(payload["declared_spacing_um"]),
+            source_spacing_um=_optional_float(payload["source_spacing_um"]),
+            spacing_at_level_0=_optional_float(payload["spacing_at_level_0"]),
+            read_spacing_um=_optional_float(payload["read_spacing_um"]),
+            effective_spacing_um=_optional_float(payload["effective_spacing_um"]),
+            requested_backend=str(payload["requested_backend"]),
+            backend=str(payload["backend"]),
+            tolerance=_optional_float(payload["tolerance"]),
+            read_level=_optional_int(payload["read_level"]),
+            is_within_tolerance=(
+                None
+                if payload["is_within_tolerance"] is None
+                else bool(payload["is_within_tolerance"])
+            ),
+            read_size=_optional_size(payload["read_size"]),
+            output_size=_optional_size(payload["output_size"]),
+        )
+
+
+def raster_read_plan(
+    *,
+    spacing_source: str,
+    declared_spacing_um: float | None,
+    requested_backend: str,
+) -> DenseImageReadPlan:
+    """Build the non-pyramid reader plan shared by every raster in one run."""
+    spacing = _optional_float(declared_spacing_um)
+    return DenseImageReadPlan(
+        reader_regime="raster",
+        spacing_source=str(spacing_source),
+        declared_spacing_um=spacing,
+        source_spacing_um=spacing,
+        spacing_at_level_0=None,
+        read_spacing_um=None,
+        effective_spacing_um=spacing,
+        requested_backend=str(requested_backend),
+        backend="pil",
+        tolerance=None,
+        read_level=None,
+        is_within_tolerance=None,
+        read_size=None,
+        output_size=None,
+    )
+
+
+def dense_image_read_plans_from_request(
+    request: dict[str, Any],
+) -> dict[str, DenseImageReadPlan]:
+    """Rebuild the parent-resolved per-image plans from a distributed request."""
+    return {
+        str(image["sample_id"]): DenseImageReadPlan.from_dict(image["read_plan"])
+        for image in request["images"]
+    }
+
+
+def resolve_spacing_read_plan(
+    spec: ImageSpec,
+    *,
+    requested_spacing_um: float,
+    spacing_source: str,
+    requested_backend: str,
+    tolerance: float,
+    resolved_backend: str | None = None,
+) -> DenseImageReadPlan:
+    """Resolve one spacing-readable image's complete plan through public hs2p APIs."""
+    image_path = Path(spec.image_path)
+    spacing_override = _optional_float(spec.spacing_at_level_0)
+    backend = resolved_backend
+    if backend is None:
+        backend = hs2p_reader.resolve_backend(
+            requested_backend,
+            wsi_path=image_path,
+            spacing_override=spacing_override,
+        ).backend
+    reader = hs2p_reader.open_slide(
+        image_path,
+        backend=backend,
+        spacing_override=spacing_override,
+    )
+    try:
+        source_spacing_um = float(reader.spacing)
+        level_selection = hs2p_geometry.select_level(
+            requested_spacing_um=float(requested_spacing_um),
+            level0_spacing_um=source_spacing_um,
+            level_downsamples=list(reader.level_downsamples),
+            tolerance=float(tolerance),
+        )
+        read_width, read_height = reader.level_dimensions[level_selection.level]
+    finally:
+        reader.close()
+
+    if not level_selection.is_within_tolerance and float(
+        level_selection.read_spacing_um
+    ) > float(requested_spacing_um):
+        raise RuntimeError(
+            "hs2p selected a level coarser than the requested spacing outside tolerance; "
+            "refusing to upsample."
+        )
+    if level_selection.is_within_tolerance:
+        output_height, output_width = int(read_height), int(read_width)
+        effective_spacing_um = float(level_selection.read_spacing_um)
+    else:
+        scale = float(level_selection.read_spacing_um) / float(requested_spacing_um)
+        output_height = int(round(int(read_height) * scale))
+        output_width = int(round(int(read_width) * scale))
+        effective_spacing_um = float(requested_spacing_um)
+
+    return DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source=str(spacing_source),
+        declared_spacing_um=float(requested_spacing_um),
+        source_spacing_um=source_spacing_um,
+        spacing_at_level_0=spacing_override,
+        read_spacing_um=float(level_selection.read_spacing_um),
+        effective_spacing_um=effective_spacing_um,
+        requested_backend=str(requested_backend),
+        backend=str(backend),
+        tolerance=float(tolerance),
+        read_level=int(level_selection.level),
+        is_within_tolerance=bool(level_selection.is_within_tolerance),
+        read_size=(int(read_height), int(read_width)),
+        output_size=(output_height, output_width),
+    )
+
+
+def read_dense_image(
+    spec: ImageSpec,
+    *,
+    plan: DenseImageReadPlan,
+    target_size: tuple[int, int],
+) -> Image.Image:
+    """Read one image according to an already-resolved immutable plan."""
+    if plan.reader_regime == "raster":
+        with Image.open(spec.image_path) as image:
+            rgb = image.convert("RGB")
+        pixels = np.asarray(rgb)
+    elif plan.reader_regime == "spacing-readable":
+        if (
+            plan.read_level is None
+            or plan.read_size is None
+            or plan.output_size is None
+        ):
+            raise ValueError(
+                f"Incomplete spacing-readable plan for sample {spec.sample_id!r}"
+            )
+        reader = hs2p_reader.open_slide(
+            str(spec.image_path),
+            backend=plan.backend,
+            spacing_override=plan.spacing_at_level_0,
+        )
+        try:
+            pixels = np.asarray(reader.read_level(plan.read_level))
+        finally:
+            reader.close()
+        observed_native = tuple(int(size) for size in pixels.shape[:2])
+        if observed_native != plan.read_size:
+            raise ValueError(
+                f"Resolved read plan for sample {spec.sample_id!r} expected native size "
+                f"{plan.read_size}, but hs2p observed {observed_native}."
+            )
+        if plan.output_size != plan.read_size:
+            output_height, output_width = plan.output_size
+            pixels = hs2p_wsi.resize_array(
+                pixels,
+                (output_width, output_height),
+                interpolation="area",
+            )
+    else:
+        raise ValueError(f"Unknown dense image reader regime {plan.reader_regime!r}")
+
+    observed = tuple(int(size) for size in pixels.shape[:2])
+    declared = (int(target_size[0]), int(target_size[1]))
+    if plan.reader_regime == "spacing-readable" and observed != declared:
+        spacing = (
+            "unknown spacing"
+            if plan.effective_spacing_um is None
+            else f"resolved spacing {plan.effective_spacing_um:g} µm/px"
+        )
+        raise ValueError(
+            f"Image {spec.sample_id!r} has observed size {observed}, but target_size "
+            f"declares {declared}, at {spacing}. Dense image extraction never performs "
+            "fit-to-size resizing."
+        )
+    return Image.fromarray(np.asarray(pixels)).convert("RGB")

--- a/slide2vec/runtime/dense_image_recipe.py
+++ b/slide2vec/runtime/dense_image_recipe.py
@@ -58,7 +58,7 @@ def malformed_dense_image_compatibility_fields(
 
 @dataclass(frozen=True, kw_only=True)
 class DenseImageRecipe:
-    """Request-wide extraction facts that determine a dense image payload."""
+    """Request-wide extraction facts combined with one parent-resolved image read plan."""
 
     encoder_name: str
     output_variant: str
@@ -119,12 +119,28 @@ class DenseImageRecipe:
             "dtype": self.dtype,
         }
 
-    def for_image(self, spec) -> dict[str, Any]:
+    def for_image(self, spec, read_plan=None) -> dict[str, Any]:
         """Add the normalized source identity to this request-wide recipe."""
+        if read_plan is None:
+            from slide2vec.runtime.dense_image_reading import raster_read_plan
+
+            read_plan = raster_read_plan(
+                spacing_source=self.spacing_source,
+                declared_spacing_um=self.declared_spacing_um,
+                requested_backend=self.requested_backend,
+            )
+        recipe = self.to_dict()
+        encoder_name = recipe.pop("encoder_name")
+        output_variant = recipe.pop("output_variant")
+        for field in read_plan.to_dict():
+            recipe.pop(field, None)
         return {
             "sample_id": str(spec.sample_id),
             "image_path": str(Path(spec.image_path).expanduser().resolve()),
-            **self.to_dict(),
+            "encoder_name": encoder_name,
+            "output_variant": output_variant,
+            **read_plan.to_dict(),
+            **recipe,
         }
 
     @classmethod
@@ -190,7 +206,15 @@ class DenseImageRecipe:
         )
 
 
-def resolve_dense_image_recipe(*, model, contract, dense, execution) -> DenseImageRecipe:
+def resolve_dense_image_recipe(
+    *,
+    model,
+    contract,
+    dense,
+    execution,
+    reader_regime: str = "raster",
+    spacing_source: str | None = None,
+) -> DenseImageRecipe:
     """Resolve the complete request-wide identity before loading the encoder."""
     if execution.precision is None:
         raise ValueError(
@@ -232,8 +256,12 @@ def resolve_dense_image_recipe(*, model, contract, dense, execution) -> DenseIma
     return DenseImageRecipe(
         encoder_name=str(model.name),
         output_variant=str(output["output_variant"]),
-        reader_regime="raster",
-        spacing_source="unknown" if spacing_um is None else "explicit",
+        reader_regime=str(reader_regime),
+        spacing_source=(
+            str(spacing_source)
+            if spacing_source is not None
+            else ("unknown" if spacing_um is None else "explicit")
+        ),
         declared_spacing_um=spacing_um,
         source_spacing_um=spacing_um,
         effective_spacing_um=spacing_um,

--- a/slide2vec/runtime/dense_image_shard.py
+++ b/slide2vec/runtime/dense_image_shard.py
@@ -7,10 +7,11 @@ grid plus one geometry sidecar per image. It is device-agnostic and ``RANK``-fre
 very same code path runs in-process for ``num_gpus=1`` and on every torchrun rank — and is
 exercised on CPU.
 
-It differs from the ROI loop in exactly one respect: there is no slide, no coordinate and no
-spacing→level plan, because the raster image is already at its asserted (or unknown) physical
-spacing and is read through Pillow without resampling. Everything
-after the pixels arrive — geometry, padding, whole-tile vs sliding encode, output dtype — is
+Raster images are decoded unchanged through Pillow. Spacing-readable images consume the
+parent-resolved immutable hs2p plan: a concrete backend reads the stored full level and hs2p
+area-downsamples to the stored output geometry when required, without rank-side selection.
+Everything after the pixels arrive — geometry, padding, whole-tile vs sliding encode, output
+dtype — is
 the shared :class:`~slide2vec.runtime.dense_regions.DenseGridEncoder`, so this module owns no
 padding, batching or blending logic of its own.
 
@@ -34,7 +35,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Sequence
+from typing import TYPE_CHECKING, Callable, Mapping, Sequence
 
 import torch
 
@@ -44,11 +45,16 @@ from slide2vec.artifacts import (
     load_metadata,
     write_dense_image,
 )
-from slide2vec.data.dataset import DeclaredGeometryCollator, ImageFileDataset
+from slide2vec.data.dataset import DeclaredGeometryCollator
 from slide2vec.runtime.batching import dataloader_kwargs, uses_cuda_runtime
 from slide2vec.runtime.dense_image_recipe import (
     DenseImageRecipe,
     malformed_dense_image_compatibility_fields,
+)
+from slide2vec.runtime.dense_image_reading import (
+    DenseImageReadPlan,
+    raster_read_plan,
+    read_dense_image,
 )
 from slide2vec.runtime.dense_regions import DenseGridEncoder
 from slide2vec.runtime.preprocessing import apply_transforms_itemwise
@@ -68,7 +74,10 @@ class DenseImageResumeDecision:
 
 
 def dense_image_resume_decision(
-    out_dir, spec: "ImageSpec", recipe: DenseImageRecipe
+    out_dir,
+    spec: "ImageSpec",
+    recipe: DenseImageRecipe,
+    read_plan: DenseImageReadPlan | None = None,
 ) -> DenseImageResumeDecision:
     """Classify one on-disk pair against the current image extraction identity."""
     payload_path, sidecar_path = dense_image_paths(out_dir, sample_id=spec.sample_id)
@@ -93,7 +102,7 @@ def dense_image_resume_decision(
             f"Malformed dense image sidecar {sidecar_path}: "
             "'compatibility' must be a JSON object"
         )
-    expected = recipe.for_image(spec)
+    expected = recipe.for_image(spec, read_plan)
     malformed = malformed_dense_image_compatibility_fields(recorded, expected)
     if malformed:
         raise ValueError(
@@ -132,17 +141,18 @@ def dense_image_metadata(
     *,
     loaded: "LoadedModel",
     recipe: DenseImageRecipe,
+    read_plan: DenseImageReadPlan | None = None,
     grid: "np.ndarray",
 ) -> dict:
     """The geometry sidecar: what was encoded, and with which dense recipe.
 
-    The dense ROI sidecar's fields plus truthful raster provenance: Pillow is the resolved
-    reader, spacing is explicit or unknown, and non-applicable pyramid-plan fields are null.
+    The dense ROI sidecar's fields plus truthful reader provenance. Raster records Pillow
+    with non-applicable pyramid fields null; spacing-readable records the complete hs2p plan.
     ``encoder_input_regime`` is ``"declared"``: unlike the pooled given-image path this run
     *did* state its geometry — ``target_size`` — and it was validated before any image was
     read, so the sidecar records a request that was honored rather than a size observed.
     """
-    compatibility = recipe.for_image(spec)
+    compatibility = recipe.for_image(spec, read_plan)
     metadata = {
         "artifact_type": "dense_image_embeddings",
         "sample_id": compatibility["sample_id"],
@@ -162,11 +172,16 @@ def dense_image_metadata(
         "spacing_source": compatibility["spacing_source"],
         "declared_spacing_um": compatibility["declared_spacing_um"],
         "source_spacing_um": compatibility["source_spacing_um"],
+        "spacing_at_level_0": compatibility["spacing_at_level_0"],
+        "read_spacing_um": compatibility["read_spacing_um"],
         "effective_spacing_um": compatibility["effective_spacing_um"],
         "requested_backend": compatibility["requested_backend"],
         "backend": compatibility["backend"],
         "tolerance": compatibility["tolerance"],
         "read_level": compatibility["read_level"],
+        "is_within_tolerance": compatibility["is_within_tolerance"],
+        "read_size": compatibility["read_size"],
+        "output_size": compatibility["output_size"],
         "read_tile_size_px": compatibility["read_tile_size_px"],
         "requested_tile_size_px": compatibility["requested_tile_size_px"],
         "pad_mode": compatibility["pad_mode"],
@@ -181,6 +196,28 @@ def dense_image_metadata(
     return metadata
 
 
+class _ResolvedDenseImageDataset(torch.utils.data.Dataset):
+    """Read each item through its parent-resolved plan, then normalize it."""
+
+    def __init__(self, specs, read_plans, *, target_size, preprocess) -> None:
+        self.specs = list(specs)
+        self.read_plans = dict(read_plans)
+        self.target_size = (int(target_size[0]), int(target_size[1]))
+        self.preprocess = preprocess
+
+    def __len__(self) -> int:
+        return len(self.specs)
+
+    def __getitem__(self, index: int):
+        spec = self.specs[index]
+        image = read_dense_image(
+            spec,
+            plan=self.read_plans[spec.sample_id],
+            target_size=self.target_size,
+        )
+        return int(index), self.preprocess(image)
+
+
 def run_dense_image_shard(
     images: Sequence["ImageSpec"],
     *,
@@ -188,6 +225,7 @@ def run_dense_image_shard(
     out_dir,
     dense: "DenseImageOptions",
     recipe: DenseImageRecipe,
+    read_plans: Mapping[str, DenseImageReadPlan] | None = None,
     batch_size: int,
     precision: str = "fp32",
     output_dtype: "torch.dtype | None" = None,
@@ -206,10 +244,21 @@ def run_dense_image_shard(
     batch's image count for per-batch progress.
     """
     images = list(images)
+    if read_plans is None:
+        default_plan = raster_read_plan(
+            spacing_source=recipe.spacing_source,
+            declared_spacing_um=recipe.declared_spacing_um,
+            requested_backend=recipe.requested_backend,
+        )
+        read_plans = {spec.sample_id: default_plan for spec in images}
+    else:
+        read_plans = dict(read_plans)
     pending = [
         spec
         for spec in images
-        if dense_image_resume_decision(out_dir, spec, recipe).needs_encode
+        if dense_image_resume_decision(
+            out_dir, spec, recipe, read_plans[spec.sample_id]
+        ).needs_encode
     ]
     for spec in pending:
         # The sidecar is the only done-marker. Remove any stale marker before the first
@@ -233,11 +282,14 @@ def run_dense_image_shard(
             precision=precision,
             output_dtype=output_dtype,
         )
-        dataset = ImageFileDataset(
-            [spec.image_path for spec in pending],
-            # partial, not a closure: when explicit spawned workers are used, only this
-            # transform recipe crosses — never the encoder — so a worker carries no weights.
-            partial(apply_transforms_itemwise, transforms=encoder.dense_transform),
+        dataset = _ResolvedDenseImageDataset(
+            pending,
+            read_plans,
+            target_size=encoder.geometry.target_size,
+            preprocess=partial(
+                apply_transforms_itemwise,
+                transforms=encoder.dense_transform,
+            ),
         )
         dataloader = torch.utils.data.DataLoader(
             dataset,
@@ -277,6 +329,7 @@ def run_dense_image_shard(
                             spec,
                             loaded=loaded,
                             recipe=recipe,
+                            read_plan=read_plans[spec.sample_id],
                             grid=grid,
                         ),
                     )

--- a/slide2vec/runtime/dense_image_stage.py
+++ b/slide2vec/runtime/dense_image_stage.py
@@ -4,10 +4,10 @@ The glue that turns a caller's :class:`~slide2vec.api.ImageSpec` list into persi
 grids. Deliberately the same five steps as the dense ROI stage, over the same machinery,
 because only the source of the pixels differs:
 
-1. **declare** the dense encoder-input contract and canonical extraction recipe — the caller states a supervision
-   ``target_size``, and the geometry the backbone will actually see (the padded image, or one
-   patch-aligned window of it) is validated here; all compatibility invariants are fixed
-   before anything is decoded or launched;
+1. **declare** the dense encoder-input contract and canonical extraction recipe — the caller
+   states a supervision ``target_size``, and the geometry the backbone will actually see
+   (the padded image, or one patch-aligned window of it) is validated here; all compatibility
+   invariants are fixed before anything is decoded or launched;
 2. **normalize** the images into resolved, uniquely-named specs;
 3. **resume-filter** them — drop only payload+sidecar pairs whose recorded image identity
    and recipe exactly match, before sharding, so no rank draws an all-done shard and idles;
@@ -20,8 +20,9 @@ because only the source of the pixels differs:
 5. **collect** one :class:`~slide2vec.artifacts.DenseImageArtifact` per input image by reading
    the sidecars back off disk (the ranks already persisted them; nobody gathers grids).
 
-Raster classification and its run-level spacing assertion are resolved before this sequence:
-there is no spacing→level read plan because a PNG/JPEG is already the pixel array to encode.
+The parent fixes the one reader regime and resolves every per-image read plan before resume.
+Raster plans name unchanged Pillow pixels; spacing-readable plans carry hs2p's concrete
+backend, source/native/effective spacing, selected level, tolerance result, and output geometry.
 """
 
 from __future__ import annotations
@@ -29,12 +30,14 @@ from __future__ import annotations
 import json
 import logging
 import math
+from dataclasses import replace
 from pathlib import Path
 from subprocess import Popen
 from typing import Sequence
 
 from slide2vec.api import DenseImageOptions, ImageSpec
 from slide2vec.artifacts import DenseImageArtifact
+from slide2vec.encoders.registry import resolve_preprocessing_defaults
 from slide2vec.encoders.validation import validate_encoder_config
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.dense_image_shard import (
@@ -45,6 +48,11 @@ from slide2vec.runtime.dense_image_shard import (
 from slide2vec.runtime.dense_image_recipe import (
     DenseImageRecipe,
     resolve_dense_image_recipe,
+)
+from slide2vec.runtime.dense_image_reading import (
+    DenseImageReadPlan,
+    raster_read_plan,
+    resolve_spacing_read_plan,
 )
 from slide2vec.runtime.dense_stage import resolve_output_torch_dtype
 from slide2vec.runtime.distributed import (
@@ -57,7 +65,7 @@ from slide2vec.runtime.image_specs import (
     build_image_specs_request,
     normalize_image_specs,
     reject_image_level0_spacing_overrides,
-    validate_raster_image_specs,
+    validate_dense_image_reader_regime,
 )
 from slide2vec.runtime.serialization import (
     serialize_dense_image_options,
@@ -70,12 +78,20 @@ logger = logging.getLogger(__name__)
 
 
 def partition_dense_images_by_resume(
-    specs: Sequence[ImageSpec], out_dir, recipe: DenseImageRecipe
+    specs: Sequence[ImageSpec],
+    out_dir,
+    recipe: DenseImageRecipe,
+    read_plans: dict[str, DenseImageReadPlan] | None = None,
 ) -> tuple[list[ImageSpec], int]:
     """Split images by exact payload+sidecar compatibility with the current request."""
     remaining: list[ImageSpec] = []
     for spec in specs:
-        decision = dense_image_resume_decision(out_dir, spec, recipe)
+        decision = dense_image_resume_decision(
+            out_dir,
+            spec,
+            recipe,
+            None if read_plans is None else read_plans[spec.sample_id],
+        )
         if decision.needs_encode:
             remaining.append(spec)
             logger.info(
@@ -93,17 +109,37 @@ def embed_images_dense(
     dense: DenseImageOptions,
     execution,
 ) -> list[DenseImageArtifact]:
-    """Extract + persist a dense grid per caller-supplied image across all visible GPUs."""
+    """Resolve, extract, and persist one dense grid per image across visible GPUs."""
     specs = normalize_image_specs(
         images,
         method_name="embed_images_dense()",
         artifact_location="dense_image_embeddings/<sample_id>",
     )
-    validate_raster_image_specs(specs)
-    reject_image_level0_spacing_overrides(
-        specs, method_name="embed_images_dense()"
-    )
-    spacing_um = None if dense.spacing_um is None else float(dense.spacing_um)
+    reader_regime, probed_auto_backends = validate_dense_image_reader_regime(specs)
+    if reader_regime == "raster":
+        reject_image_level0_spacing_overrides(
+            specs, method_name="embed_images_dense()"
+        )
+    spacing_source = "explicit"
+    if dense.spacing_um is None:
+        if reader_regime == "spacing-readable":
+            try:
+                spacing_um = float(
+                    resolve_preprocessing_defaults(model.name)["spacing_um"]
+                )
+            except (KeyError, ValueError) as exc:
+                raise ValueError(
+                    "DenseImageOptions.spacing_um must be explicit for spacing-readable "
+                    f"inputs when encoder {model.name!r} has no single resolvable model "
+                    f"default: {exc}"
+                ) from exc
+            spacing_source = "model_default"
+            dense = replace(dense, spacing_um=spacing_um)
+        else:
+            spacing_um = None
+            spacing_source = "unknown"
+    else:
+        spacing_um = float(dense.spacing_um)
     if spacing_um is not None and (not math.isfinite(spacing_um) or spacing_um <= 0):
         raise ValueError(
             "DenseImageOptions.spacing_um must be a positive, finite value or None."
@@ -123,11 +159,38 @@ def embed_images_dense(
         contract=contract,
         dense=dense,
         execution=execution,
+        reader_regime=reader_regime,
+        spacing_source=spacing_source,
     )
+    if reader_regime == "raster":
+        shared_read_plan = raster_read_plan(
+            spacing_source=spacing_source,
+            declared_spacing_um=spacing_um,
+            requested_backend=dense.backend,
+        )
+        read_plans = {spec.sample_id: shared_read_plan for spec in specs}
+    else:
+        read_plans = {
+            spec.sample_id: resolve_spacing_read_plan(
+                spec,
+                requested_spacing_um=spacing_um,
+                spacing_source=spacing_source,
+                requested_backend=dense.backend,
+                tolerance=dense.tolerance,
+                resolved_backend=(
+                    probed_auto_backends.get(spec.sample_id)
+                    if dense.backend.strip().lower() == "auto"
+                    else None
+                ),
+            )
+            for spec in specs
+        }
     out_dir = Path(execution.output_dir).expanduser().resolve()
     execution = execution.with_output_dir(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
-    remaining, skipped = partition_dense_images_by_resume(specs, out_dir, recipe)
+    remaining, skipped = partition_dense_images_by_resume(
+        specs, out_dir, recipe, read_plans=read_plans
+    )
     if skipped:
         logger.info(
             "resume: %s/%s images already on disk, encoding %s",
@@ -147,6 +210,7 @@ def embed_images_dense(
                 remaining,
                 dense=dense,
                 recipe=recipe,
+                read_plans=read_plans,
                 execution=execution,
                 out_dir=out_dir,
             )
@@ -156,6 +220,7 @@ def embed_images_dense(
                 remaining,
                 dense=dense,
                 recipe=recipe,
+                read_plans=read_plans,
                 execution=execution,
                 out_dir=out_dir,
             )
@@ -169,6 +234,7 @@ def _run_dense_images_in_process(
     *,
     dense: DenseImageOptions,
     recipe: DenseImageRecipe,
+    read_plans: dict[str, DenseImageReadPlan],
     execution,
     out_dir,
 ) -> None:
@@ -188,6 +254,7 @@ def _run_dense_images_in_process(
         out_dir=out_dir,
         dense=dense,
         recipe=recipe,
+        read_plans=read_plans,
         batch_size=int(execution.batch_size),
         precision=execution.precision,
         output_dtype=resolve_output_torch_dtype(execution),
@@ -206,6 +273,7 @@ def _run_dense_images_distributed(
     *,
     dense: DenseImageOptions,
     recipe: DenseImageRecipe,
+    read_plans: dict[str, DenseImageReadPlan],
     execution,
     out_dir,
 ) -> None:
@@ -221,7 +289,7 @@ def _run_dense_images_distributed(
             "execution": serialize_execution(execution),
             "output_dir": str(out_dir),
             "progress_events_path": str(progress_events_path),
-            **build_image_specs_request(specs),
+            **build_image_specs_request(specs, read_plans=read_plans),
         }
         request_path.write_text(json.dumps(request, indent=2, sort_keys=True), encoding="utf-8")
         run_torchrun_worker(

--- a/slide2vec/runtime/image_specs.py
+++ b/slide2vec/runtime/image_specs.py
@@ -1,35 +1,130 @@
-"""The flat list of named image files both given-geometry paths work over.
+"""Named image normalization and dense reader-regime classification.
 
 :meth:`slide2vec.api.Model.embed_images` (pooled, issue #234) and
 :meth:`slide2vec.api.Model.embed_images_dense` (dense grids, issue #235) take the same input
-unit — a caller-named image file — and stage it the same way, so normalizing that list and
-moving it to the torchrun ranks lives here rather than being copied per path. What differs
-between them is only what each rank *does* with an image, which is the shard loops' business.
+unit — a caller-named image file — and share normalization/request transport. Dense extraction
+additionally derives its one raster or hs2p spacing-readable regime from reader capabilities.
 """
 
 from __future__ import annotations
 
 from collections import Counter
+from functools import lru_cache
+from importlib import import_module
 from pathlib import Path
+import pkgutil
 from typing import Sequence
+
+import hs2p.wsi.backends as hs2p_wsi_backends
+from hs2p.wsi import reader as hs2p_reader
 
 from slide2vec.api import ImageSpec
 
 RASTER_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg"})
 
 
-def validate_raster_image_specs(specs: Sequence[ImageSpec]) -> None:
-    """Require the closed raster suffix set owned by the Pillow dense-image path."""
-    unsupported = [
-        f"{spec.sample_id!r} ({spec.image_path})"
-        for spec in specs
-        if Path(spec.image_path).suffix.lower() not in RASTER_IMAGE_SUFFIXES
-    ]
-    if unsupported:
-        raise ValueError(
-            "Dense raster image extraction accepts exactly .png, .jpg, and .jpeg "
-            f"(case-insensitive); unsupported inputs: {unsupported}"
+@lru_cache(maxsize=1)
+def spacing_readable_image_suffixes() -> frozenset[str]:
+    """Return the suffix capabilities declared by hs2p's installed WSI readers."""
+    suffixes: set[str] = set()
+    for module_info in pkgutil.iter_modules(
+        hs2p_wsi_backends.__path__,
+        prefix=f"{hs2p_wsi_backends.__name__}.",
+    ):
+        module = import_module(module_info.name)
+        for name, value in vars(module).items():
+            if not name.endswith("_SUPPORTED_SUFFIXES"):
+                continue
+            if not isinstance(value, (set, frozenset, list, tuple)):
+                continue
+            suffixes.update(
+                str(suffix).lower()
+                for suffix in value
+                if isinstance(suffix, str) and suffix.startswith(".")
+            )
+    if not suffixes:
+        raise RuntimeError(
+            "The installed hs2p WSI readers do not declare any supported path suffixes."
         )
+    return frozenset(suffixes)
+
+
+def validate_dense_image_reader_regime(
+    specs: Sequence[ImageSpec],
+) -> tuple[str, dict[str, str]]:
+    """Resolve one regime and retain auto backends discovered by openability probes.
+
+    CuCIM and VIPS publish suffix capabilities, while hs2p's OpenSlide/ASAP readers
+    deliberately accept paths based on file contents. For a suffix outside the published
+    sets, first ask hs2p to resolve under the caller's real metadata policy. Only if that
+    fails, a synthetic-spacing probe distinguishes reader-openable content from unsupported
+    content; its backend is never carried into the real plan.
+    """
+    spacing_suffixes = spacing_readable_image_suffixes()
+    resolved_auto_backends: dict[str, str] = {}
+    grouped: dict[str, list[str]] = {
+        "raster": [],
+        "spacing-readable": [],
+        "unsupported": [],
+    }
+    for spec in specs:
+        suffix = Path(spec.image_path).suffix.lower()
+        if suffix in RASTER_IMAGE_SUFFIXES:
+            regime = "raster"
+        elif suffix in spacing_suffixes:
+            regime = "spacing-readable"
+        else:
+            spacing_override = (
+                float(spec.spacing_at_level_0)
+                if spec.spacing_at_level_0 is not None
+                else None
+            )
+            try:
+                selection = hs2p_reader.resolve_backend(
+                    "auto",
+                    wsi_path=Path(spec.image_path),
+                    spacing_override=spacing_override,
+                )
+            except RuntimeError:
+                try:
+                    synthetic_selection = hs2p_reader.resolve_backend(
+                        "auto",
+                        wsi_path=Path(spec.image_path),
+                        spacing_override=1.0,
+                    )
+                except RuntimeError:
+                    regime = "unsupported"
+                else:
+                    # The source is reader-openable, so surface the real metadata/override
+                    # error instead of mislabelling its suffix as unsupported. This metadata
+                    # open never decodes pixels, and the synthetic backend is not persisted.
+                    probe_reader = hs2p_reader.open_slide(
+                        spec.image_path,
+                        backend=synthetic_selection.backend,
+                        spacing_override=spacing_override,
+                    )
+                    probe_reader.close()
+                    regime = "spacing-readable"
+            else:
+                regime = "spacing-readable"
+                resolved_auto_backends[spec.sample_id] = str(selection.backend)
+        grouped[regime].append(f"{spec.sample_id!r} ({spec.image_path})")
+    if grouped["unsupported"]:
+        supported_spacing = ", ".join(sorted(spacing_suffixes))
+        raise ValueError(
+            "Dense image extraction received unsupported path suffixes. Raster formats are "
+            "exactly .png, .jpg, and .jpeg; hs2p spacing-readable formats include "
+            f"{supported_spacing} plus other sources its registered readers can open. "
+            f"Unsupported samples: {grouped['unsupported']}"
+        )
+    present = [regime for regime in ("raster", "spacing-readable") if grouped[regime]]
+    if len(present) != 1:
+        raise ValueError(
+            "A dense image run must use exactly one reader regime. "
+            f"raster samples: {grouped['raster']}; "
+            f"spacing-readable samples: {grouped['spacing-readable']}"
+        )
+    return present[0], resolved_auto_backends
 
 
 def reject_image_level0_spacing_overrides(
@@ -83,7 +178,7 @@ def normalize_image_specs(
     return specs
 
 
-def build_image_specs_request(specs: Sequence[ImageSpec]) -> dict:
+def build_image_specs_request(specs: Sequence[ImageSpec], *, read_plans=None) -> dict:
     """The flat image list crossing to the torchrun ranks, in the order the parent fixed.
 
     Order is the payload: every rank rebuilds this exact list and derives its own contiguous
@@ -96,6 +191,11 @@ def build_image_specs_request(specs: Sequence[ImageSpec]) -> dict:
                 "sample_id": spec.sample_id,
                 "image_path": str(spec.image_path),
                 "spacing_at_level_0": spec.spacing_at_level_0,
+                **(
+                    {}
+                    if read_plans is None
+                    else {"read_plan": read_plans[spec.sample_id].to_dict()}
+                ),
             }
             for spec in specs
         ]

--- a/tests/test_dense_image_reading.py
+++ b/tests/test_dense_image_reading.py
@@ -1,0 +1,408 @@
+"""Resolved hs2p read plans for spacing-readable dense images (issue #259)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from slide2vec.api import ImageSpec
+from slide2vec.runtime.dense_image_reading import (
+    DenseImageReadPlan,
+    dense_image_read_plans_from_request,
+    read_dense_image,
+    resolve_spacing_read_plan,
+)
+from slide2vec.runtime.image_specs import build_image_specs_request
+
+
+class _MetadataReader:
+    def __init__(
+        self,
+        *,
+        spacing: float,
+        level_dimensions: list[tuple[int, int]],
+        level_downsamples: list[tuple[float, float]],
+    ) -> None:
+        self.spacing = spacing
+        self.level_dimensions = level_dimensions
+        self.level_downsamples = level_downsamples
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_parent_resolves_a_native_within_tolerance_plan_through_hs2p(
+    tmp_path, monkeypatch
+):
+    """A near-native level is accepted losslessly and remains the effective spacing."""
+    from hs2p.wsi import geometry as hs2p_geometry
+    from hs2p.wsi import reader as hs2p_reader
+
+    source = _MetadataReader(
+        spacing=0.252,
+        level_dimensions=[(6, 4), (3, 2)],
+        level_downsamples=[(1.0, 1.0), (2.0, 2.0)],
+    )
+    monkeypatch.setattr(
+        hs2p_reader,
+        "resolve_backend",
+        lambda requested_backend, **kwargs: SimpleNamespace(backend="openslide"),
+    )
+    monkeypatch.setattr(
+        hs2p_reader,
+        "open_slide",
+        lambda path, backend, **kwargs: source,
+    )
+    monkeypatch.setattr(
+        hs2p_geometry,
+        "select_level",
+        lambda **kwargs: hs2p_geometry.LevelSelection(
+            level=1,
+            read_spacing_um=0.504,
+            is_within_tolerance=True,
+        ),
+    )
+    spec = ImageSpec(sample_id="near-native", image_path=tmp_path / "sample.SVS")
+
+    plan = resolve_spacing_read_plan(
+        spec,
+        requested_spacing_um=0.5,
+        spacing_source="explicit",
+        requested_backend="auto",
+        tolerance=0.05,
+    )
+
+    assert plan.to_dict() == {
+        "reader_regime": "spacing-readable",
+        "spacing_source": "explicit",
+        "declared_spacing_um": 0.5,
+        "source_spacing_um": 0.252,
+        "spacing_at_level_0": None,
+        "read_spacing_um": 0.504,
+        "effective_spacing_um": 0.504,
+        "requested_backend": "auto",
+        "backend": "openslide",
+        "tolerance": 0.05,
+        "read_level": 1,
+        "is_within_tolerance": True,
+        "read_size": [2, 3],
+        "output_size": [2, 3],
+    }
+    assert source.closed
+
+
+def test_level0_override_is_the_authoritative_source_spacing(tmp_path, monkeypatch):
+    from hs2p.wsi import geometry as hs2p_geometry
+    from hs2p.wsi import reader as hs2p_reader
+
+    opened = {}
+    source = _MetadataReader(
+        spacing=0.4,
+        level_dimensions=[(8, 8)],
+        level_downsamples=[(1.0, 1.0)],
+    )
+
+    def _resolve(requested_backend, **kwargs):
+        opened["resolve"] = (requested_backend, kwargs)
+        return SimpleNamespace(backend="vips")
+
+    def _open(path, backend, **kwargs):
+        opened["open"] = (path, backend, kwargs)
+        return source
+
+    monkeypatch.setattr(hs2p_reader, "resolve_backend", _resolve)
+    monkeypatch.setattr(hs2p_reader, "open_slide", _open)
+    monkeypatch.setattr(
+        hs2p_geometry,
+        "select_level",
+        lambda **kwargs: hs2p_geometry.LevelSelection(
+            level=0,
+            read_spacing_um=0.4,
+            is_within_tolerance=True,
+        ),
+    )
+    spec = ImageSpec(
+        sample_id="override",
+        image_path=tmp_path / "sample.tif",
+        spacing_at_level_0=0.4,
+    )
+
+    plan = resolve_spacing_read_plan(
+        spec,
+        requested_spacing_um=0.4,
+        spacing_source="explicit",
+        requested_backend="auto",
+        tolerance=0.05,
+    )
+
+    assert plan.source_spacing_um == pytest.approx(0.4)
+    assert plan.spacing_at_level_0 == pytest.approx(0.4)
+    assert opened["resolve"][1]["spacing_override"] == pytest.approx(0.4)
+    assert opened["open"][2]["spacing_override"] == pytest.approx(0.4)
+
+
+def test_missing_source_spacing_is_a_hard_hs2p_error(tmp_path, monkeypatch):
+    from hs2p.wsi import reader as hs2p_reader
+
+    monkeypatch.setattr(
+        hs2p_reader,
+        "resolve_backend",
+        lambda requested_backend, **kwargs: SimpleNamespace(backend="openslide"),
+    )
+    monkeypatch.setattr(
+        hs2p_reader,
+        "open_slide",
+        lambda path, backend, **kwargs: (_ for _ in ()).throw(
+            ValueError(
+                f"Unable to infer slide spacing for path={path} with backend={backend}"
+            )
+        ),
+    )
+
+    with pytest.raises(ValueError, match=r"Unable to infer slide spacing.*sample\.svs"):
+        resolve_spacing_read_plan(
+            ImageSpec(sample_id="missing", image_path=tmp_path / "sample.svs"),
+            requested_spacing_um=0.5,
+            spacing_source="explicit",
+            requested_backend="openslide",
+            tolerance=0.05,
+        )
+
+
+def test_explicit_backend_is_authoritative_and_never_falls_back(tmp_path, monkeypatch):
+    from hs2p.wsi import reader as hs2p_reader
+
+    opened = {}
+    source = _MetadataReader(
+        spacing=0.5,
+        level_dimensions=[(4, 4)],
+        level_downsamples=[(1.0, 1.0)],
+    )
+
+    def _open(path, backend, **kwargs):
+        opened["backend"] = backend
+        return source
+
+    monkeypatch.setattr(hs2p_reader, "open_slide", _open)
+
+    plan = resolve_spacing_read_plan(
+        ImageSpec(sample_id="explicit", image_path=tmp_path / "sample.svs"),
+        requested_spacing_um=0.5,
+        spacing_source="explicit",
+        requested_backend="openslide",
+        tolerance=0.05,
+    )
+
+    assert plan.requested_backend == "openslide"
+    assert plan.backend == "openslide"
+    assert opened["backend"] == "openslide"
+
+
+def test_complete_read_plan_round_trips_with_each_distributed_image(tmp_path):
+    spec = ImageSpec(
+        sample_id="round-trip",
+        image_path=str((tmp_path / "sample.svs").resolve()),
+        spacing_at_level_0=0.25,
+    )
+    plan = DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source="model_default",
+        declared_spacing_um=0.5,
+        source_spacing_um=0.25,
+        spacing_at_level_0=0.25,
+        read_spacing_um=0.25,
+        effective_spacing_um=0.5,
+        requested_backend="auto",
+        backend="vips",
+        tolerance=0.05,
+        read_level=0,
+        is_within_tolerance=False,
+        read_size=(448, 448),
+        output_size=(224, 224),
+    )
+
+    request = json.loads(
+        json.dumps(build_image_specs_request([spec], read_plans={spec.sample_id: plan}))
+    )
+
+    assert dense_image_read_plans_from_request(request) == {spec.sample_id: plan}
+
+
+def test_rank_reads_native_pixels_without_resolving_the_plan_again(
+    tmp_path, monkeypatch
+):
+    """The concrete backend/level fixed by the parent are consumed verbatim."""
+    from hs2p.wsi import geometry as hs2p_geometry
+    from hs2p.wsi import reader as hs2p_reader
+
+    pixels = np.array(
+        [
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            [[10, 11, 12], [13, 14, 15], [16, 17, 18]],
+        ],
+        dtype=np.uint8,
+    )
+
+    class _Reader:
+        def read_level(self, level):
+            assert level == 2
+            return pixels.copy()
+
+        def close(self):
+            pass
+
+    def _open(path, backend, **kwargs):
+        assert path == str(tmp_path / "sample.svs")
+        assert backend == "openslide"
+        assert kwargs == {"spacing_override": None}
+        return _Reader()
+
+    monkeypatch.setattr(hs2p_reader, "open_slide", _open)
+    monkeypatch.setattr(
+        hs2p_reader,
+        "resolve_backend",
+        lambda *args, **kwargs: pytest.fail("rank must not resolve a backend"),
+    )
+    monkeypatch.setattr(
+        hs2p_geometry,
+        "select_level",
+        lambda **kwargs: pytest.fail("rank must not select a level"),
+    )
+    plan = DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source="explicit",
+        declared_spacing_um=0.5,
+        source_spacing_um=0.25,
+        spacing_at_level_0=None,
+        read_spacing_um=0.5,
+        effective_spacing_um=0.5,
+        requested_backend="auto",
+        backend="openslide",
+        tolerance=0.05,
+        read_level=2,
+        is_within_tolerance=True,
+        read_size=(2, 3),
+        output_size=(2, 3),
+    )
+
+    image = read_dense_image(
+        ImageSpec(sample_id="native", image_path=tmp_path / "sample.svs"),
+        plan=plan,
+        target_size=(2, 3),
+    )
+
+    np.testing.assert_array_equal(np.asarray(image), pixels)
+
+
+def test_rank_area_downsamples_to_exact_pixels_from_the_resolved_plan(
+    tmp_path, monkeypatch
+):
+    """A non-tolerant native level is area-reduced, never fit-to-size resized."""
+    from hs2p.wsi import reader as hs2p_reader
+
+    pixels = np.array(
+        [
+            [[0, 0, 0], [2, 2, 2], [10, 10, 10], [12, 12, 12]],
+            [[4, 4, 4], [6, 6, 6], [14, 14, 14], [16, 16, 16]],
+            [[20, 20, 20], [22, 22, 22], [30, 30, 30], [32, 32, 32]],
+            [[24, 24, 24], [26, 26, 26], [34, 34, 34], [36, 36, 36]],
+        ],
+        dtype=np.uint8,
+    )
+
+    class _Reader:
+        def read_level(self, level):
+            assert level == 0
+            return pixels.copy()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        hs2p_reader,
+        "open_slide",
+        lambda path, backend, **kwargs: _Reader(),
+    )
+    plan = DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source="model_default",
+        declared_spacing_um=0.5,
+        source_spacing_um=0.25,
+        spacing_at_level_0=None,
+        read_spacing_um=0.25,
+        effective_spacing_um=0.5,
+        requested_backend="auto",
+        backend="vips",
+        tolerance=0.05,
+        read_level=0,
+        is_within_tolerance=False,
+        read_size=(4, 4),
+        output_size=(2, 2),
+    )
+
+    image = read_dense_image(
+        ImageSpec(sample_id="downsampled", image_path=tmp_path / "sample.tif"),
+        plan=plan,
+        target_size=(2, 2),
+    )
+
+    expected = np.array(
+        [
+            [[3, 3, 3], [13, 13, 13]],
+            [[23, 23, 23], [33, 33, 33]],
+        ],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(np.asarray(image), expected)
+
+
+def test_spacing_read_target_mismatch_names_geometry_and_effective_spacing(
+    tmp_path, monkeypatch
+):
+    from hs2p.wsi import reader as hs2p_reader
+
+    class _Reader:
+        def read_level(self, level):
+            return np.zeros((3, 4, 3), dtype=np.uint8)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        hs2p_reader,
+        "open_slide",
+        lambda path, backend, **kwargs: _Reader(),
+    )
+    plan = DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source="explicit",
+        declared_spacing_um=0.5,
+        source_spacing_um=0.504,
+        spacing_at_level_0=None,
+        read_spacing_um=0.504,
+        effective_spacing_um=0.504,
+        requested_backend="auto",
+        backend="openslide",
+        tolerance=0.05,
+        read_level=1,
+        is_within_tolerance=True,
+        read_size=(3, 4),
+        output_size=(3, 4),
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        read_dense_image(
+            ImageSpec(sample_id="wrong-size", image_path=tmp_path / "sample.svs"),
+            plan=plan,
+            target_size=(4, 4),
+        )
+
+    assert str(excinfo.value) == (
+        "Image 'wrong-size' has observed size (3, 4), but target_size declares "
+        "(4, 4), at resolved spacing 0.504 µm/px. Dense image extraction never "
+        "performs fit-to-size resizing."
+    )

--- a/tests/test_dense_image_resume.py
+++ b/tests/test_dense_image_resume.py
@@ -11,6 +11,7 @@ from slide2vec.api import DenseImageOptions, ExecutionOptions, ImageSpec, Model
 from slide2vec.artifacts import dense_image_paths
 from slide2vec.runtime.dense_image_stage import partition_dense_images_by_resume
 from slide2vec.runtime.dense_image_recipe import resolve_dense_image_recipe
+from slide2vec.runtime.dense_image_reading import DenseImageReadPlan
 from slide2vec.runtime.image_specs import (
     build_image_specs_request,
     image_specs_from_request,
@@ -208,6 +209,55 @@ def test_resume_skips_only_a_complete_exactly_compatible_pair(tmp_path):
 
 
 @pytest.mark.parametrize(
+    ("changed_field", "changed_value"),
+    [
+        ("source_spacing_um", 0.26),
+        ("backend", "openslide"),
+    ],
+)
+def test_resume_recomputes_when_parent_resolved_source_or_auto_backend_changes(
+    tmp_path, changed_field, changed_value
+):
+    from dataclasses import replace
+
+    source = (tmp_path / "source.svs").resolve()
+    spec = ImageSpec(sample_id="sample-1", image_path=str(source))
+    recipe = _resolved_recipe(tmp_path)
+    original = DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source="explicit",
+        declared_spacing_um=0.5,
+        source_spacing_um=0.25,
+        spacing_at_level_0=None,
+        read_spacing_um=0.25,
+        effective_spacing_um=0.5,
+        requested_backend="auto",
+        backend="vips",
+        tolerance=0.05,
+        read_level=0,
+        is_within_tolerance=False,
+        read_size=(448, 448),
+        output_size=(224, 224),
+    )
+    _publish_pair(
+        tmp_path / "out",
+        spec,
+        recipe.for_image(spec, original),
+    )
+    current = replace(original, **{changed_field: changed_value})
+
+    remaining, skipped = partition_dense_images_by_resume(
+        [spec],
+        tmp_path / "out",
+        recipe,
+        read_plans={spec.sample_id: current},
+    )
+
+    assert remaining == [spec]
+    assert skipped == 0
+
+
+@pytest.mark.parametrize(
     ("condition", "differing_fields"),
     [
         ("missing-pair", "payload, sidecar"),
@@ -325,11 +375,16 @@ def test_every_recorded_compatibility_field_participates_in_resume(tmp_path):
         "spacing_source",
         "declared_spacing_um",
         "source_spacing_um",
+        "spacing_at_level_0",
+        "read_spacing_um",
         "effective_spacing_um",
         "requested_backend",
         "backend",
         "tolerance",
         "read_level",
+        "is_within_tolerance",
+        "read_size",
+        "output_size",
         "read_tile_size_px",
         "requested_tile_size_px",
         "target_size",

--- a/tests/test_dense_image_shard.py
+++ b/tests/test_dense_image_shard.py
@@ -35,6 +35,7 @@ from slide2vec.api import DenseImageOptions, ImageSpec  # noqa: E402
 from slide2vec.artifacts import dense_image_paths, write_dense_image  # noqa: E402
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
 from slide2vec.runtime.dense_image_shard import run_dense_image_shard  # noqa: E402
+from slide2vec.runtime.dense_image_reading import DenseImageReadPlan  # noqa: E402
 from slide2vec.runtime.dense_image_recipe import DenseImageRecipe  # noqa: E402
 from slide2vec.runtime.dense_regions import (  # noqa: E402
     compute_dense_geometry,
@@ -294,11 +295,16 @@ def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
         "spacing_source": "explicit",
         "declared_spacing_um": 0.5,
         "source_spacing_um": 0.5,
+        "spacing_at_level_0": None,
+        "read_spacing_um": None,
         "effective_spacing_um": 0.5,
         "requested_backend": "auto",
         "backend": "pil",
         "tolerance": None,
         "read_level": None,
+        "is_within_tolerance": None,
+        "read_size": None,
+        "output_size": None,
         "read_tile_size_px": None,
         "requested_tile_size_px": None,
         "pad_mode": "reflect",
@@ -317,11 +323,16 @@ def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
             "spacing_source": "explicit",
             "declared_spacing_um": 0.5,
             "source_spacing_um": 0.5,
+            "spacing_at_level_0": None,
+            "read_spacing_um": None,
             "effective_spacing_um": 0.5,
             "requested_backend": "auto",
             "backend": "pil",
             "tolerance": None,
             "read_level": None,
+            "is_within_tolerance": None,
+            "read_size": None,
+            "output_size": None,
             "read_tile_size_px": None,
             "requested_tile_size_px": None,
             "target_size": [60, 60],
@@ -340,6 +351,68 @@ def test_run_dense_image_shard_sidecar_records_extraction_geometry(tmp_path):
             "dtype": "float32",
         },
     }
+
+
+def test_spacing_readable_sidecar_records_the_complete_resolved_plan(
+    tmp_path, monkeypatch
+):
+    from hs2p.wsi import reader as hs2p_reader
+
+    pixels = np.zeros((64, 64, 3), dtype=np.uint8)
+
+    class _Reader:
+        def read_level(self, level):
+            assert level == 1
+            return pixels.copy()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        hs2p_reader,
+        "open_slide",
+        lambda path, backend, **kwargs: _Reader(),
+    )
+    enc = _encoder()
+    spec = ImageSpec(
+        sample_id="spacing-readable",
+        image_path=str((tmp_path / "source.svs").resolve()),
+        spacing_at_level_0=0.252,
+    )
+    plan = DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source="model_default",
+        declared_spacing_um=0.5,
+        source_spacing_um=0.252,
+        spacing_at_level_0=0.252,
+        read_spacing_um=0.504,
+        effective_spacing_um=0.504,
+        requested_backend="auto",
+        backend="vips",
+        tolerance=0.05,
+        read_level=1,
+        is_within_tolerance=True,
+        read_size=(64, 64),
+        output_size=(64, 64),
+    )
+
+    artifact = run_dense_image_shard(
+        [spec],
+        loaded=_loaded(enc),
+        out_dir=tmp_path / "out",
+        dense=_dense(),
+        recipe=_recipe(),
+        read_plans={spec.sample_id: plan},
+        batch_size=1,
+        num_workers=0,
+    )[0]
+
+    meta = json.loads(artifact.metadata_path.read_text())
+    expected_plan = plan.to_dict()
+    assert {field: meta[field] for field in expected_plan} == expected_plan
+    assert {
+        field: meta["compatibility"][field] for field in expected_plan
+    } == expected_plan
 
 
 def test_explicit_spacing_changes_provenance_but_not_raster_pixels(tmp_path):

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -91,12 +91,55 @@ def _skip_dense_image_encoding(monkeypatch) -> None:
     monkeypatch.setattr(
         dense_image_stage,
         "partition_dense_images_by_resume",
-        lambda normalized, out_dir, recipe: ([], len(normalized)),
+        lambda normalized, out_dir, recipe, read_plans=None: ([], len(normalized)),
     )
     monkeypatch.setattr(
         dense_image_stage,
         "dense_image_artifact_from_disk",
         lambda out_dir, spec: spec,
+    )
+
+
+def _mock_hs2p_spacing_reader(
+    monkeypatch,
+    *,
+    spacing=0.25,
+    level_dimensions=((64, 64),),
+    level_downsamples=((1.0, 1.0),),
+    resolved_backend="openslide",
+):
+    from hs2p.wsi import reader as hs2p_reader
+
+    class _Reader:
+        def __init__(self, *, spacing_override=None):
+            self.spacing = (
+                float(spacing)
+                if spacing_override is None
+                else float(spacing_override)
+            )
+            self.level_dimensions = list(level_dimensions)
+            self.level_downsamples = list(level_downsamples)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        hs2p_reader,
+        "resolve_backend",
+        lambda requested_backend, **kwargs: SimpleNamespace(
+            backend=(
+                resolved_backend
+                if requested_backend == "auto"
+                else requested_backend
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        hs2p_reader,
+        "open_slide",
+        lambda path, backend, spacing_override=None, **kwargs: _Reader(
+            spacing_override=spacing_override
+        ),
     )
 
 
@@ -285,7 +328,7 @@ def test_dense_image_raster_suffixes_are_exact_and_case_insensitive(tmp_path, mo
     monkeypatch.setattr(
         dense_image_stage,
         "partition_dense_images_by_resume",
-        lambda specs, out_dir, recipe: ([], len(specs)),
+        lambda specs, out_dir, recipe, read_plans=None: ([], len(specs)),
     )
     monkeypatch.setattr(
         dense_image_stage,
@@ -300,14 +343,406 @@ def test_dense_image_raster_suffixes_are_exact_and_case_insensitive(tmp_path, mo
         )
     ] == [spec.sample_id for spec in accepted]
 
-    for suffix in (".tif", ".tiff", ".svs", ".png.tmp", ""):
-        with pytest.raises(ValueError, match=r"raster.*\.png.*\.jpg.*\.jpeg"):
+    for suffix in (".bmp", ".png.tmp", ""):
+        with pytest.raises(ValueError, match=r"Raster.*\.png.*\.jpg.*\.jpeg"):
             dense_image_stage.embed_images_dense(
                 model,
                 [ImageSpec(sample_id="unsupported", image_path=tmp_path / f"image{suffix}")],
                 dense=_dense(),
                 execution=execution,
             )
+
+
+def test_spacing_readable_suffixes_are_case_insensitive_and_may_mix_within_one_run(
+    tmp_path, monkeypatch
+):
+    """hs2p-supported WSI suffixes form one regime even when their formats differ."""
+    _mock_hs2p_spacing_reader(monkeypatch)
+    _skip_dense_image_encoding(monkeypatch)
+    model = _FakeModel(_encoder())
+    execution = ExecutionOptions(
+        output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+    )
+    specs = [
+        ImageSpec(sample_id="tiff", image_path=tmp_path / "image.TiF"),
+        ImageSpec(sample_id="aperio", image_path=tmp_path / "image.SvS"),
+    ]
+
+    artifacts = dense_image_stage.embed_images_dense(
+        model,
+        specs,
+        dense=_dense(target_size=32, backend="openslide"),
+        execution=execution,
+    )
+
+    assert [artifact.sample_id for artifact in artifacts] == ["tiff", "aperio"]
+
+
+def test_openslide_formats_are_classified_by_hs2p_openability_and_resolution_is_reused(
+    tmp_path, monkeypatch
+):
+    """Readers without suffix constants are probed once without decoding pixels."""
+    from hs2p.wsi import reader as hs2p_reader
+
+    resolve_calls = []
+    open_calls = []
+
+    class _Reader:
+        spacing = 0.5
+        level_dimensions = [(64, 64)]
+        level_downsamples = [(1.0, 1.0)]
+
+        def read_level(self, level):
+            pytest.fail(f"classification/resume filtering must not decode level {level}")
+
+        def close(self):
+            pass
+
+    def _resolve(requested_backend, *, wsi_path, **kwargs):
+        assert requested_backend == "auto"
+        resolve_calls.append((Path(wsi_path).suffix.lower(), kwargs))
+        return SimpleNamespace(backend="openslide")
+
+    def _open(path, *, backend, spacing_override=None, **kwargs):
+        open_calls.append((Path(path).suffix.lower(), backend, spacing_override))
+        return _Reader()
+
+    monkeypatch.setattr(hs2p_reader, "resolve_backend", _resolve)
+    monkeypatch.setattr(hs2p_reader, "open_slide", _open)
+    _skip_dense_image_encoding(monkeypatch)
+    specs = [
+        ImageSpec(
+            sample_id=suffix[1:],
+            image_path=tmp_path / f"image{suffix.upper()}",
+            spacing_at_level_0=0.5,
+        )
+        for suffix in (".avs", ".dcm", ".vms", ".vmu", ".czi")
+    ]
+
+    artifacts = dense_image_stage.embed_images_dense(
+        _FakeModel(_encoder()),
+        specs,
+        dense=_dense(backend="auto"),
+        execution=ExecutionOptions(
+            output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+        ),
+    )
+
+    assert [artifact.sample_id for artifact in artifacts] == [
+        "avs",
+        "dcm",
+        "vms",
+        "vmu",
+        "czi",
+    ]
+    assert [suffix for suffix, _ in resolve_calls] == [
+        ".avs",
+        ".dcm",
+        ".vms",
+        ".vmu",
+        ".czi",
+    ]
+    assert [suffix for suffix, _, _ in open_calls] == [
+        ".avs",
+        ".dcm",
+        ".vms",
+        ".vmu",
+        ".czi",
+    ]
+    assert all(backend == "openslide" for _, backend, _ in open_calls)
+
+
+def test_synthetic_format_probe_does_not_replace_real_auto_backend_resolution(
+    tmp_path, monkeypatch
+):
+    """A probe-only spacing cannot select the backend persisted in the real plan."""
+    from hs2p.wsi import reader as hs2p_reader
+
+    resolve_calls = []
+    open_calls = []
+
+    class _Reader:
+        spacing = 0.5
+        level_dimensions = [(64, 64)]
+        level_downsamples = [(1.0, 1.0)]
+
+        def read_level(self, level):
+            pytest.fail(f"resume filtering must not decode level {level}")
+
+        def close(self):
+            pass
+
+    def _resolve(requested_backend, *, spacing_override=None, **kwargs):
+        assert requested_backend == "auto"
+        resolve_calls.append(spacing_override)
+        return SimpleNamespace(
+            backend="openslide" if spacing_override == 1.0 else "vips"
+        )
+
+    def _open(path, *, backend, spacing_override=None, **kwargs):
+        open_calls.append((backend, spacing_override))
+        return _Reader()
+
+    monkeypatch.setattr(hs2p_reader, "resolve_backend", _resolve)
+    monkeypatch.setattr(hs2p_reader, "open_slide", _open)
+    _skip_dense_image_encoding(monkeypatch)
+
+    dense_image_stage.embed_images_dense(
+        _FakeModel(_encoder()),
+        [ImageSpec(sample_id="dicom", image_path=tmp_path / "image.dcm")],
+        dense=_dense(backend="auto"),
+        execution=ExecutionOptions(
+            output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+        ),
+    )
+
+    assert resolve_calls == [None]
+    assert open_calls == [("vips", None)]
+
+
+def test_unknown_suffix_probe_surfaces_invalid_override_instead_of_unsupported(
+    tmp_path, monkeypatch
+):
+    """Synthetic openability is only a discriminator after the real policy fails."""
+    from hs2p.wsi import reader as hs2p_reader
+
+    resolve_calls = []
+
+    def _resolve(requested_backend, *, spacing_override=None, **kwargs):
+        assert requested_backend == "auto"
+        resolve_calls.append(spacing_override)
+        if spacing_override == 1.0:
+            return SimpleNamespace(backend="openslide")
+        raise RuntimeError("auto resolution rejected the source")
+
+    def _open(path, *, backend, spacing_override=None, **kwargs):
+        assert backend == "openslide"
+        assert spacing_override == -0.5
+        raise ValueError("spacing override must be positive")
+
+    monkeypatch.setattr(hs2p_reader, "resolve_backend", _resolve)
+    monkeypatch.setattr(hs2p_reader, "open_slide", _open)
+    model = _FakeModel(_encoder())
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("override validation must precede model loading"),
+    )
+
+    with pytest.raises(ValueError, match="spacing override must be positive"):
+        dense_image_stage.embed_images_dense(
+            model,
+            [
+                ImageSpec(
+                    sample_id="dicom",
+                    image_path=tmp_path / "image.dcm",
+                    spacing_at_level_0=-0.5,
+                )
+            ],
+            dense=_dense(backend="auto"),
+            execution=ExecutionOptions(
+                output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+            ),
+        )
+
+    assert resolve_calls == [-0.5, 1.0]
+
+
+def test_mixed_reader_regimes_fail_with_samples_grouped_before_any_read_or_model_load(
+    tmp_path, monkeypatch
+):
+    from hs2p.wsi import reader as hs2p_reader
+
+    monkeypatch.setattr(
+        hs2p_reader,
+        "resolve_backend",
+        lambda *args, **kwargs: pytest.fail("mixed runs must fail before reader resolution"),
+    )
+    model = _FakeModel(_encoder())
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("mixed runs must fail before model loading"),
+    )
+    execution = ExecutionOptions(
+        output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        dense_image_stage.embed_images_dense(
+            model,
+            [
+                ImageSpec(sample_id="raster-a", image_path=tmp_path / "a.PNG"),
+                ImageSpec(sample_id="slide-b", image_path=tmp_path / "b.SVS"),
+            ],
+            dense=_dense(),
+            execution=execution,
+        )
+
+    message = str(excinfo.value)
+    assert "exactly one reader regime" in message
+    assert "raster samples" in message and "raster-a" in message
+    assert "spacing-readable samples" in message and "slide-b" in message
+
+
+def test_unsupported_dense_image_suffix_fails_validation_before_loading(tmp_path, monkeypatch):
+    from hs2p.wsi import reader as hs2p_reader
+
+    monkeypatch.setattr(
+        hs2p_reader,
+        "resolve_backend",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("no registered hs2p reader can open this source")
+        ),
+    )
+    model = _FakeModel(_encoder())
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("unsupported suffixes must fail before model loading"),
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        dense_image_stage.embed_images_dense(
+            model,
+            [
+                ImageSpec(
+                    sample_id="not-an-image",
+                    image_path=tmp_path / "sample.not-a-wsi",
+                )
+            ],
+            dense=_dense(),
+            execution=ExecutionOptions(
+                output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+            ),
+        )
+    message = str(excinfo.value)
+    assert "unsupported path suffixes" in message
+    assert "not-an-image" in message
+    assert ".png, .jpg, and .jpeg" in message
+
+
+def test_omitted_spacing_readable_scale_resolves_the_model_default_before_reading(
+    tmp_path, monkeypatch
+):
+    """A constrained encoder's one registry spacing becomes the declared read scale."""
+
+    _mock_hs2p_spacing_reader(monkeypatch, spacing=0.5)
+    captured = {}
+
+    def _capture_plan(specs, out_dir, recipe, **kwargs):
+        del out_dir
+        captured.update(recipe=recipe, specs=list(specs), **kwargs)
+        return [], len(specs)
+
+    monkeypatch.setattr(
+        dense_image_stage, "partition_dense_images_by_resume", _capture_plan
+    )
+    monkeypatch.setattr(
+        dense_image_stage,
+        "dense_image_artifact_from_disk",
+        lambda out_dir, spec: spec,
+    )
+    model = _FakeModel(_encoder(), name="uni")
+    execution = ExecutionOptions(
+        output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+    )
+
+    dense_image_stage.embed_images_dense(
+        model,
+        [ImageSpec(sample_id="sample", image_path=tmp_path / "sample.svs")],
+        dense=_dense(spacing_um=None, backend="openslide"),
+        execution=execution,
+    )
+
+    assert captured["recipe"].spacing_source == "model_default"
+    assert captured["recipe"].declared_spacing_um == pytest.approx(0.5)
+    assert captured["read_plans"]["sample"].to_dict() == {
+        "reader_regime": "spacing-readable",
+        "spacing_source": "model_default",
+        "declared_spacing_um": 0.5,
+        "source_spacing_um": 0.5,
+        "spacing_at_level_0": None,
+        "read_spacing_um": 0.5,
+        "effective_spacing_um": 0.5,
+        "requested_backend": "openslide",
+        "backend": "openslide",
+        "tolerance": 0.05,
+        "read_level": 0,
+        "is_within_tolerance": True,
+        "read_size": [64, 64],
+        "output_size": [64, 64],
+    }
+
+
+@pytest.mark.parametrize(
+    ("encoder_name", "supported_spacing_um"),
+    [
+        ("issue259-multiple-no-default", [0.5, 1.0]),
+        ("issue259-agnostic-no-default", None),
+    ],
+)
+def test_omitted_spacing_readable_scale_requires_one_resolvable_model_default(
+    tmp_path, monkeypatch, encoder_name, supported_spacing_um
+):
+    import slide2vec.encoders.registry as encoder_registry_module
+    from slide2vec.encoders.registry import register_encoder
+    from slide2vec.runtime.registry import Registry
+
+    # Register against a fresh public registry binding so later tests see the original.
+    monkeypatch.setattr(
+        encoder_registry_module, "encoder_registry", Registry("encoders")
+    )
+
+    @register_encoder(
+        encoder_name,
+        output_variants={"default": {"encode_dim": 192}},
+        default_output_variant="default",
+        input_size=224,
+        supports_variable_input_size=True,
+        patch_size=16,
+        supported_spacing_um=supported_spacing_um,
+    )
+    class _RegisteredForSpacingTest:
+        pass
+
+    model = _FakeModel(_encoder(), name=encoder_name)
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("default resolution must precede model loading"),
+    )
+
+    with pytest.raises(ValueError, match=r"DenseImageOptions\.spacing_um.*explicit"):
+        dense_image_stage.embed_images_dense(
+            model,
+            [ImageSpec(sample_id="sample", image_path=tmp_path / "sample.svs")],
+            dense=_dense(spacing_um=None),
+            execution=ExecutionOptions(
+                output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+            ),
+        )
+
+
+def test_unregistered_encoder_requires_explicit_spacing_for_spacing_readable_inputs(
+    tmp_path, monkeypatch
+):
+    model = _FakeModel(_encoder(), name="issue259-unregistered")
+    monkeypatch.setattr(
+        model,
+        "_load_backend",
+        lambda: pytest.fail("default resolution must precede model loading"),
+    )
+
+    with pytest.raises(ValueError, match=r"DenseImageOptions\.spacing_um.*explicit"):
+        dense_image_stage.embed_images_dense(
+            model,
+            [ImageSpec(sample_id="sample", image_path=tmp_path / "sample.tif")],
+            dense=_dense(spacing_um=None),
+            execution=ExecutionOptions(
+                output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
+            ),
+        )
 
 
 def test_non_recommended_numeric_raster_spacing_is_rejected(tmp_path, monkeypatch):
@@ -544,6 +979,7 @@ def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
         serialize_execution,
     )
     from slide2vec.runtime.dense_image_recipe import resolve_dense_image_recipe
+    from slide2vec.runtime.dense_image_reading import raster_read_plan
 
     specs = _images(tmp_path, ["a", "b", "c", "d"])
     loaded = _loaded(_encoder())
@@ -586,7 +1022,17 @@ def test_worker_encodes_only_its_rank_shard(tmp_path, monkeypatch):
         ),
         "output_dir": str(tmp_path / "out"),
         "progress_events_path": None,
-        **build_image_specs_request(specs),
+        **build_image_specs_request(
+            specs,
+            read_plans={
+                spec.sample_id: raster_read_plan(
+                    spacing_source="explicit",
+                    declared_spacing_um=0.5,
+                    requested_backend="auto",
+                )
+                for spec in specs
+            },
+        ),
     }
     request_path = tmp_path / "dense_image_request.json"
     request_path.write_text(json.dumps(request), encoding="utf-8")


### PR DESCRIPTION
## Summary

- classify each dense-image run into exactly one raster or hs2p spacing-readable reader regime, including content-based capability probing for readers such as OpenSlide
- resolve immutable per-image backend, source spacing, native level, tolerance, read geometry, and effective spacing plans in the parent before resume filtering, then round-trip them to distributed ranks
- read complete selected levels through hs2p, area-downsample without upsampling, enforce strict post-read target geometry, and persist the complete plan in sidecars and compatibility identity
- document the public reader/spacing contract and cover native, downsampled, default/override, backend, serialization, metadata, resume, mixed, unsupported, and OpenSlide-backed examples

## Why

Dense extraction previously handled only Pillow raster inputs, so pre-cropped WSI-format images could not be read at a run-level physical scale or resumed against a fully resolved read identity. The parent now owns resolution and ranks consume the exact immutable plan, preventing backend/level policy drift across processes.

## User impact

Callers can pass hs2p-readable pre-cropped images to `Model.embed_images_dense`, request an explicit physical spacing or use one unambiguous model default, override source level-0 spacing when needed, and receive sidecars that distinguish declared, source, native-read, and effective spacing. Mixed regimes, unsupported inputs, missing metadata, invalid overrides, and target-geometry mismatches fail before model inference with actionable errors.

## Validation

- focused dense-image suite: `89 passed, 1 deselected` before the final classifier review; final classifier regressions: `4 passed`
- full suite: `757 passed, 14 skipped`; the sole failure is the pre-existing `tests/test_dense_image_shard.py::test_multi_rank_matches_single_rank` exact CPU tensor comparison, reproduced on clean `main`
- docs: `python -m sphinx -W -b html docs ...` succeeded
- final `/code-review`: no actionable Standards or Spec findings

Closes #259