### PR TITLE
Unify dense source-spacing contracts

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -209,6 +209,28 @@ variable-size model setting:
 Region-level streaming
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+The public region entry point accepts level-0 point coordinates and the same
+optional source-spacing declaration as dense images:
+
+.. code-block:: python
+
+   from slide2vec import DenseOptions, ExecutionOptions, SlideRegions
+
+   artifacts = model.embed_regions_dense(
+       [SlideRegions(
+           sample_id="slide-1",
+           image_path="/data/slide-1.svs",
+           coordinates=[[1024, 2048], [4096, 2048]],
+           spacing_at_level_0=0.252,
+       )],
+       dense=DenseOptions(spacing_um=0.5, target_size=224),
+       execution=ExecutionOptions(output_dir="outputs"),
+   )
+
+The coordinates remain in the source level-0 pixel frame. hs2p resolves the
+source declaration, backend, level, native read spacing, and effective encoded
+spacing once per source; every fact is persisted and checked by resume.
+
 The encoder-level API above operates on tiles you have already read and
 normalized. To extract dense grids over the regions of an hs2p ``TilingResult``,
 slide2vec provides a higher-level streaming primitive,
@@ -316,8 +338,10 @@ inputs use the parent-resolved hs2p plan described below.
    model = Model.from_preset("virchow2")
    artifacts = model.embed_images_dense(
        [
-           ImageSpec(sample_id="ocelot-001", image_path="/data/ocelot/001.jpg"),
-           ImageSpec(sample_id="ocelot-002", image_path="/data/ocelot/002.jpg"),
+           ImageSpec(sample_id="ocelot-001", image_path="/data/ocelot/001.jpg",
+                     spacing_at_level_0=0.25),
+           ImageSpec(sample_id="ocelot-002", image_path="/data/ocelot/002.jpg",
+                     spacing_at_level_0=0.25),
        ],
        dense=DenseImageOptions(
            target_size=1024,
@@ -341,20 +365,17 @@ geometry, dense settings, inference precision, and stored dtype exactly match
 the current call. Missing, legacy, or incompatible pairs are recomputed, so an
 interrupted run is restarted by re-issuing the call.
 
-**Reader regimes and physical scale.** One dense-image run uses exactly one
-:term:`reader regime`; mixing regimes is rejected with samples grouped by
-regime before model loading or pixel decoding. A :term:`raster image` has one
-of the exact case-insensitive suffixes ``.png``, ``.jpg``, and ``.jpeg`` and
-uses Pillow ``convert("RGB")``. Multiple suffixes in that set may share a run.
-A positive, finite numeric ``spacing_um`` is the :term:`declared spacing` for
-raster pixels: it is checked by the normal recommended-settings policy but
-never changes the pixels. ``spacing_um=None`` records unknown spacing.
+**Source spacing and physical scale.** Every dense source uses a public hs2p
+reader. PNG/JPEG inputs use hs2p 4.4.1's one-level PIL reader; because those
+files have no reliable embedded physical spacing, their
+``ImageSpec.spacing_at_level_0`` declaration is required. Exact-spacing reads
+preserve the same RGB bytes as an unchanged Pillow read. Coarser requests use
+hs2p area downsampling; finer image requests raise under hs2p's content-aware
+no-upsampling policy. Flat and pyramidal sources may share a run.
 
-A :term:`spacing-readable image` has a format declared by an installed hs2p
-reader. Multiple spacing-readable suffixes may share a run. Here numeric
-``spacing_um`` is the declared spacing and ``None`` resolves the encoder's
-single registry default. Encoders with ambiguous or missing defaults, including
-unregistered/custom encoders, require an explicit value. The parent asks hs2p
+Numeric ``spacing_um`` is the :term:`declared spacing`; ``None`` resolves the
+encoder's single registry default. Encoders with ambiguous or missing defaults,
+including unregistered/custom encoders, require an explicit value. The parent asks hs2p
 to resolve each source's level-0 spacing, concrete backend, native read level
 and spacing, and tolerance result before resume filtering. Ranks consume that
 immutable plan: hs2p reads the complete selected level and area-downsamples only
@@ -363,10 +384,12 @@ native spacing is the :term:`effective spacing`; an area-downsampled image has
 the declared spacing as its effective spacing. Reads never upsample and an
 explicit backend never silently falls back.
 
-``ImageSpec.spacing_at_level_0`` overrides hs2p's source level-0 metadata for
-spacing-readable inputs. Without it, hs2p metadata is authoritative and missing
-spacing is an error. Raster dense extraction and :meth:`Model.embed_images`
-reject a non-null override rather than silently ignoring it.
+``ImageSpec.spacing_at_level_0`` is an optional finite positive caller
+declaration passed to hs2p. Without it, hs2p metadata is authoritative and
+missing spacing is an error. The declaration, resolved ``source_spacing_um``,
+requested ``declared_spacing_um``, and encoded-grid ``effective_spacing_um``
+remain separate values in every dense sidecar. :meth:`Model.embed_images`
+(the pooled API) retains its existing raster policy.
 
 **target_size is a declaration, not a resize.** The :term:`target size` is
 checked after the selected

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -6,24 +6,28 @@ The dense-image API uses the following terms consistently:
 .. glossary::
 
    raster image
-      A ``.png``, ``.jpg``, or ``.jpeg`` input decoded to RGB by Pillow.
-      Its pixels are already rendered at their intended scale. A declared
-      spacing records an assertion about those pixels and never resizes them.
+      A ``.png``, ``.jpg``, or ``.jpeg`` input opened by hs2p's one-level PIL
+      reader. It requires a ``spacing_at_level_0`` declaration when used by a
+      dense API because it has no reliable embedded physical spacing.
 
    spacing-readable image
       An input whose installed hs2p reader exposes physical spacing and image
       levels. slide2vec resolves one native level and may area-downsample it to
       the requested scale, but never upsamples.
 
-   reader regime
-      The single reading policy used by a dense-image run: either raster image
-      or spacing-readable image. The two regimes cannot be mixed in one call.
+   source-spacing declaration
+      Optional finite positive caller metadata named ``spacing_at_level_0`` on
+      both :class:`~slide2vec.ImageSpec` and :class:`~slide2vec.SlideRegions`.
+      It is passed to hs2p and persisted unchanged.
+
+   source spacing
+      ``source_spacing_um``: the level-0 spacing hs2p resolves after applying
+      the optional source-spacing declaration.
 
    declared spacing
-      The physical scale requested or asserted by
-      :class:`~slide2vec.DenseImageOptions`. For a raster image it is provenance
-      only; for a spacing-readable image it drives level selection and any
-      permitted area downsampling.
+      ``declared_spacing_um``: the requested run spacing from
+      :class:`~slide2vec.DenseImageOptions` or :class:`~slide2vec.DenseOptions`.
+      It drives level selection and any permitted area downsampling.
 
    effective spacing
       The physical scale of the pixels handed to the encoder. It is the accepted

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -235,6 +235,41 @@ recorded, never validated: the caller supplied pixels it never requested, so
 there is no request to check it against.
 
 
+Dense Region Grids
+------------------
+
+:meth:`~slide2vec.Model.embed_regions_dense` writes one payload and sidecar per
+level-0 point coordinate under
+``dense_embeddings/[<annotation>/]<sample_id>/<x>_<y>``. Region resume compares
+the sidecar's ``compatibility`` object, rather than trusting sidecar presence.
+It contains the same source/read geometry vocabulary as dense images:
+
+.. code-block:: json
+
+   {
+     "reader_regime": "spacing-readable",
+     "spacing_source": "explicit",
+     "spacing_at_level_0": null,
+     "source_spacing_um": 0.252,
+     "declared_spacing_um": 0.5,
+     "read_spacing_um": 0.504,
+     "effective_spacing_um": 0.504,
+     "requested_backend": "auto",
+     "backend": "vips",
+     "tolerance": 0.05,
+     "read_level": 1,
+     "is_within_tolerance": true,
+     "read_size": [224, 224],
+     "output_size": [224, 224]
+   }
+
+``spacing_at_level_0`` is the optional caller declaration;
+``source_spacing_um`` is hs2p's resolved source level-0 spacing;
+``declared_spacing_um`` is the requested run spacing; and
+``effective_spacing_um`` is the spacing of the encoded grid. Changing the
+declaration or any resolved read-plan field invalidates region resume.
+
+
 Dense Image Grids
 -----------------
 
@@ -272,20 +307,20 @@ payload.
      "encoder_name": "virchow2",
      "encoder_level": "tile",
      "encoder_input_regime": "declared",
-     "reader_regime": "raster",
+     "reader_regime": "spacing-readable",
      "spacing_source": "explicit",
      "declared_spacing_um": 0.5,
-     "source_spacing_um": 0.5,
-     "spacing_at_level_0": null,
-     "read_spacing_um": null,
+     "source_spacing_um": 0.25,
+     "spacing_at_level_0": 0.25,
+     "read_spacing_um": 0.25,
      "effective_spacing_um": 0.5,
      "requested_backend": "auto",
      "backend": "pil",
-     "tolerance": null,
-     "read_level": null,
-     "is_within_tolerance": null,
-     "read_size": null,
-     "output_size": null,
+     "tolerance": 0.05,
+     "read_level": 0,
+     "is_within_tolerance": false,
+     "read_size": [2048, 2048],
+     "output_size": [1024, 1024],
      "read_tile_size_px": null,
      "requested_tile_size_px": null,
      "image_path": "/data/ocelot/001.jpg",
@@ -309,20 +344,20 @@ payload.
        "image_path": "/data/ocelot/001.jpg",
        "encoder_name": "virchow2",
        "output_variant": "cls_patch_mean",
-       "reader_regime": "raster",
+       "reader_regime": "spacing-readable",
        "spacing_source": "explicit",
        "declared_spacing_um": 0.5,
-       "source_spacing_um": 0.5,
-       "spacing_at_level_0": null,
-       "read_spacing_um": null,
+       "source_spacing_um": 0.25,
+       "spacing_at_level_0": 0.25,
+       "read_spacing_um": 0.25,
        "effective_spacing_um": 0.5,
        "requested_backend": "auto",
        "backend": "pil",
-       "tolerance": null,
-       "read_level": null,
-       "is_within_tolerance": null,
-       "read_size": null,
-       "output_size": null,
+       "tolerance": 0.05,
+       "read_level": 0,
+       "is_within_tolerance": false,
+       "read_size": [2048, 2048],
+       "output_size": [1024, 1024],
        "read_tile_size_px": null,
        "requested_tile_size_px": null,
        "target_size": [1024, 1024],
@@ -351,12 +386,11 @@ precision; and stored dtype. GPU count, batch size, workers, prefetching, output
 directory, and other execution mechanics are deliberately excluded.
 ``encoder_input_regime`` is ``"declared"`` — unlike a pooled image embedding,
 this run *stated* its geometry and it was validated before any image was read.
-For raster inputs, ``reader_regime="raster"`` and ``backend="pil"`` record the
-unchanged Pillow RGB path. Explicit spacing repeats the caller's assertion in
-``declared_spacing_um``, ``source_spacing_um``, and ``effective_spacing_um``;
-unknown spacing records all three as ``null`` with
-``spacing_source="unknown"``. Pyramid-plan fields stay ``null`` because no
-level was selected and no spacing-driven resize occurred.
+For PNG/JPEG inputs, ``reader_regime="spacing-readable"`` and ``backend="pil"``
+record hs2p's one-level PIL path. ``spacing_at_level_0`` is required when the
+source has no embedded spacing. An exact-spacing read is byte-identical to the
+unchanged Pillow RGB read; a coarser request records level 0 as the read and the
+truthful downsampled ``output_size`` and ``effective_spacing_um``.
 
 For spacing-readable inputs, the compatibility object records the complete
 parent-resolved hs2p plan. For example, a source whose level-0 spacing is

--- a/docs/release-notes/5.6.0.rst
+++ b/docs/release-notes/5.6.0.rst
@@ -7,10 +7,16 @@ Dense-image migration
 soma can replace its private dense image reader and extraction loop with
 ``Model.embed_images_dense``. Keep the encoder, reader backend, batch size,
 precision, output dtype, inputs, dense options, and model output variant fixed
-while validating the migration. Raster image recipes preserve Pillow RGB
-pixels and dense-grid geometry. For a spacing-readable image, slide2vec uses a
-parent-resolved hs2p plan; native-level and area-downsampled reads match soma's
-current hs2p reader byte-for-byte.
+while validating the migration. PNG/JPEG sources use hs2p 4.4.1's one-level
+PIL reader: exact-spacing reads preserve Pillow RGB pixels, while coarser
+requests may area-downsample. Pyramidal sources use the same parent-resolved
+hs2p contract. Finer image requests remain forbidden.
+
+Both ``ImageSpec`` and ``SlideRegions`` accept the optional finite positive
+``spacing_at_level_0`` caller declaration. Dense image and region sidecars keep
+that declaration distinct from resolved ``source_spacing_um``, requested
+``declared_spacing_um``, and encoded-grid ``effective_spacing_um``. Those values
+and the full resolved read plan participate in resume compatibility.
 
 One-GPU and multi-GPU extraction preserve input order, artifact shapes and
 dtypes, metadata, and finite outputs. Corresponding grids are compared in
@@ -40,7 +46,7 @@ Scope
 -----
 
 This release does not add supervision-mask I/O, spacing-aware
-``Model.embed_images``, mixed reader regimes, per-image requested spacing,
-raster spacing resize, fit-to-target resize, upsampling, a new backend
+``Model.embed_images``, per-image requested spacing, fit-to-target resize,
+upsampling, a new backend
 priority, source hashing, heterogeneous target sizes, or cross-GPU bit
 identity.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.0",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.1",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -88,7 +88,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.0",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.1",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -43,6 +43,8 @@ PathLike = str | Path
 def _validated_spacing_at_level_0(value: float | None) -> float | None:
     if value is None:
         return None
+    if isinstance(value, bool):
+        raise ValueError("spacing_at_level_0 must be a positive, finite value or None")
     spacing = float(value)
     if not math.isfinite(spacing) or spacing <= 0:
         raise ValueError("spacing_at_level_0 must be a positive, finite value or None")

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -1,6 +1,7 @@
 
 import copy
 import logging
+import math
 import os
 from dataclasses import dataclass, field, replace
 from contextlib import contextmanager
@@ -37,6 +38,15 @@ from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 from slide2vec.utils.utils import cpu_worker_limit, slurm_cpu_limit
 
 PathLike = str | Path
+
+
+def _validated_spacing_at_level_0(value: float | None) -> float | None:
+    if value is None:
+        return None
+    spacing = float(value)
+    if not math.isfinite(spacing) or spacing <= 0:
+        raise ValueError("spacing_at_level_0 must be a positive, finite value or None")
+    return spacing
 
 
 class SlideLike(Protocol):
@@ -446,16 +456,15 @@ class DenseOptions:
 class DenseImageOptions:
     """Dense ``(d, gh, gw)`` extraction over pre-cropped images.
 
-    One run has one reader regime. ``.png``, ``.jpg``, and ``.jpeg`` inputs
-    (case-insensitive) use Pillow and treat numeric ``spacing_um`` as an assertion about
-    unchanged pixels. hs2p-supported WSI formats form the spacing-readable regime: hs2p
-    resolves source spacing, backend, pyramid level, tolerance, complete-extent read, and
-    area downsampling at the one requested run-level ``spacing_um``. Omitted spacing resolves
-    the encoder's single registry default for spacing-readable inputs and requires an
-    explicit value when no default is available.
+    Every supported source uses hs2p's spacing-aware reader contract. ``.png``, ``.jpg``,
+    and ``.jpeg`` inputs use hs2p's one-level PIL reader and therefore require
+    ``ImageSpec.spacing_at_level_0``; WSI readers may resolve native metadata instead.
+    hs2p resolves source spacing, backend, pyramid level, tolerance, complete-extent read,
+    and permitted area downsampling at the requested run-level ``spacing_um``. Omitted
+    spacing resolves the encoder's single registry default.
 
-    ``ImageSpec.spacing_at_level_0`` overrides level-0 metadata only for spacing-readable
-    sources. ``target_size`` is always a strict post-read declaration, never a fit-to-size
+    ``ImageSpec.spacing_at_level_0`` is the optional caller declaration used by hs2p when
+    resolving level-0 spacing. ``target_size`` is always a strict post-read declaration, never a fit-to-size
     request: each final pixel array must already be exactly this size. Declaring it up front
     lets the effective encoder input be validated (and variable-input constructor settings
     resolved) before model loading or pixel decoding. Differing final geometries therefore
@@ -465,9 +474,8 @@ class DenseImageOptions:
     #: Supervision geometry in pixels the dense grid registers to: a square side length, or
     #: an explicit ``(height, width)`` for non-square images.
     target_size: int | tuple[int, int]
-    #: Positive, finite run-level spacing in µm/px: asserted for raster pixels and requested
-    #: for spacing-readable reads. ``None`` is unknown for raster and resolves the encoder's
-    #: single registry default for spacing-readable inputs.
+    #: Positive, finite requested run spacing in µm/px. ``None`` resolves the encoder's
+    #: single registry default.
     spacing_um: float | None = None
     #: Relative spacing tolerance used by hs2p for spacing-readable level selection; raster
     #: reads have no tolerance result.
@@ -502,7 +510,9 @@ class SlideRegions:
     The dense input unit soma's slide-manifest path hands to
     :meth:`Model.embed_regions_dense`. ``coordinates`` is an ``(N, 2)`` array of level-0
     top-left ``(x, y)`` pixel coordinates; each ROI is read + encoded into one persisted
-    ``(d, gh, gw)`` grid named ``<x>_<y>.pt``. ``annotation`` namespaces the output under a
+    ``(d, gh, gw)`` grid named ``<x>_<y>.pt``. ``spacing_at_level_0`` optionally declares
+    the source image's level-0 spacing when metadata is missing or must be overridden.
+    ``annotation`` namespaces the output under a
     per-class subdirectory (reusing the pooled convention); ``None`` is the flat layout.
     """
 
@@ -510,6 +520,15 @@ class SlideRegions:
     image_path: PathLike
     coordinates: Any
     annotation: str | None = None
+    #: Optional caller declaration for the source's level-0 spacing in µm/px.
+    spacing_at_level_0: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "spacing_at_level_0",
+            _validated_spacing_at_level_0(self.spacing_at_level_0),
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -517,18 +536,24 @@ class ImageSpec:
     """One named image source: ``(sample_id, image_path, spacing_at_level_0)``.
 
     The input unit of :meth:`Model.embed_images` — the Given-geometry counterpart of
-    :class:`SlideRegions`. ``spacing_at_level_0`` represents caller metadata for
-    spacing-readable image sources. The current raster paths reject a non-null value: a
-    pre-cropped PNG/JPEG has no slide pyramid or level-0 read plan to override. ``sample_id``
+    :class:`SlideRegions`. ``spacing_at_level_0`` is the optional finite positive caller
+    declaration used by hs2p to resolve source level-0 spacing. Flat PNG/JPEG sources have
+    no embedded spacing and therefore require it for dense extraction. ``sample_id``
     is the artifact's whole identity, so it must be unique within a run and a valid filename
     component.
     """
 
     sample_id: str
     image_path: PathLike
-    #: Optional caller override for the source's level-0 spacing. Raster image paths reject
-    #: non-null overrides because they have no slide pyramid or level-0 read plan.
+    #: Optional caller declaration for the source's level-0 spacing in µm/px.
     spacing_at_level_0: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "spacing_at_level_0",
+            _validated_spacing_at_level_0(self.spacing_at_level_0),
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -832,7 +857,8 @@ class Model:
         dense transform, and written to ``dense_embeddings/[<class>/]<sample_id>/<x>_<y>.pt``
         plus a geometry sidecar. The run splits its ROIs across all visible GPUs
         (``execution.num_gpus``); ``num_gpus=1`` encodes fully in-process. Resume is
-        automatic — ROIs whose sidecar already exists are skipped. Returns one
+        automatic — only ROIs whose sidecar has the same source-spacing declaration and
+        resolved hs2p read plan are skipped. Returns one
         :class:`~slide2vec.artifacts.DenseRegionArtifact` per input ROI.
 
         The effective encoder input — the padded ROI for a whole-tile run, one
@@ -869,16 +895,14 @@ class Model:
         identity and complete extraction recipe. Returns one
         :class:`~slide2vec.artifacts.DenseImageArtifact` per input image, in input order.
 
-        One run uses one reader regime. Raster inputs are exactly ``.png``, ``.jpg``, and
-        ``.jpeg`` (case-insensitive) and always use Pillow's RGB decoder.
-        ``dense.spacing_um`` asserts the scale those unchanged pixels already have; ``None``
-        records unknown spacing. hs2p-supported WSI inputs are spacing-readable:
+        Every source is opened through hs2p. PNG/JPEG inputs use hs2p's one-level PIL reader
+        and require ``ImageSpec.spacing_at_level_0`` because they have no embedded spacing.
         ``dense.spacing_um`` requests one physical read scale, or ``None`` resolves the
         encoder's single registry default. The parent resolves each source's metadata,
         concrete backend, native level, tolerance result, and final geometry before resume;
         hs2p reads that complete level and area-downsamples when required, but never
-        upsamples. ``ImageSpec.spacing_at_level_0`` overrides source metadata only in this
-        spacing-readable regime and is rejected for raster inputs.
+        upsamples. ``ImageSpec.spacing_at_level_0`` is preserved separately from the
+        resolved source spacing and is passed to every hs2p backend.
 
         Everything after reading is shared with the slide path, including the effective encoder input — the padded image
         for a whole-image run, one patch-aligned window for a sliding one — which is declared

--- a/slide2vec/data/tile_reader.py
+++ b/slide2vec/data/tile_reader.py
@@ -325,6 +325,7 @@ class WSIRegionReader:
             self._resize_to_px if self._resize_to_px is not None else self._region_size_px
         )
         self._reader = None
+        self._pil_rgb = None
 
     def _ensure_open(self) -> None:
         if self._reader is None:
@@ -341,8 +342,34 @@ class WSIRegionReader:
                     spacing_override=self._spacing_at_level_0,
                     gpu_decode=self._gpu_decode,
                 )
+            if self._backend == "pil":
+                from PIL import Image
+
+                with Image.open(self._image_path) as image:
+                    self._pil_rgb = image.convert("RGB")
 
     def _read_regions_batch(self, locations: list[tuple[int, int]]) -> list[np.ndarray]:
+        if self._backend == "pil":
+            if self._pil_rgb is None:
+                raise RuntimeError("PIL dense region reader was not initialized")
+            size = self._region_size_px
+            width, height = self._pil_rgb.size
+            regions = []
+            for x, y in locations:
+                left, top = max(0, x), max(0, y)
+                right, bottom = min(width, x + size), min(height, y + size)
+                canvas = np.full((size, size, 3), 255, dtype=np.uint8)
+                if right > left and bottom > top:
+                    crop = np.asarray(
+                        self._pil_rgb.crop((left, top, right, bottom)),
+                        dtype=np.uint8,
+                    )
+                    canvas[
+                        top - y : bottom - y,
+                        left - x : right - x,
+                    ] = crop
+                regions.append(canvas)
+            return regions
         if self._backend == "cucim":
             return list(
                 self._reader.read_regions(

--- a/slide2vec/data/tile_reader.py
+++ b/slide2vec/data/tile_reader.py
@@ -310,6 +310,7 @@ class WSIRegionReader:
         gpu_decode: bool = False,
         resize_to_px: int | None = None,
         interpolation: str = "area",
+        spacing_at_level_0: float | None = None,
     ):
         self._image_path = str(image_path)
         self._backend = backend
@@ -319,6 +320,7 @@ class WSIRegionReader:
         self._region_size_px = int(region_size_px)
         self._resize_to_px = int(resize_to_px) if resize_to_px is not None else None
         self._interpolation = interpolation
+        self._spacing_at_level_0 = spacing_at_level_0
         self._out_size_px = (
             self._resize_to_px if self._resize_to_px is not None else self._region_size_px
         )
@@ -326,7 +328,19 @@ class WSIRegionReader:
 
     def _ensure_open(self) -> None:
         if self._reader is None:
-            self._reader = _open_wsi_backend(self._image_path, self._backend, self._gpu_decode)
+            if self._spacing_at_level_0 is None:
+                self._reader = _open_wsi_backend(
+                    self._image_path, self._backend, self._gpu_decode
+                )
+            else:
+                from hs2p.wsi.reader import open_slide
+
+                self._reader = open_slide(
+                    self._image_path,
+                    backend=self._backend,
+                    spacing_override=self._spacing_at_level_0,
+                    gpu_decode=self._gpu_decode,
+                )
 
     def _read_regions_batch(self, locations: list[tuple[int, int]]) -> list[np.ndarray]:
         if self._backend == "cucim":

--- a/slide2vec/runtime/dense_image_reading.py
+++ b/slide2vec/runtime/dense_image_reading.py
@@ -155,23 +155,17 @@ def resolve_spacing_read_plan(
     )
     try:
         source_spacing_um = float(reader.spacing)
-        level_selection = hs2p_geometry.select_level(
+        level_selection = hs2p_geometry.select_level_for_spacing_read(
             requested_spacing_um=float(requested_spacing_um),
             level0_spacing_um=source_spacing_um,
             level_downsamples=list(reader.level_downsamples),
             tolerance=float(tolerance),
+            content_kind="image",
         )
         read_width, read_height = reader.level_dimensions[level_selection.level]
     finally:
         reader.close()
 
-    if not level_selection.is_within_tolerance and float(
-        level_selection.read_spacing_um
-    ) > float(requested_spacing_um):
-        raise RuntimeError(
-            "hs2p selected a level coarser than the requested spacing outside tolerance; "
-            "refusing to upsample."
-        )
     if level_selection.is_within_tolerance:
         output_height, output_width = int(read_height), int(read_width)
         effective_spacing_um = float(level_selection.read_spacing_um)
@@ -196,6 +190,64 @@ def resolve_spacing_read_plan(
         is_within_tolerance=bool(level_selection.is_within_tolerance),
         read_size=(int(read_height), int(read_width)),
         output_size=(output_height, output_width),
+    )
+
+
+def resolve_region_read_plan(
+    image_path: str | Path,
+    *,
+    spacing_at_level_0: float | None,
+    requested_spacing_um: float,
+    target_size_px: int,
+    requested_backend: str,
+    tolerance: float,
+) -> DenseImageReadPlan:
+    """Resolve a dense ROI read through the same public hs2p source contract."""
+    path = Path(image_path)
+    selection = hs2p_reader.resolve_backend(
+        requested_backend,
+        wsi_path=path,
+        spacing_override=spacing_at_level_0,
+    )
+    reader = hs2p_reader.open_slide(
+        str(path),
+        backend=selection.backend,
+        spacing_override=spacing_at_level_0,
+    )
+    try:
+        source_spacing_um = float(reader.spacing)
+        plan = hs2p_geometry.plan_spacing_read(
+            requested_spacing_um=float(requested_spacing_um),
+            level0_spacing_um=source_spacing_um,
+            level_downsamples=list(reader.level_downsamples),
+            target_size_px=(int(target_size_px), int(target_size_px)),
+            tolerance=float(tolerance),
+            content_kind="image",
+        )
+    finally:
+        reader.close()
+
+    read_width, read_height = plan.read_size_px
+    effective_spacing_um = (
+        float(plan.read_spacing_um)
+        if plan.is_within_tolerance
+        else float(requested_spacing_um)
+    )
+    return DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source="explicit",
+        declared_spacing_um=float(requested_spacing_um),
+        source_spacing_um=source_spacing_um,
+        spacing_at_level_0=_optional_float(spacing_at_level_0),
+        read_spacing_um=float(plan.read_spacing_um),
+        effective_spacing_um=effective_spacing_um,
+        requested_backend=str(requested_backend),
+        backend=str(selection.backend),
+        tolerance=float(tolerance),
+        read_level=int(plan.level),
+        is_within_tolerance=bool(plan.is_within_tolerance),
+        read_size=(int(read_height), int(read_width)),
+        output_size=(int(target_size_px), int(target_size_px)),
     )
 
 

--- a/slide2vec/runtime/dense_image_reading.py
+++ b/slide2vec/runtime/dense_image_reading.py
@@ -271,15 +271,22 @@ def read_dense_image(
             raise ValueError(
                 f"Incomplete spacing-readable plan for sample {spec.sample_id!r}"
             )
-        reader = hs2p_reader.open_slide(
-            str(spec.image_path),
-            backend=plan.backend,
-            spacing_override=plan.spacing_at_level_0,
-        )
-        try:
-            pixels = np.asarray(reader.read_level(plan.read_level))
-        finally:
-            reader.close()
+        if plan.backend == "pil":
+            # hs2p's PIL reader intentionally preserves label modes as index arrays.
+            # Dense image encoding is RGB content, so retain the source palette/mode
+            # semantics of the pre-contract Pillow ``convert("RGB")`` read.
+            with Image.open(spec.image_path) as image:
+                pixels = np.asarray(image.convert("RGB"))
+        else:
+            reader = hs2p_reader.open_slide(
+                str(spec.image_path),
+                backend=plan.backend,
+                spacing_override=plan.spacing_at_level_0,
+            )
+            try:
+                pixels = np.asarray(reader.read_level(plan.read_level))
+            finally:
+                reader.close()
         observed_native = tuple(int(size) for size in pixels.shape[:2])
         if observed_native != plan.read_size:
             raise ValueError(

--- a/slide2vec/runtime/dense_image_recipe.py
+++ b/slide2vec/runtime/dense_image_recipe.py
@@ -33,8 +33,12 @@ def malformed_dense_image_compatibility_fields(
             continue
         reference = expected[field]
         valid = True
-        if field == "window_size":
+        if field in {"window_size", "spacing_at_level_0"}:
             valid = value is None or is_int(value)
+            if field == "spacing_at_level_0":
+                valid = value is None or (
+                    isinstance(value, (int, float)) and not isinstance(value, bool)
+                )
         elif field == "image_pad_value":
             valid = value is None or (
                 isinstance(value, (int, float)) and not isinstance(value, bool)

--- a/slide2vec/runtime/dense_image_shard.py
+++ b/slide2vec/runtime/dense_image_shard.py
@@ -7,8 +7,8 @@ grid plus one geometry sidecar per image. It is device-agnostic and ``RANK``-fre
 very same code path runs in-process for ``num_gpus=1`` and on every torchrun rank — and is
 exercised on CPU.
 
-Raster images are decoded unchanged through Pillow. Spacing-readable images consume the
-parent-resolved immutable hs2p plan: a concrete backend reads the stored full level and hs2p
+All public dense sources consume a parent-resolved immutable hs2p plan: a concrete backend
+reads the stored full level and hs2p
 area-downsamples to the stored output geometry when required, without rank-side selection.
 Everything after the pixels arrive — geometry, padding, whole-tile vs sliding encode, output
 dtype — is

--- a/slide2vec/runtime/dense_image_stage.py
+++ b/slide2vec/runtime/dense_image_stage.py
@@ -49,11 +49,7 @@ from slide2vec.runtime.dense_image_recipe import (
     DenseImageRecipe,
     resolve_dense_image_recipe,
 )
-from slide2vec.runtime.dense_image_reading import (
-    DenseImageReadPlan,
-    raster_read_plan,
-    resolve_spacing_read_plan,
-)
+from slide2vec.runtime.dense_image_reading import DenseImageReadPlan, resolve_spacing_read_plan
 from slide2vec.runtime.dense_stage import resolve_output_torch_dtype
 from slide2vec.runtime.distributed import (
     distributed_coordination_dir,
@@ -64,7 +60,6 @@ from slide2vec.runtime.distributed_stage import validate_multi_gpu_execution
 from slide2vec.runtime.image_specs import (
     build_image_specs_request,
     normalize_image_specs,
-    reject_image_level0_spacing_overrides,
     validate_dense_image_reader_regime,
 )
 from slide2vec.runtime.serialization import (
@@ -116,28 +111,19 @@ def embed_images_dense(
         artifact_location="dense_image_embeddings/<sample_id>",
     )
     reader_regime, probed_auto_backends = validate_dense_image_reader_regime(specs)
-    if reader_regime == "raster":
-        reject_image_level0_spacing_overrides(
-            specs, method_name="embed_images_dense()"
-        )
     spacing_source = "explicit"
     if dense.spacing_um is None:
-        if reader_regime == "spacing-readable":
-            try:
-                spacing_um = float(
-                    resolve_preprocessing_defaults(model.name)["spacing_um"]
-                )
-            except (KeyError, ValueError) as exc:
-                raise ValueError(
-                    "DenseImageOptions.spacing_um must be explicit for spacing-readable "
-                    f"inputs when encoder {model.name!r} has no single resolvable model "
-                    f"default: {exc}"
-                ) from exc
-            spacing_source = "model_default"
-            dense = replace(dense, spacing_um=spacing_um)
-        else:
-            spacing_um = None
-            spacing_source = "unknown"
+        try:
+            spacing_um = float(
+                resolve_preprocessing_defaults(model.name)["spacing_um"]
+            )
+        except (KeyError, ValueError) as exc:
+            raise ValueError(
+                "DenseImageOptions.spacing_um must be explicit when encoder "
+                f"{model.name!r} has no single resolvable model default: {exc}"
+            ) from exc
+        spacing_source = "model_default"
+        dense = replace(dense, spacing_um=spacing_um)
     else:
         spacing_um = float(dense.spacing_um)
     if spacing_um is not None and (not math.isfinite(spacing_um) or spacing_um <= 0):
@@ -162,29 +148,24 @@ def embed_images_dense(
         reader_regime=reader_regime,
         spacing_source=spacing_source,
     )
-    if reader_regime == "raster":
-        shared_read_plan = raster_read_plan(
+    read_plans = {
+        spec.sample_id: resolve_spacing_read_plan(
+            spec,
+            requested_spacing_um=spacing_um,
             spacing_source=spacing_source,
-            declared_spacing_um=spacing_um,
             requested_backend=dense.backend,
+            tolerance=dense.tolerance,
+            resolved_backend=(
+                probed_auto_backends.get(spec.sample_id)
+                if (
+                    dense.backend.strip().lower() == "auto"
+                    or Path(spec.image_path).suffix.lower() in {".png", ".jpg", ".jpeg"}
+                )
+                else None
+            ),
         )
-        read_plans = {spec.sample_id: shared_read_plan for spec in specs}
-    else:
-        read_plans = {
-            spec.sample_id: resolve_spacing_read_plan(
-                spec,
-                requested_spacing_um=spacing_um,
-                spacing_source=spacing_source,
-                requested_backend=dense.backend,
-                tolerance=dense.tolerance,
-                resolved_backend=(
-                    probed_auto_backends.get(spec.sample_id)
-                    if dense.backend.strip().lower() == "auto"
-                    else None
-                ),
-            )
-            for spec in specs
-        }
+        for spec in specs
+    }
     out_dir = Path(execution.output_dir).expanduser().resolve()
     execution = execution.with_output_dir(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here

--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -464,6 +464,7 @@ def iter_regions_dense(
         num_cucim_workers=int(num_workers),
         resize_to_px=requested_tile_size_px,  # area-resizes iff read != requested
         interpolation="area",
+        spacing_at_level_0=getattr(tiling_result, "spacing_at_level_0", None),
     )
 
     def _stream() -> Iterator[np.ndarray]:

--- a/slide2vec/runtime/dense_shard.py
+++ b/slide2vec/runtime/dense_shard.py
@@ -67,6 +67,14 @@ class RegionSpec:
     requested_tile_size_px: int
     backend: str
     annotation: str | None = None
+    spacing_at_level_0: float | None = None
+    source_spacing_um: float | None = None
+    declared_spacing_um: float | None = None
+    read_spacing_um: float | None = None
+    effective_spacing_um: float | None = None
+    requested_backend: str = "auto"
+    tolerance: float = 0.05
+    is_within_tolerance: bool = True
 
 
 def _slide_key(spec: RegionSpec) -> tuple:
@@ -79,7 +87,40 @@ def _slide_key(spec: RegionSpec) -> tuple:
         spec.read_tile_size_px,
         spec.requested_tile_size_px,
         spec.backend,
+        spec.spacing_at_level_0,
+        spec.source_spacing_um,
+        spec.declared_spacing_um,
+        spec.read_spacing_um,
+        spec.effective_spacing_um,
+        spec.requested_backend,
+        spec.tolerance,
+        spec.is_within_tolerance,
     )
+
+
+def region_read_compatibility(spec: RegionSpec) -> dict:
+    """Canonical source/read-plan identity used by region resume."""
+    return {
+        "reader_regime": "spacing-readable",
+        "spacing_source": "explicit",
+        "spacing_at_level_0": spec.spacing_at_level_0,
+        "source_spacing_um": spec.source_spacing_um,
+        "declared_spacing_um": spec.declared_spacing_um,
+        "read_spacing_um": spec.read_spacing_um,
+        "effective_spacing_um": spec.effective_spacing_um,
+        "requested_backend": spec.requested_backend,
+        "backend": spec.backend,
+        "tolerance": float(spec.tolerance),
+        "read_level": int(spec.read_level),
+        "is_within_tolerance": bool(spec.is_within_tolerance),
+        "read_size": [int(spec.read_tile_size_px), int(spec.read_tile_size_px)],
+        "output_size": [
+            int(spec.requested_tile_size_px),
+            int(spec.requested_tile_size_px),
+        ],
+        "read_tile_size_px": int(spec.read_tile_size_px),
+        "requested_tile_size_px": int(spec.requested_tile_size_px),
+    }
 
 
 def region_needs_encode(out_dir, spec: RegionSpec) -> bool:
@@ -91,7 +132,10 @@ def region_needs_encode(out_dir, spec: RegionSpec) -> bool:
     _, sidecar_path = region_dense_paths(
         out_dir, sample_id=spec.sample_id, annotation=spec.annotation, x=spec.x, y=spec.y
     )
-    return not sidecar_path.exists()
+    if not sidecar_path.exists():
+        return True
+    metadata = load_metadata(sidecar_path)
+    return metadata.get("compatibility") != region_read_compatibility(spec)
 
 
 def dense_artifact_from_disk(out_dir, spec) -> DenseRegionArtifact:
@@ -133,19 +177,33 @@ def _build_dense_tiling_result(specs: list[RegionSpec], dense: "DenseOptions"):
     y = np.asarray([s.y for s in specs], dtype=np.int64)
     requested = int(head.requested_tile_size_px)
     read = int(head.read_tile_size_px)
-    spacing = float(dense.spacing_um)
+    declared_spacing = (
+        float(dense.spacing_um)
+        if head.declared_spacing_um is None
+        else float(head.declared_spacing_um)
+    )
+    read_spacing = (
+        declared_spacing
+        if head.read_spacing_um is None
+        else float(head.read_spacing_um)
+    )
+    source_spacing = (
+        declared_spacing
+        if head.source_spacing_um is None
+        else float(head.source_spacing_um)
+    )
     tiles = TileGeometry(
         x=x,
         y=y,
         tissue_fractions=np.ones(len(specs), dtype=np.float32),
         requested_tile_size_px=requested,
-        requested_spacing_um=spacing,
+        requested_spacing_um=declared_spacing,
         read_level=int(head.read_level),
         read_tile_size_px=read,
-        read_spacing_um=spacing,
+        read_spacing_um=read_spacing,
         tile_size_lv0=read,
-        is_within_tolerance=True,
-        base_spacing_um=spacing,
+        is_within_tolerance=bool(head.is_within_tolerance),
+        base_spacing_um=source_spacing,
         slide_dimensions=[0, 0],
         level_downsamples=[1.0],
         overlap=0.0,
@@ -157,13 +215,13 @@ def _build_dense_tiling_result(specs: list[RegionSpec], dense: "DenseOptions"):
         image_path=head.image_path,
         backend=head.backend,
         requested_backend=head.backend,
-        tolerance=float(dense.tolerance),
+        tolerance=float(head.tolerance),
         step_px_lv0=read,
         tissue_method="none",
         requested_seg_downsample=1,
         seg_downsample=1,
         seg_level=0,
-        seg_spacing_um=spacing,
+        seg_spacing_um=source_spacing,
         seg_sthresh=0,
         seg_sthresh_up=255,
         seg_mthresh=0,
@@ -176,6 +234,7 @@ def _build_dense_tiling_result(specs: list[RegionSpec], dense: "DenseOptions"):
         white_threshold=255,
         black_threshold=0,
         fraction_threshold=0.0,
+        spacing_at_level_0=head.spacing_at_level_0,
     )
 
 
@@ -184,6 +243,7 @@ def _region_metadata(
 ) -> dict:
     """Extraction-geometry sidecar (D5/D7): geometry + encode params slide2vec owns, nothing else."""
     grid_arr = np.asarray(grid)
+    compatibility = region_read_compatibility(spec)
     return {
         "artifact_type": "dense_embeddings",
         "sample_id": spec.sample_id,
@@ -198,12 +258,7 @@ def _region_metadata(
         "patch_size": [int(geometry.patch_size[0]), int(geometry.patch_size[1])],
         "encoded_size": [int(geometry.encoded_size[0]), int(geometry.encoded_size[1])],
         "pad": [int(geometry.pad[0]), int(geometry.pad[1])],
-        "spacing_um": float(dense.spacing_um),
-        "tolerance": float(dense.tolerance),
-        "backend": spec.backend,
-        "read_level": int(spec.read_level),
-        "read_tile_size_px": int(spec.read_tile_size_px),
-        "requested_tile_size_px": int(spec.requested_tile_size_px),
+        **compatibility,
         "pad_mode": dense.pad_mode,
         "image_pad_value": dense.image_pad_value,
         "window_size": dense.window_size,
@@ -211,6 +266,7 @@ def _region_metadata(
         "feature_kind": dense.feature_kind,
         "attention_blocks": [int(b) for b in dense.attention_blocks],
         "attention_include_registers": bool(dense.attention_include_registers),
+        "compatibility": compatibility,
     }
 
 

--- a/slide2vec/runtime/dense_shard.py
+++ b/slide2vec/runtime/dense_shard.py
@@ -18,7 +18,8 @@ What this module owns is the CPU-testable encode/write layer (D12):
 
 Writes are atomic and sidecar-last (D6): payload to a temp file → ``os.replace`` into place
 → then the sidecar. So a payload with no sidecar unambiguously means an incomplete ROI, and
-resume trusts the sidecar as the done-marker. slide2vec owns the dense *write* because it
+the sidecar proves write completion; resume additionally requires its compatibility metadata
+to match the current read plan. slide2vec owns the dense *write* because it
 owns the dense *distribution* (docs/adr/0001): ranks are separate OS processes and a grid is
 ~1000× a pooled embedding, so ranks persist final artifacts directly and nobody gathers.
 """
@@ -38,6 +39,7 @@ from slide2vec.artifacts import (
     structural_artifact_annotation,
     write_dense_region,
 )
+from slide2vec.runtime.dense_image_reading import DenseImageReadPlan
 
 if TYPE_CHECKING:
     import torch
@@ -50,81 +52,56 @@ class RegionSpec:
     """One ROI (the flat sharding unit): identity + its slide's resolved read geometry.
 
     ``sample_id`` / ``annotation`` / ``(x, y)`` name the persisted artifact
-    (``dense_embeddings/[<class>/]<sample_id>/<x>_<y>.pt``) and are geometry-independent, so
-    the resume check can run before any slide is opened. ``read_level`` /
-    ``read_tile_size_px`` / ``requested_tile_size_px`` / ``backend`` are the per-slide read
-    plan the parent resolved once (via hs2p ``plan_spacing_read``); every ROI of a slide
-    carries the same values, so :func:`run_dense_shard` rebuilds the ``TilingResult`` without
-    re-opening the slide for metadata.
+    (``dense_embeddings/[<class>/]<sample_id>/<x>_<y>.pt``). ``read_plan`` is the immutable
+    source/read geometry the parent resolved once through hs2p; every ROI of a slide shares
+    that value, so ranks rebuild the ``TilingResult`` without reopening source metadata.
     """
 
     sample_id: str
     image_path: str
     x: int
     y: int
-    read_level: int
-    read_tile_size_px: int
-    requested_tile_size_px: int
-    backend: str
+    read_plan: DenseImageReadPlan
     annotation: str | None = None
-    spacing_at_level_0: float | None = None
-    source_spacing_um: float | None = None
-    declared_spacing_um: float | None = None
-    read_spacing_um: float | None = None
-    effective_spacing_um: float | None = None
-    requested_backend: str = "auto"
-    tolerance: float = 0.05
-    is_within_tolerance: bool = True
 
+    def slide_group_key(self) -> tuple:
+        """Identity for consecutive ROIs that share one source and read plan."""
+        return (self.image_path, self.sample_id, self.annotation, self.read_plan)
 
-def _slide_key(spec: RegionSpec) -> tuple:
-    """Group key: consecutive ROIs sharing this open one slide's reader + read plan."""
-    return (
-        spec.image_path,
-        spec.sample_id,
-        spec.annotation,
-        spec.read_level,
-        spec.read_tile_size_px,
-        spec.requested_tile_size_px,
-        spec.backend,
-        spec.spacing_at_level_0,
-        spec.source_spacing_um,
-        spec.declared_spacing_um,
-        spec.read_spacing_um,
-        spec.effective_spacing_um,
-        spec.requested_backend,
-        spec.tolerance,
-        spec.is_within_tolerance,
-    )
+    @property
+    def read_level(self) -> int:
+        if self.read_plan.read_level is None:
+            raise ValueError(f"Missing read level for dense region {self.sample_id!r}")
+        return int(self.read_plan.read_level)
+
+    @property
+    def read_tile_size_px(self) -> int:
+        if self.read_plan.read_size is None:
+            raise ValueError(f"Missing read size for dense region {self.sample_id!r}")
+        return int(self.read_plan.read_size[0])
+
+    @property
+    def requested_tile_size_px(self) -> int:
+        if self.read_plan.output_size is None:
+            raise ValueError(f"Missing output size for dense region {self.sample_id!r}")
+        return int(self.read_plan.output_size[0])
+
+    @property
+    def backend(self) -> str:
+        return self.read_plan.backend
 
 
 def region_read_compatibility(spec: RegionSpec) -> dict:
     """Canonical source/read-plan identity used by region resume."""
     return {
-        "reader_regime": "spacing-readable",
-        "spacing_source": "explicit",
-        "spacing_at_level_0": spec.spacing_at_level_0,
-        "source_spacing_um": spec.source_spacing_um,
-        "declared_spacing_um": spec.declared_spacing_um,
-        "read_spacing_um": spec.read_spacing_um,
-        "effective_spacing_um": spec.effective_spacing_um,
-        "requested_backend": spec.requested_backend,
-        "backend": spec.backend,
-        "tolerance": float(spec.tolerance),
-        "read_level": int(spec.read_level),
-        "is_within_tolerance": bool(spec.is_within_tolerance),
-        "read_size": [int(spec.read_tile_size_px), int(spec.read_tile_size_px)],
-        "output_size": [
-            int(spec.requested_tile_size_px),
-            int(spec.requested_tile_size_px),
-        ],
+        **spec.read_plan.to_dict(),
         "read_tile_size_px": int(spec.read_tile_size_px),
         "requested_tile_size_px": int(spec.requested_tile_size_px),
     }
 
 
 def region_needs_encode(out_dir, spec: RegionSpec) -> bool:
-    """Resume/crash-safety predicate: a ROI needs encoding iff its sidecar is absent.
+    """Return whether the ROI lacks a sidecar with the current resolved read plan.
 
     The sidecar is written last (D6), so its presence is the done-marker; a ``.pt`` with no
     sidecar is a crashed write and is re-encoded.
@@ -177,21 +154,19 @@ def _build_dense_tiling_result(specs: list[RegionSpec], dense: "DenseOptions"):
     y = np.asarray([s.y for s in specs], dtype=np.int64)
     requested = int(head.requested_tile_size_px)
     read = int(head.read_tile_size_px)
-    declared_spacing = (
-        float(dense.spacing_um)
-        if head.declared_spacing_um is None
-        else float(head.declared_spacing_um)
-    )
-    read_spacing = (
-        declared_spacing
-        if head.read_spacing_um is None
-        else float(head.read_spacing_um)
-    )
-    source_spacing = (
-        declared_spacing
-        if head.source_spacing_um is None
-        else float(head.source_spacing_um)
-    )
+    plan = head.read_plan
+
+    def required_float(field: str) -> float:
+        value = getattr(plan, field)
+        if value is None:
+            raise ValueError(
+                f"Dense region read plan for {head.sample_id!r} lacks {field}"
+            )
+        return float(value)
+
+    declared_spacing = required_float("declared_spacing_um")
+    read_spacing = required_float("read_spacing_um")
+    source_spacing = required_float("source_spacing_um")
     tiles = TileGeometry(
         x=x,
         y=y,
@@ -202,7 +177,7 @@ def _build_dense_tiling_result(specs: list[RegionSpec], dense: "DenseOptions"):
         read_tile_size_px=read,
         read_spacing_um=read_spacing,
         tile_size_lv0=read,
-        is_within_tolerance=bool(head.is_within_tolerance),
+        is_within_tolerance=bool(plan.is_within_tolerance),
         base_spacing_um=source_spacing,
         slide_dimensions=[0, 0],
         level_downsamples=[1.0],
@@ -215,7 +190,7 @@ def _build_dense_tiling_result(specs: list[RegionSpec], dense: "DenseOptions"):
         image_path=head.image_path,
         backend=head.backend,
         requested_backend=head.backend,
-        tolerance=float(head.tolerance),
+        tolerance=required_float("tolerance"),
         step_px_lv0=read,
         tissue_method="none",
         requested_seg_downsample=1,
@@ -234,7 +209,7 @@ def _build_dense_tiling_result(specs: list[RegionSpec], dense: "DenseOptions"):
         white_threshold=255,
         black_threshold=0,
         fraction_threshold=0.0,
-        spacing_at_level_0=head.spacing_at_level_0,
+        spacing_at_level_0=plan.spacing_at_level_0,
     )
 
 
@@ -286,8 +261,9 @@ def run_dense_shard(
     """Encode + persist one shard's ROIs, one ``<x>_<y>.pt`` + sidecar per ROI.
 
     Groups the shard's ROIs into contiguous per-slide runs (so each slide is opened once),
-    skips any ROI whose sidecar already exists (crash-safety / resume, D9), builds a minimal
-    ``TilingResult`` for the ROIs that remain, and streams their grids through
+    skips any ROI whose completed sidecar has compatibility metadata matching the current
+    read plan (crash-safety / resume, D9), builds a minimal ``TilingResult`` for the ROIs
+    that remain, and streams their grids through
     :func:`~slide2vec.runtime.dense_regions.iter_regions_dense` — writing each grid atomically
     and sidecar-last (D6). Device-agnostic and RANK-free: the identical loop runs in-process
     for ``num_gpus=1`` and on each rank under torchrun.
@@ -300,7 +276,7 @@ def run_dense_shard(
 
     regions = list(regions)
     artifacts: list[DenseRegionArtifact] = []
-    for _key, group_iter in groupby(regions, key=_slide_key):
+    for _key, group_iter in groupby(regions, key=RegionSpec.slide_group_key):
         group = list(group_iter)
         pending = [spec for spec in group if region_needs_encode(out_dir, spec)]
         written: dict[tuple[int, int], DenseRegionArtifact] = {}

--- a/slide2vec/runtime/dense_stage.py
+++ b/slide2vec/runtime/dense_stage.py
@@ -5,10 +5,10 @@ grids, mirroring the pooled distributed stage but writing dense artifacts direct
 ranks (slide2vec owns the dense write because it owns the dense distribution — docs/adr/0001):
 
 1. **flatten** every ``SlideRegions`` into the slide-ordered flat ROI list;
-2. **resume-filter** it (D9) — drop ROIs whose sidecar already exists, before sharding, so
-   no rank draws an all-done shard and idles; the skip count is logged;
-3. **resolve** each remaining slide's read plan once (hs2p ``plan_spacing_read`` against the
-   slide's own pyramid) into per-ROI :class:`~slide2vec.runtime.dense_shard.RegionSpec`;
+2. **resolve** each slide's source spacing and read plan once through public hs2p APIs into
+   per-ROI :class:`~slide2vec.runtime.dense_shard.RegionSpec`;
+3. **resume-filter** it (D9) — drop ROIs whose sidecar records that same declaration and
+   resolved plan before sharding, so no rank draws an all-done shard and idles;
 4. **dispatch**: ``num_gpus=1`` runs :func:`~slide2vec.runtime.dense_shard.run_dense_shard`
    fully in-process (no torchrun); ``num_gpus>1`` writes the coordinates to an npz + a JSON
    request and launches :mod:`slide2vec.distributed.dense_worker` under torchrun;
@@ -36,6 +36,10 @@ from slide2vec.runtime.dense_shard import (
     region_needs_encode,
     run_dense_shard,
 )
+from slide2vec.runtime.dense_image_reading import (
+    DenseImageReadPlan,
+    resolve_region_read_plan,
+)
 from slide2vec.runtime.distributed import (
     distributed_coordination_dir,
     reset_progress_event_logs,
@@ -61,6 +65,7 @@ class _FlatRegion:
     x: int
     y: int
     annotation: str | None
+    spacing_at_level_0: float | None
 
 
 def flatten_slide_regions(regions: Sequence) -> list[_FlatRegion]:
@@ -79,19 +84,33 @@ def flatten_slide_regions(regions: Sequence) -> list[_FlatRegion]:
         sample_id = str(slide_regions.sample_id)
         image_path = str(Path(slide_regions.image_path).expanduser().resolve())
         for x, y in coordinates:
-            flat.append(_FlatRegion(sample_id, image_path, int(x), int(y), annotation))
+            flat.append(
+                _FlatRegion(
+                    sample_id,
+                    image_path,
+                    int(x),
+                    int(y),
+                    annotation,
+                    slide_regions.spacing_at_level_0,
+                )
+            )
     return flat
 
 
 def partition_regions_by_resume(
-    flat: Sequence[_FlatRegion], out_dir
-) -> tuple[list[_FlatRegion], int]:
+    specs: Sequence[RegionSpec], out_dir
+) -> tuple[list[RegionSpec], int]:
     """Split the flat list into (needs-encode, already-on-disk-count) by sidecar existence."""
-    remaining = [region for region in flat if region_needs_encode(out_dir, region)]
-    return remaining, len(flat) - len(remaining)
+    remaining = [spec for spec in specs if region_needs_encode(out_dir, spec)]
+    return remaining, len(specs) - len(remaining)
 
 
-def resolve_slide_read_plan(image_path: str, dense) -> tuple[int, int, str]:
+def resolve_slide_read_plan(
+    image_path: str,
+    dense,
+    *,
+    spacing_at_level_0: float | None = None,
+) -> DenseImageReadPlan:
     """Resolve one slide's ``(read_level, read_tile_size_px, resolved_backend)`` for ``dense``.
 
     Opens the slide once (hs2p ``WSI``) to read its level-0 spacing + pyramid and runs the
@@ -99,18 +118,14 @@ def resolve_slide_read_plan(image_path: str, dense) -> tuple[int, int, str]:
     tiling path uses. This is the only step that opens a slide for metadata; it never runs on
     the CPU test path (the encode/read seam is faked separately).
     """
-    from hs2p.wsi.geometry import plan_spacing_read
-    from hs2p.wsi.wsi import WSI
-
-    wsi = WSI(Path(image_path), backend=dense.backend)
-    plan = plan_spacing_read(
+    return resolve_region_read_plan(
+        image_path,
+        spacing_at_level_0=spacing_at_level_0,
         requested_spacing_um=float(dense.spacing_um),
-        level0_spacing_um=float(wsi.get_level_spacing(0)),
-        level_downsamples=list(wsi.level_downsamples),
-        target_size_px=(int(dense.target_size), int(dense.target_size)),
+        target_size_px=int(dense.target_size),
+        requested_backend=str(dense.backend),
         tolerance=float(dense.tolerance),
     )
-    return int(plan.level), int(plan.read_size_px[0]), str(wsi.backend)
 
 
 def resolve_region_specs(flat: Sequence[_FlatRegion], dense) -> list[RegionSpec]:
@@ -119,25 +134,40 @@ def resolve_region_specs(flat: Sequence[_FlatRegion], dense) -> list[RegionSpec]
     The read plan is resolved once per unique slide (cached), so a slide's ROIs share one
     ``plan_spacing_read`` call; ordering is untouched so downstream sharding stays contiguous.
     """
-    plans: dict[str, tuple[int, int, str]] = {}
+    plans: dict[tuple[str, float | None], DenseImageReadPlan] = {}
     specs: list[RegionSpec] = []
     for region in flat:
-        plan = plans.get(region.image_path)
+        plan_key = (region.image_path, region.spacing_at_level_0)
+        plan = plans.get(plan_key)
         if plan is None:
-            plan = resolve_slide_read_plan(region.image_path, dense)
-            plans[region.image_path] = plan
-        read_level, read_tile_size_px, backend = plan
+            plan = resolve_slide_read_plan(
+                region.image_path,
+                dense,
+                spacing_at_level_0=region.spacing_at_level_0,
+            )
+            plans[plan_key] = plan
+        if plan.read_level is None or plan.read_size is None:
+            raise ValueError(f"Incomplete dense region read plan for {region.image_path}")
+        read_tile_size_px = int(plan.read_size[0])
         specs.append(
             RegionSpec(
                 sample_id=region.sample_id,
                 image_path=region.image_path,
                 x=region.x,
                 y=region.y,
-                read_level=read_level,
+                read_level=int(plan.read_level),
                 read_tile_size_px=read_tile_size_px,
                 requested_tile_size_px=int(dense.target_size),
-                backend=backend,
+                backend=plan.backend,
                 annotation=region.annotation,
+                spacing_at_level_0=plan.spacing_at_level_0,
+                source_spacing_um=plan.source_spacing_um,
+                declared_spacing_um=plan.declared_spacing_um,
+                read_spacing_um=plan.read_spacing_um,
+                effective_spacing_um=plan.effective_spacing_um,
+                requested_backend=plan.requested_backend,
+                tolerance=float(plan.tolerance),
+                is_within_tolerance=bool(plan.is_within_tolerance),
             )
         )
     return specs
@@ -169,7 +199,8 @@ def embed_regions_dense(
     execution = execution.with_output_dir(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)  # coordination dir + artifacts live under here
     flat = flatten_slide_regions(regions)
-    remaining, skipped = partition_regions_by_resume(flat, out_dir)
+    specs = resolve_region_specs(flat, dense)
+    remaining, skipped = partition_regions_by_resume(specs, out_dir)
     if skipped:
         logger.info(
             "resume: %s/%s regions already on disk, encoding %s",
@@ -183,11 +214,10 @@ def embed_regions_dense(
         num_gpus=execution.num_gpus,
     )
     if remaining:
-        specs = resolve_region_specs(remaining, dense)
         if execution.num_gpus == 1:
-            _run_dense_in_process(model, specs, dense=dense, execution=execution, out_dir=out_dir)
+            _run_dense_in_process(model, remaining, dense=dense, execution=execution, out_dir=out_dir)
         else:
-            _run_dense_distributed(model, specs, dense=dense, execution=execution, out_dir=out_dir)
+            _run_dense_distributed(model, remaining, dense=dense, execution=execution, out_dir=out_dir)
     emit_progress("dense.regions.finished", total=len(flat))
     return [dense_artifact_from_disk(out_dir, region) for region in flat]
 
@@ -220,6 +250,14 @@ def _slide_group_key(spec: RegionSpec) -> tuple:
         spec.read_tile_size_px,
         spec.requested_tile_size_px,
         spec.backend,
+        spec.spacing_at_level_0,
+        spec.source_spacing_um,
+        spec.declared_spacing_um,
+        spec.read_spacing_um,
+        spec.effective_spacing_um,
+        spec.requested_backend,
+        spec.tolerance,
+        spec.is_within_tolerance,
     )
 
 
@@ -244,6 +282,14 @@ def build_dense_worker_request(specs: Sequence[RegionSpec], *, coordinates_npz_p
                 "read_tile_size_px": int(head.read_tile_size_px),
                 "requested_tile_size_px": int(head.requested_tile_size_px),
                 "backend": head.backend,
+                "spacing_at_level_0": head.spacing_at_level_0,
+                "source_spacing_um": head.source_spacing_um,
+                "declared_spacing_um": head.declared_spacing_um,
+                "read_spacing_um": head.read_spacing_um,
+                "effective_spacing_um": head.effective_spacing_um,
+                "requested_backend": head.requested_backend,
+                "tolerance": head.tolerance,
+                "is_within_tolerance": head.is_within_tolerance,
                 "num_regions": len(group),
             }
         )
@@ -273,6 +319,14 @@ def region_specs_from_request(request: dict) -> list[RegionSpec]:
                     requested_tile_size_px=int(slide["requested_tile_size_px"]),
                     backend=str(slide["backend"]),
                     annotation=slide["annotation"],
+                    spacing_at_level_0=slide.get("spacing_at_level_0"),
+                    source_spacing_um=slide.get("source_spacing_um"),
+                    declared_spacing_um=slide.get("declared_spacing_um"),
+                    read_spacing_um=slide.get("read_spacing_um"),
+                    effective_spacing_um=slide.get("effective_spacing_um"),
+                    requested_backend=str(slide.get("requested_backend", "auto")),
+                    tolerance=float(slide.get("tolerance", 0.05)),
+                    is_within_tolerance=bool(slide.get("is_within_tolerance", True)),
                 )
             )
         offset += count

--- a/slide2vec/runtime/dense_stage.py
+++ b/slide2vec/runtime/dense_stage.py
@@ -100,7 +100,7 @@ def flatten_slide_regions(regions: Sequence) -> list[_FlatRegion]:
 def partition_regions_by_resume(
     specs: Sequence[RegionSpec], out_dir
 ) -> tuple[list[RegionSpec], int]:
-    """Split the flat list into (needs-encode, already-on-disk-count) by sidecar existence."""
+    """Split specs by whether the sidecar matches the resolved read plan."""
     remaining = [spec for spec in specs if region_needs_encode(out_dir, spec)]
     return remaining, len(specs) - len(remaining)
 
@@ -111,7 +111,7 @@ def resolve_slide_read_plan(
     *,
     spacing_at_level_0: float | None = None,
 ) -> DenseImageReadPlan:
-    """Resolve one slide's ``(read_level, read_tile_size_px, resolved_backend)`` for ``dense``.
+    """Resolve one slide's immutable dense-region read plan through public hs2p APIs.
 
     Opens the slide once (hs2p ``WSI``) to read its level-0 spacing + pyramid and runs the
     shared ``plan_spacing_read`` kernel — the identical spacing→level resolution the pooled
@@ -148,26 +148,14 @@ def resolve_region_specs(flat: Sequence[_FlatRegion], dense) -> list[RegionSpec]
             plans[plan_key] = plan
         if plan.read_level is None or plan.read_size is None:
             raise ValueError(f"Incomplete dense region read plan for {region.image_path}")
-        read_tile_size_px = int(plan.read_size[0])
         specs.append(
             RegionSpec(
                 sample_id=region.sample_id,
                 image_path=region.image_path,
                 x=region.x,
                 y=region.y,
-                read_level=int(plan.read_level),
-                read_tile_size_px=read_tile_size_px,
-                requested_tile_size_px=int(dense.target_size),
-                backend=plan.backend,
+                read_plan=plan,
                 annotation=region.annotation,
-                spacing_at_level_0=plan.spacing_at_level_0,
-                source_spacing_um=plan.source_spacing_um,
-                declared_spacing_um=plan.declared_spacing_um,
-                read_spacing_um=plan.read_spacing_um,
-                effective_spacing_um=plan.effective_spacing_um,
-                requested_backend=plan.requested_backend,
-                tolerance=float(plan.tolerance),
-                is_within_tolerance=bool(plan.is_within_tolerance),
             )
         )
     return specs
@@ -241,26 +229,6 @@ def _run_dense_in_process(model, specs, *, dense, execution, out_dir) -> None:
     )
 
 
-def _slide_group_key(spec: RegionSpec) -> tuple:
-    return (
-        spec.image_path,
-        spec.sample_id,
-        spec.annotation,
-        spec.read_level,
-        spec.read_tile_size_px,
-        spec.requested_tile_size_px,
-        spec.backend,
-        spec.spacing_at_level_0,
-        spec.source_spacing_um,
-        spec.declared_spacing_um,
-        spec.read_spacing_um,
-        spec.effective_spacing_um,
-        spec.requested_backend,
-        spec.tolerance,
-        spec.is_within_tolerance,
-    )
-
-
 def build_dense_worker_request(specs: Sequence[RegionSpec], *, coordinates_npz_path):
     """Split the flat specs into per-slide groups for the request JSON (coords go to npz).
 
@@ -270,7 +238,7 @@ def build_dense_worker_request(specs: Sequence[RegionSpec], *, coordinates_npz_p
     """
     slides = []
     coordinates: list[tuple[int, int]] = []
-    for _key, group_iter in groupby(specs, key=_slide_group_key):
+    for _key, group_iter in groupby(specs, key=RegionSpec.slide_group_key):
         group = list(group_iter)
         head = group[0]
         slides.append(
@@ -278,18 +246,7 @@ def build_dense_worker_request(specs: Sequence[RegionSpec], *, coordinates_npz_p
                 "sample_id": head.sample_id,
                 "image_path": head.image_path,
                 "annotation": head.annotation,
-                "read_level": int(head.read_level),
-                "read_tile_size_px": int(head.read_tile_size_px),
-                "requested_tile_size_px": int(head.requested_tile_size_px),
-                "backend": head.backend,
-                "spacing_at_level_0": head.spacing_at_level_0,
-                "source_spacing_um": head.source_spacing_um,
-                "declared_spacing_um": head.declared_spacing_um,
-                "read_spacing_um": head.read_spacing_um,
-                "effective_spacing_um": head.effective_spacing_um,
-                "requested_backend": head.requested_backend,
-                "tolerance": head.tolerance,
-                "is_within_tolerance": head.is_within_tolerance,
+                "read_plan": head.read_plan.to_dict(),
                 "num_regions": len(group),
             }
         )
@@ -314,19 +271,8 @@ def region_specs_from_request(request: dict) -> list[RegionSpec]:
                     image_path=str(slide["image_path"]),
                     x=int(x),
                     y=int(y),
-                    read_level=int(slide["read_level"]),
-                    read_tile_size_px=int(slide["read_tile_size_px"]),
-                    requested_tile_size_px=int(slide["requested_tile_size_px"]),
-                    backend=str(slide["backend"]),
+                    read_plan=DenseImageReadPlan.from_dict(slide["read_plan"]),
                     annotation=slide["annotation"],
-                    spacing_at_level_0=slide.get("spacing_at_level_0"),
-                    source_spacing_um=slide.get("source_spacing_um"),
-                    declared_spacing_um=slide.get("declared_spacing_um"),
-                    read_spacing_um=slide.get("read_spacing_um"),
-                    effective_spacing_um=slide.get("effective_spacing_um"),
-                    requested_backend=str(slide.get("requested_backend", "auto")),
-                    tolerance=float(slide.get("tolerance", 0.05)),
-                    is_within_tolerance=bool(slide.get("is_within_tolerance", True)),
                 )
             )
         offset += count

--- a/slide2vec/runtime/hierarchical.py
+++ b/slide2vec/runtime/hierarchical.py
@@ -51,6 +51,7 @@ def resolve_hierarchical_geometry(preprocessing: PreprocessingConfig, tiling_res
         level_downsamples=_level_downsample_pairs(getattr(tiling_result, "level_downsamples")),
         target_size_px=(requested_tile_size_px, requested_tile_size_px),
         tolerance=float(preprocessing.tolerance),
+        content_kind="image",
     )
     read_spacing_um = float(read_plan.read_spacing_um)
     read_tile_size_px = int(read_plan.read_size_px[0])

--- a/slide2vec/runtime/image_specs.py
+++ b/slide2vec/runtime/image_specs.py
@@ -1,9 +1,9 @@
-"""Named image normalization and dense reader-regime classification.
+"""Named image normalization and dense hs2p source classification.
 
 :meth:`slide2vec.api.Model.embed_images` (pooled, issue #234) and
 :meth:`slide2vec.api.Model.embed_images_dense` (dense grids, issue #235) take the same input
 unit — a caller-named image file — and share normalization/request transport. Dense extraction
-additionally derives its one raster or hs2p spacing-readable regime from reader capabilities.
+resolves every supported source, including flat PNG/JPEG inputs, through hs2p.
 """
 
 from __future__ import annotations
@@ -52,7 +52,7 @@ def spacing_readable_image_suffixes() -> frozenset[str]:
 def validate_dense_image_reader_regime(
     specs: Sequence[ImageSpec],
 ) -> tuple[str, dict[str, str]]:
-    """Resolve one regime and retain auto backends discovered by openability probes.
+    """Validate hs2p support and retain auto backends discovered by openability probes.
 
     CuCIM and VIPS publish suffix capabilities, while hs2p's OpenSlide/ASAP readers
     deliberately accept paths based on file contents. For a suffix outside the published
@@ -70,7 +70,16 @@ def validate_dense_image_reader_regime(
     for spec in specs:
         suffix = Path(spec.image_path).suffix.lower()
         if suffix in RASTER_IMAGE_SUFFIXES:
-            regime = "raster"
+            # hs2p 4.4.1 owns flat-raster source spacing and decoding through its
+            # one-level PIL reader. Resolve it just like any other source so missing
+            # declarations surface from the same public reader contract.
+            selection = hs2p_reader.resolve_backend(
+                "auto",
+                wsi_path=Path(spec.image_path),
+                spacing_override=spec.spacing_at_level_0,
+            )
+            regime = "spacing-readable"
+            resolved_auto_backends[spec.sample_id] = str(selection.backend)
         elif suffix in spacing_suffixes:
             regime = "spacing-readable"
         else:
@@ -117,14 +126,7 @@ def validate_dense_image_reader_regime(
             f"{supported_spacing} plus other sources its registered readers can open. "
             f"Unsupported samples: {grouped['unsupported']}"
         )
-    present = [regime for regime in ("raster", "spacing-readable") if grouped[regime]]
-    if len(present) != 1:
-        raise ValueError(
-            "A dense image run must use exactly one reader regime. "
-            f"raster samples: {grouped['raster']}; "
-            f"spacing-readable samples: {grouped['spacing-readable']}"
-        )
-    return present[0], resolved_auto_backends
+    return "spacing-readable", resolved_auto_backends
 
 
 def reject_image_level0_spacing_overrides(

--- a/tests/fixtures/gpu_dense_artifact_metadata.json
+++ b/tests/fixtures/gpu_dense_artifact_metadata.json
@@ -26,8 +26,11 @@
     ],
     "image_pad_value": null,
     "image_path": "<IMAGE_PATH>",
-    "is_within_tolerance": null,
-    "output_size": null,
+    "is_within_tolerance": true,
+    "output_size": [
+      224,
+      224
+    ],
     "output_variant": "default",
     "overlap": 0.0,
     "pad": [
@@ -40,22 +43,25 @@
       8
     ],
     "precision": "fp32",
-    "read_level": null,
-    "read_size": null,
-    "read_spacing_um": null,
+    "read_level": 0,
+    "read_size": [
+      224,
+      224
+    ],
+    "read_spacing_um": 0.5,
     "read_tile_size_px": null,
-    "reader_regime": "raster",
+    "reader_regime": "spacing-readable",
     "requested_backend": "auto",
     "requested_tile_size_px": null,
     "sample_id": "<SAMPLE_ID>",
     "source_spacing_um": 0.5,
-    "spacing_at_level_0": null,
+    "spacing_at_level_0": 0.5,
     "spacing_source": "explicit",
     "target_size": [
       224,
       224
     ],
-    "tolerance": null,
+    "tolerance": 0.05,
     "window_size": null
   },
   "declared_spacing_um": 0.5,
@@ -77,8 +83,11 @@
   ],
   "image_pad_value": null,
   "image_path": "<IMAGE_PATH>",
-  "is_within_tolerance": null,
-  "output_size": null,
+  "is_within_tolerance": true,
+  "output_size": [
+    224,
+    224
+  ],
   "overlap": 0.0,
   "pad": [
     0,
@@ -89,21 +98,24 @@
     8,
     8
   ],
-  "read_level": null,
-  "read_size": null,
-  "read_spacing_um": null,
+  "read_level": 0,
+  "read_size": [
+    224,
+    224
+  ],
+  "read_spacing_um": 0.5,
   "read_tile_size_px": null,
-  "reader_regime": "raster",
+  "reader_regime": "spacing-readable",
   "requested_backend": "auto",
   "requested_tile_size_px": null,
   "sample_id": "<SAMPLE_ID>",
   "source_spacing_um": 0.5,
-  "spacing_at_level_0": null,
+  "spacing_at_level_0": 0.5,
   "spacing_source": "explicit",
   "target_size": [
     224,
     224
   ],
-  "tolerance": null,
+  "tolerance": 0.05,
   "window_size": null
 }

--- a/tests/test_dense_encoder_input.py
+++ b/tests/test_dense_encoder_input.py
@@ -230,6 +230,7 @@ class _FakeBackend:
 @pytest.fixture
 def stand_in_virchow2(monkeypatch):
     import slide2vec.inference as inference
+    from slide2vec.runtime.dense_image_reading import DenseImageReadPlan
 
     _StandInVirchow2.constructed = []
     monkeypatch.setattr(
@@ -242,7 +243,22 @@ def stand_in_virchow2(monkeypatch):
     )
     monkeypatch.setattr(
         dense_stage, "resolve_slide_read_plan",
-        lambda image_path, dense: (0, int(dense.target_size), "cucim"),
+        lambda image_path, dense, spacing_at_level_0=None: DenseImageReadPlan(
+            reader_regime="spacing-readable",
+            spacing_source="explicit",
+            declared_spacing_um=float(dense.spacing_um),
+            source_spacing_um=0.5,
+            spacing_at_level_0=spacing_at_level_0,
+            read_spacing_um=0.5,
+            effective_spacing_um=0.5,
+            requested_backend="auto",
+            backend="cucim",
+            tolerance=float(dense.tolerance),
+            read_level=0,
+            is_within_tolerance=True,
+            read_size=(int(dense.target_size), int(dense.target_size)),
+            output_size=(int(dense.target_size), int(dense.target_size)),
+        ),
     )
     return _StandInVirchow2
 

--- a/tests/test_dense_image_resume.py
+++ b/tests/test_dense_image_resume.py
@@ -211,8 +211,18 @@ def test_resume_skips_only_a_complete_exactly_compatible_pair(tmp_path):
 @pytest.mark.parametrize(
     ("changed_field", "changed_value"),
     [
+        ("spacing_at_level_0", 0.3),
         ("source_spacing_um", 0.26),
+        ("declared_spacing_um", 0.75),
+        ("read_spacing_um", 0.5),
+        ("effective_spacing_um", 0.504),
+        ("requested_backend", "openslide"),
         ("backend", "openslide"),
+        ("tolerance", 0.1),
+        ("read_level", 1),
+        ("is_within_tolerance", True),
+        ("read_size", (224, 224)),
+        ("output_size", (112, 112)),
     ],
 )
 def test_resume_recomputes_when_parent_resolved_source_or_auto_backend_changes(

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -79,7 +79,13 @@ def _images(tmp_path, names, *, width=64, height=64) -> list[ImageSpec]:
         rng = np.random.default_rng(abs(hash(name)) % (2**32))
         pixels = rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
         Image.fromarray(pixels).save(path)
-        specs.append(ImageSpec(sample_id=name, image_path=path))
+        specs.append(
+            ImageSpec(
+                sample_id=name,
+                image_path=path,
+                spacing_at_level_0=0.5,
+            )
+        )
     return specs
 
 
@@ -297,34 +303,60 @@ def test_embed_images_dense_requires_at_least_one_image(tmp_path):
         dense_image_stage.embed_images_dense(model, [], dense=_dense(), execution=execution)
 
 
-def test_embed_images_dense_rejects_raster_level0_spacing_override(tmp_path, monkeypatch):
+def test_embed_images_dense_resolves_png_through_hs2p_pil_reader(tmp_path, monkeypatch):
     model = _FakeModel(_encoder())
+    captured = {}
     monkeypatch.setattr(
-        model,
-        "_load_backend",
-        lambda: pytest.fail("override validation must precede backend loading"),
+        dense_image_stage,
+        "partition_dense_images_by_resume",
+        lambda specs, out_dir, recipe, read_plans=None: (
+            captured.update(read_plans=read_plans) or [],
+            len(specs),
+        ),
+    )
+    monkeypatch.setattr(
+        dense_image_stage, "dense_image_artifact_from_disk", lambda out_dir, spec: spec
     )
     execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
+    image_path = tmp_path / "image.png"
+    Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8)).save(image_path)
     spec = ImageSpec(
         sample_id="raster",
-        image_path=tmp_path / "image.png",
+        image_path=image_path,
         spacing_at_level_0=0.25,
     )
 
-    with pytest.raises(ValueError, match=r"spacing_at_level_0.*raster"):
-        dense_image_stage.embed_images_dense(
-            model, [spec], dense=_dense(), execution=execution
-        )
+    artifacts = dense_image_stage.embed_images_dense(
+        model, [spec], dense=_dense(), execution=execution
+    )
+
+    assert [artifact.sample_id for artifact in artifacts] == [spec.sample_id]
+    plan = captured["read_plans"]["raster"]
+    assert plan.backend == "pil"
+    assert plan.spacing_at_level_0 == pytest.approx(0.25)
+    assert plan.source_spacing_um == pytest.approx(0.25)
+    assert plan.declared_spacing_um == pytest.approx(0.5)
+    assert plan.effective_spacing_um == pytest.approx(0.5)
 
 
 def test_dense_image_raster_suffixes_are_exact_and_case_insensitive(tmp_path, monkeypatch):
-    """This issue's reader regime is exactly PNG/JPEG; spacing-readable inputs are #259."""
+    """hs2p's PIL source capability is exactly PNG/JPEG and case-insensitive."""
     model = _FakeModel(_encoder())
     execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
-    accepted = [
-        ImageSpec(sample_id=f"accepted-{index}", image_path=tmp_path / f"image{suffix}")
-        for index, suffix in enumerate((".png", ".PNG", ".jpg", ".JPG", ".jpeg", ".JPEG"))
-    ]
+    accepted = []
+    for index, suffix in enumerate((".png", ".PNG", ".jpg", ".JPG", ".jpeg", ".JPEG")):
+        path = tmp_path / f"image-{index}{suffix}"
+        image_format = "PNG" if suffix.lower() == ".png" else "JPEG"
+        Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8)).save(
+            path, format=image_format
+        )
+        accepted.append(
+            ImageSpec(
+                sample_id=f"accepted-{index}",
+                image_path=path,
+                spacing_at_level_0=0.5,
+            )
+        )
     monkeypatch.setattr(
         dense_image_stage,
         "partition_dense_images_by_resume",
@@ -500,7 +532,7 @@ def test_synthetic_format_probe_does_not_replace_real_auto_backend_resolution(
     assert open_calls == [("vips", None)]
 
 
-def test_unknown_suffix_probe_surfaces_invalid_override_instead_of_unsupported(
+def test_invalid_source_spacing_is_rejected_before_unknown_suffix_probe(
     tmp_path, monkeypatch
 ):
     """Synthetic openability is only a discriminator after the real policy fails."""
@@ -515,13 +547,7 @@ def test_unknown_suffix_probe_surfaces_invalid_override_instead_of_unsupported(
             return SimpleNamespace(backend="openslide")
         raise RuntimeError("auto resolution rejected the source")
 
-    def _open(path, *, backend, spacing_override=None, **kwargs):
-        assert backend == "openslide"
-        assert spacing_override == -0.5
-        raise ValueError("spacing override must be positive")
-
     monkeypatch.setattr(hs2p_reader, "resolve_backend", _resolve)
-    monkeypatch.setattr(hs2p_reader, "open_slide", _open)
     model = _FakeModel(_encoder())
     monkeypatch.setattr(
         model,
@@ -529,7 +555,7 @@ def test_unknown_suffix_probe_surfaces_invalid_override_instead_of_unsupported(
         lambda: pytest.fail("override validation must precede model loading"),
     )
 
-    with pytest.raises(ValueError, match="spacing override must be positive"):
+    with pytest.raises(ValueError, match="spacing_at_level_0.*positive.*finite"):
         dense_image_stage.embed_images_dense(
             model,
             [
@@ -545,44 +571,67 @@ def test_unknown_suffix_probe_surfaces_invalid_override_instead_of_unsupported(
             ),
         )
 
-    assert resolve_calls == [-0.5, 1.0]
+    assert resolve_calls == []
 
 
-def test_mixed_reader_regimes_fail_with_samples_grouped_before_any_read_or_model_load(
+def test_flat_and_wsi_sources_share_one_dense_read_contract(
     tmp_path, monkeypatch
 ):
     from hs2p.wsi import reader as hs2p_reader
 
-    monkeypatch.setattr(
-        hs2p_reader,
-        "resolve_backend",
-        lambda *args, **kwargs: pytest.fail("mixed runs must fail before reader resolution"),
-    )
+    def _resolve(requested_backend, *, wsi_path, **kwargs):
+        return SimpleNamespace(
+            backend="pil" if Path(wsi_path).suffix.lower() == ".png" else "openslide"
+        )
+
+    class _Reader:
+        spacing = 0.5
+        level_dimensions = [(64, 64)]
+        level_downsamples = [(1.0, 1.0)]
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hs2p_reader, "resolve_backend", _resolve)
+    monkeypatch.setattr(hs2p_reader, "open_slide", lambda *args, **kwargs: _Reader())
     model = _FakeModel(_encoder())
+    captured = {}
     monkeypatch.setattr(
-        model,
-        "_load_backend",
-        lambda: pytest.fail("mixed runs must fail before model loading"),
+        dense_image_stage,
+        "partition_dense_images_by_resume",
+        lambda specs, out_dir, recipe, read_plans=None: (
+            captured.update(read_plans=read_plans) or [],
+            len(specs),
+        ),
+    )
+    monkeypatch.setattr(
+        dense_image_stage, "dense_image_artifact_from_disk", lambda out_dir, spec: spec
     )
     execution = ExecutionOptions(
         output_dir=tmp_path / "out", num_gpus=1, precision="fp32"
     )
 
-    with pytest.raises(ValueError) as excinfo:
-        dense_image_stage.embed_images_dense(
-            model,
-            [
-                ImageSpec(sample_id="raster-a", image_path=tmp_path / "a.PNG"),
-                ImageSpec(sample_id="slide-b", image_path=tmp_path / "b.SVS"),
-            ],
-            dense=_dense(),
-            execution=execution,
-        )
+    artifacts = dense_image_stage.embed_images_dense(
+        model,
+        [
+            ImageSpec(
+                sample_id="raster-a",
+                image_path=tmp_path / "a.PNG",
+                spacing_at_level_0=0.5,
+            ),
+            ImageSpec(
+                sample_id="slide-b",
+                image_path=tmp_path / "b.SVS",
+                spacing_at_level_0=0.5,
+            ),
+        ],
+        dense=_dense(),
+        execution=execution,
+    )
 
-    message = str(excinfo.value)
-    assert "exactly one reader regime" in message
-    assert "raster samples" in message and "raster-a" in message
-    assert "spacing-readable samples" in message and "slide-b" in message
+    assert [artifact.sample_id for artifact in artifacts] == ["raster-a", "slide-b"]
+    assert captured["read_plans"]["raster-a"].backend == "pil"
+    assert captured["read_plans"]["slide-b"].backend == "openslide"
 
 
 def test_unsupported_dense_image_suffix_fails_validation_before_loading(tmp_path, monkeypatch):
@@ -799,18 +848,25 @@ def test_allowed_non_recommended_numeric_raster_spacing_warns_once(
     assert caplog.text.count("allow_non_recommended_settings=True") == 1
 
 
-def test_unknown_raster_spacing_is_rejected_for_constrained_encoder(tmp_path):
+def test_omitted_output_spacing_resolves_constrained_encoder_default(
+    tmp_path, monkeypatch
+):
     specs = _images(tmp_path, ["a", "b"])
     execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
     constrained = _FakeModel(_encoder(), name="uni")
 
-    with pytest.raises(ValueError, match=r"requested_spacing_um=unknown.*recommended"):
-        dense_image_stage.embed_images_dense(
-            constrained, specs, dense=_dense(spacing_um=None), execution=execution
-        )
+    _skip_dense_image_encoding(monkeypatch)
+
+    artifacts = dense_image_stage.embed_images_dense(
+        constrained, specs, dense=_dense(spacing_um=None), execution=execution
+    )
+
+    assert [artifact.sample_id for artifact in artifacts] == ["a", "b"]
 
 
-def test_allowed_unknown_raster_spacing_warns_once(tmp_path, monkeypatch, caplog):
+def test_omitted_output_spacing_with_override_flag_emits_no_warning(
+    tmp_path, monkeypatch, caplog
+):
     specs = _images(tmp_path, ["a", "b"])
     execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
     constrained = _FakeModel(_encoder(), name="uni")
@@ -822,10 +878,10 @@ def test_allowed_unknown_raster_spacing_warns_once(tmp_path, monkeypatch, caplog
             constrained, specs, dense=_dense(spacing_um=None), execution=execution
         )
 
-    assert caplog.text.count("requested_spacing_um=unknown") == 1
+    assert caplog.text == ""
 
 
-def test_unknown_raster_spacing_is_accepted_for_agnostic_encoder(
+def test_omitted_output_spacing_resolves_agnostic_encoder_default(
     tmp_path, monkeypatch, caplog
 ):
     specs = _images(tmp_path, ["a", "b"])

--- a/tests/test_dense_shard.py
+++ b/tests/test_dense_shard.py
@@ -88,8 +88,17 @@ class _FakeBackendFactory:
 
 @pytest.fixture
 def fake_backend(monkeypatch) -> _FakeBackendFactory:
+    from hs2p.wsi import reader as hs2p_reader
+
     factory = _FakeBackendFactory()
     monkeypatch.setattr(tile_reader, "_open_wsi_backend", factory)
+    monkeypatch.setattr(
+        hs2p_reader,
+        "open_slide",
+        lambda path, backend, *, spacing_override=None, gpu_decode=False: factory(
+            path, backend, gpu_decode
+        ),
+    )
     return factory
 
 
@@ -105,6 +114,14 @@ def _spec(x, y, *, sample_id="s0", image_path="s0.tif", annotation=None,
         requested_tile_size_px=int(requested),
         backend=backend,
         annotation=annotation,
+        spacing_at_level_0=None,
+        source_spacing_um=0.25,
+        declared_spacing_um=0.5,
+        read_spacing_um=0.5,
+        effective_spacing_um=0.5,
+        requested_backend="auto",
+        tolerance=0.05,
+        is_within_tolerance=True,
     )
 
 
@@ -290,6 +307,47 @@ def test_run_dense_shard_skips_regions_with_existing_sidecar(fake_backend, tmp_p
     assert [a.path for a in second] == [a.path for a in first]
 
 
+@pytest.mark.parametrize(
+    ("changed_field", "changed_value"),
+    [
+        ("spacing_at_level_0", 0.25),
+        ("source_spacing_um", 0.4),
+        ("read_spacing_um", 0.4),
+        ("effective_spacing_um", 0.4),
+        ("read_level", 1),
+        ("read_tile_size_px", 96),
+        ("backend", "openslide"),
+    ],
+)
+def test_region_resume_reencodes_when_source_or_resolved_read_plan_changes(
+    fake_backend, tmp_path, changed_field, changed_value
+):
+    from dataclasses import replace
+
+    encoder = _encoder()
+    original = _spec(0, 0)
+    run_dense_shard(
+        [original],
+        model=encoder,
+        out_dir=tmp_path,
+        dense=_dense(),
+        batch_size=1,
+        device="cpu",
+    )
+    reads_before = len(fake_backend.locations_read)
+
+    run_dense_shard(
+        [replace(original, **{changed_field: changed_value})],
+        model=encoder,
+        out_dir=tmp_path,
+        dense=_dense(),
+        batch_size=1,
+        device="cpu",
+    )
+
+    assert len(fake_backend.locations_read) == reads_before + 1
+
+
 def test_run_dense_shard_reencodes_payload_missing_its_sidecar(fake_backend, tmp_path):
     """Crash-safety (D6): a ``.pt`` with no sidecar is re-encoded, never counted as done."""
     enc = _encoder()
@@ -380,10 +438,20 @@ def test_run_dense_shard_sidecar_records_extraction_geometry_only(fake_backend, 
         "patch_size": [16, 16],
         "encoded_size": [64, 64],
         "pad": [4, 4],
-        "spacing_um": 0.5,
+        "reader_regime": "spacing-readable",
+        "spacing_source": "explicit",
+        "spacing_at_level_0": None,
+        "source_spacing_um": 0.25,
+        "declared_spacing_um": 0.5,
+        "read_spacing_um": 0.5,
+        "effective_spacing_um": 0.5,
+        "requested_backend": "auto",
         "tolerance": 0.05,
         "backend": "cucim",
         "read_level": 0,
+        "is_within_tolerance": True,
+        "read_size": [60, 60],
+        "output_size": [60, 60],
         "read_tile_size_px": 60,
         "requested_tile_size_px": 60,
         "pad_mode": "reflect",
@@ -393,6 +461,24 @@ def test_run_dense_shard_sidecar_records_extraction_geometry_only(fake_backend, 
         "feature_kind": "patch_features",
         "attention_blocks": [-1],
         "attention_include_registers": False,
+        "compatibility": {
+            "reader_regime": "spacing-readable",
+            "spacing_source": "explicit",
+            "spacing_at_level_0": None,
+            "source_spacing_um": 0.25,
+            "declared_spacing_um": 0.5,
+            "read_spacing_um": 0.5,
+            "effective_spacing_um": 0.5,
+            "requested_backend": "auto",
+            "backend": "cucim",
+            "tolerance": 0.05,
+            "read_level": 0,
+            "is_within_tolerance": True,
+            "read_size": [60, 60],
+            "output_size": [60, 60],
+            "read_tile_size_px": 60,
+            "requested_tile_size_px": 60,
+        },
     }
 
 

--- a/tests/test_dense_shard.py
+++ b/tests/test_dense_shard.py
@@ -26,6 +26,7 @@ from slide2vec.artifacts import region_dense_paths, write_dense_region  # noqa: 
 from slide2vec.data import tile_reader  # noqa: E402
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
 from slide2vec.runtime.dense_shard import RegionSpec, run_dense_shard  # noqa: E402
+from slide2vec.runtime.dense_image_reading import DenseImageReadPlan  # noqa: E402
 from slide2vec.runtime.sharding import plan_contiguous_shards  # noqa: E402
 
 
@@ -109,19 +110,26 @@ def _spec(x, y, *, sample_id="s0", image_path="s0.tif", annotation=None,
         image_path=image_path,
         x=int(x),
         y=int(y),
-        read_level=int(read_level),
-        read_tile_size_px=int(read if read is not None else requested),
-        requested_tile_size_px=int(requested),
-        backend=backend,
+        read_plan=DenseImageReadPlan(
+            reader_regime="spacing-readable",
+            spacing_source="explicit",
+            declared_spacing_um=0.5,
+            source_spacing_um=0.25,
+            spacing_at_level_0=None,
+            read_spacing_um=0.5,
+            effective_spacing_um=0.5,
+            requested_backend="auto",
+            backend=backend,
+            tolerance=0.05,
+            read_level=int(read_level),
+            is_within_tolerance=True,
+            read_size=(
+                int(read if read is not None else requested),
+                int(read if read is not None else requested),
+            ),
+            output_size=(int(requested), int(requested)),
+        ),
         annotation=annotation,
-        spacing_at_level_0=None,
-        source_spacing_um=0.25,
-        declared_spacing_um=0.5,
-        read_spacing_um=0.5,
-        effective_spacing_um=0.5,
-        requested_backend="auto",
-        tolerance=0.05,
-        is_within_tolerance=True,
     )
 
 
@@ -315,7 +323,7 @@ def test_run_dense_shard_skips_regions_with_existing_sidecar(fake_backend, tmp_p
         ("read_spacing_um", 0.4),
         ("effective_spacing_um", 0.4),
         ("read_level", 1),
-        ("read_tile_size_px", 96),
+        ("read_size", (96, 96)),
         ("backend", "openslide"),
     ],
 )
@@ -337,7 +345,14 @@ def test_region_resume_reencodes_when_source_or_resolved_read_plan_changes(
     reads_before = len(fake_backend.locations_read)
 
     run_dense_shard(
-        [replace(original, **{changed_field: changed_value})],
+        [
+            replace(
+                original,
+                read_plan=replace(
+                    original.read_plan, **{changed_field: changed_value}
+                ),
+            )
+        ],
         model=encoder,
         out_dir=tmp_path,
         dense=_dense(),

--- a/tests/test_dense_source_spacing.py
+++ b/tests/test_dense_source_spacing.py
@@ -1,0 +1,168 @@
+"""Public source-spacing contract shared by both dense extraction inputs (#268)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from slide2vec.api import ImageSpec, SlideRegions
+from slide2vec.api import DenseOptions
+from slide2vec.runtime import dense_stage
+from slide2vec.runtime.dense_image_reading import (
+    read_dense_image,
+    resolve_spacing_read_plan,
+)
+
+
+@pytest.mark.parametrize("value", [0.0, -0.25, math.inf, -math.inf, math.nan])
+@pytest.mark.parametrize("input_type", [ImageSpec, SlideRegions])
+def test_dense_inputs_reject_non_positive_or_non_finite_level0_spacing(
+    input_type, value
+):
+    kwargs = {
+        "sample_id": "sample",
+        "image_path": "source.png",
+        "spacing_at_level_0": value,
+    }
+    if input_type is SlideRegions:
+        kwargs["coordinates"] = np.asarray([[0, 0]], dtype=np.int64)
+
+    with pytest.raises(ValueError, match="spacing_at_level_0.*positive.*finite"):
+        input_type(**kwargs)
+
+
+@pytest.mark.parametrize("suffix", [".png", ".jpg"])
+def test_exact_spacing_flat_read_matches_unchanged_pillow_rgb_bytes(tmp_path, suffix):
+    pixels = np.arange(5 * 7 * 3, dtype=np.uint8).reshape(5, 7, 3)
+    path = tmp_path / f"source{suffix}"
+    Image.fromarray(pixels).save(path)
+    with Image.open(path) as source:
+        expected = np.asarray(source.convert("RGB"))
+    spec = ImageSpec(
+        sample_id="flat", image_path=path, spacing_at_level_0=0.25
+    )
+
+    plan = resolve_spacing_read_plan(
+        spec,
+        requested_spacing_um=0.25,
+        spacing_source="explicit",
+        requested_backend="auto",
+        tolerance=0.05,
+    )
+    observed = np.asarray(read_dense_image(spec, plan=plan, target_size=(5, 7)))
+
+    assert plan.backend == "pil"
+    assert plan.read_size == (5, 7)
+    assert plan.output_size == (5, 7)
+    assert plan.source_spacing_um == pytest.approx(0.25)
+    assert plan.effective_spacing_um == pytest.approx(0.25)
+    np.testing.assert_array_equal(observed, expected)
+
+
+def test_coarser_flat_read_has_exact_downsampled_dimensions_and_spacing(tmp_path):
+    path = tmp_path / "source.png"
+    Image.fromarray(np.zeros((6, 10, 3), dtype=np.uint8)).save(path)
+    spec = ImageSpec(
+        sample_id="flat", image_path=path, spacing_at_level_0=0.25
+    )
+
+    plan = resolve_spacing_read_plan(
+        spec,
+        requested_spacing_um=0.5,
+        spacing_source="explicit",
+        requested_backend="auto",
+        tolerance=0.05,
+    )
+    observed = read_dense_image(spec, plan=plan, target_size=(3, 5))
+
+    assert observed.size == (5, 3)
+    assert plan.source_spacing_um == pytest.approx(0.25)
+    assert plan.read_spacing_um == pytest.approx(0.25)
+    assert plan.effective_spacing_um == pytest.approx(0.5)
+    assert plan.read_size == (6, 10)
+    assert plan.output_size == (3, 5)
+
+
+def test_finer_flat_read_raises_through_hs2p_no_upsampling_contract(tmp_path):
+    path = tmp_path / "source.png"
+    Image.fromarray(np.zeros((6, 10, 3), dtype=np.uint8)).save(path)
+
+    with pytest.raises(ValueError, match="image upsampling is forbidden"):
+        resolve_spacing_read_plan(
+            ImageSpec(
+                sample_id="flat", image_path=path, spacing_at_level_0=0.5
+            ),
+            requested_spacing_um=0.25,
+            spacing_source="explicit",
+            requested_backend="auto",
+            tolerance=0.05,
+        )
+
+
+def test_flat_source_without_spacing_declaration_fails_in_hs2p(tmp_path):
+    path = tmp_path / "source.png"
+    Image.fromarray(np.zeros((6, 10, 3), dtype=np.uint8)).save(path)
+
+    with pytest.raises(ValueError, match="Unable to infer slide spacing.*backend=pil"):
+        resolve_spacing_read_plan(
+            ImageSpec(sample_id="flat", image_path=path),
+            requested_spacing_um=0.5,
+            spacing_source="explicit",
+            requested_backend="auto",
+            tolerance=0.05,
+        )
+
+
+@pytest.mark.parametrize(
+    ("spacing_at_level_0", "resolved_source_spacing"),
+    [(None, 0.25), (0.4, 0.4)],
+)
+def test_dense_region_read_plan_records_native_and_override_spacing_separately(
+    tmp_path, monkeypatch, spacing_at_level_0, resolved_source_spacing
+):
+    from types import SimpleNamespace
+    from hs2p.wsi import reader as hs2p_reader
+
+    opened = []
+
+    class _Reader:
+        spacing = resolved_source_spacing
+        level_downsamples = [(1.0, 1.0), (2.0, 2.0)]
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        hs2p_reader,
+        "resolve_backend",
+        lambda requested_backend, **kwargs: SimpleNamespace(backend="openslide"),
+    )
+
+    def _open(path, backend, *, spacing_override=None, **kwargs):
+        opened.append((path, backend, spacing_override))
+        return _Reader()
+
+    monkeypatch.setattr(hs2p_reader, "open_slide", _open)
+
+    plan = dense_stage.resolve_slide_read_plan(
+        str(tmp_path / "source.svs"),
+        DenseOptions(spacing_um=0.5, target_size=64),
+        spacing_at_level_0=spacing_at_level_0,
+    )
+
+    assert plan.spacing_at_level_0 == spacing_at_level_0
+    assert plan.source_spacing_um == pytest.approx(resolved_source_spacing)
+    assert plan.declared_spacing_um == pytest.approx(0.5)
+    expected_read_spacing = 0.4 if spacing_at_level_0 == 0.4 else 0.5
+    assert plan.read_spacing_um == pytest.approx(expected_read_spacing)
+    assert plan.effective_spacing_um == pytest.approx(0.5)
+    assert plan.read_level == (0 if spacing_at_level_0 == 0.4 else 1)
+    expected_read_size = (80, 80) if spacing_at_level_0 == 0.4 else (64, 64)
+    assert plan.read_size == expected_read_size
+    assert plan.output_size == (64, 64)
+    assert opened == [
+        (str(tmp_path / "source.svs"), "openslide", spacing_at_level_0)
+    ]

--- a/tests/test_dense_source_spacing.py
+++ b/tests/test_dense_source_spacing.py
@@ -17,7 +17,9 @@ from slide2vec.runtime.dense_image_reading import (
 )
 
 
-@pytest.mark.parametrize("value", [0.0, -0.25, math.inf, -math.inf, math.nan])
+@pytest.mark.parametrize(
+    "value", [False, True, 0.0, -0.25, math.inf, -math.inf, math.nan]
+)
 @pytest.mark.parametrize("input_type", [ImageSpec, SlideRegions])
 def test_dense_inputs_reject_non_positive_or_non_finite_level0_spacing(
     input_type, value
@@ -59,6 +61,30 @@ def test_exact_spacing_flat_read_matches_unchanged_pillow_rgb_bytes(tmp_path, su
     assert plan.output_size == (5, 7)
     assert plan.source_spacing_um == pytest.approx(0.25)
     assert plan.effective_spacing_um == pytest.approx(0.25)
+    np.testing.assert_array_equal(observed, expected)
+
+
+def test_exact_spacing_palette_png_preserves_pillow_rgb_bytes(tmp_path):
+    indices = np.asarray([[0, 1], [2, 1]], dtype=np.uint8)
+    source = Image.fromarray(indices, mode="P")
+    source.putpalette([255, 0, 0, 0, 255, 0, 0, 0, 255] + [0] * (256 * 3 - 9))
+    path = tmp_path / "palette.png"
+    source.save(path)
+    with Image.open(path) as image:
+        expected = np.asarray(image.convert("RGB"))
+    spec = ImageSpec(
+        sample_id="palette", image_path=path, spacing_at_level_0=0.5
+    )
+    plan = resolve_spacing_read_plan(
+        spec,
+        requested_spacing_um=0.5,
+        spacing_source="explicit",
+        requested_backend="auto",
+        tolerance=0.05,
+    )
+
+    observed = np.asarray(read_dense_image(spec, plan=plan, target_size=(2, 2)))
+
     np.testing.assert_array_equal(observed, expected)
 
 

--- a/tests/test_dense_stage.py
+++ b/tests/test_dense_stage.py
@@ -57,21 +57,50 @@ class _FakeBackend:
 
 @pytest.fixture
 def fake_backend(monkeypatch):
+    from hs2p.wsi import reader as hs2p_reader
+
     backends: dict[str, _FakeBackend] = {}
 
     def _open(image_path, backend, gpu_decode):
         return backends.setdefault(str(image_path), _FakeBackend())
 
     monkeypatch.setattr(tile_reader, "_open_wsi_backend", _open)
+    monkeypatch.setattr(
+        hs2p_reader,
+        "open_slide",
+        lambda path, backend, *, spacing_override=None, gpu_decode=False: _open(
+            path, backend, gpu_decode
+        ),
+    )
     return backends
 
 
 @pytest.fixture
 def stub_read_plan(monkeypatch):
     """Stub per-slide read-plan resolution so no real slide is opened for metadata."""
+    from slide2vec.runtime.dense_image_reading import DenseImageReadPlan
+
     monkeypatch.setattr(
-        dense_stage, "resolve_slide_read_plan",
-        lambda image_path, dense: (0, int(dense.target_size), "cucim"),
+        dense_stage,
+        "resolve_slide_read_plan",
+        lambda image_path, dense, spacing_at_level_0=None: DenseImageReadPlan(
+            reader_regime="spacing-readable",
+            spacing_source="explicit",
+            declared_spacing_um=float(dense.spacing_um),
+            source_spacing_um=(
+                0.25 if spacing_at_level_0 is None else float(spacing_at_level_0)
+            ),
+            spacing_at_level_0=spacing_at_level_0,
+            read_spacing_um=float(dense.spacing_um),
+            effective_spacing_um=float(dense.spacing_um),
+            requested_backend=str(dense.backend),
+            backend="cucim",
+            tolerance=float(dense.tolerance),
+            read_level=0,
+            is_within_tolerance=True,
+            read_size=(int(dense.target_size), int(dense.target_size)),
+            output_size=(int(dense.target_size), int(dense.target_size)),
+        ),
     )
 
 
@@ -106,10 +135,11 @@ class _FakeModel:
 
 
 def _regions(sample_id="s0", image_path="s0.tif", coords=((0, 0), (64, 0), (0, 64)),
-             annotation=None) -> SlideRegions:
+             annotation=None, spacing_at_level_0=None) -> SlideRegions:
     return SlideRegions(
         sample_id=sample_id, image_path=image_path,
         coordinates=np.asarray(coords, dtype=np.int64), annotation=annotation,
+        spacing_at_level_0=spacing_at_level_0,
     )
 
 
@@ -143,6 +173,75 @@ def test_embed_regions_dense_num_gpus_one_runs_in_process(fake_backend, stub_rea
         assert art.metadata_path.exists()
         assert art.grid_shape == (4, 4)
     assert {num_workers for backend in fake_backend.values() for num_workers in backend.num_workers} == {7}
+
+
+def test_dense_region_sidecar_preserves_source_declaration_and_resolved_spacing(
+    fake_backend, stub_read_plan, tmp_path
+):
+    artifacts = dense_stage.embed_regions_dense(
+        _FakeModel(_encoder()),
+        [_regions(coords=((0, 0),), spacing_at_level_0=0.4)],
+        dense=_dense(),
+        execution=ExecutionOptions(
+            output_dir=tmp_path,
+            num_gpus=1,
+            num_workers_per_gpu=0,
+            precision="fp32",
+        ),
+    )
+
+    metadata = json.loads(artifacts[0].metadata_path.read_text())
+    expected_spacing = {
+        "spacing_at_level_0": 0.4,
+        "source_spacing_um": 0.4,
+        "declared_spacing_um": 0.5,
+        "read_spacing_um": 0.5,
+        "effective_spacing_um": 0.5,
+    }
+    assert {
+        field: metadata[field]
+        for field in (
+            "spacing_at_level_0",
+            "source_spacing_um",
+            "declared_spacing_um",
+            "read_spacing_um",
+            "effective_spacing_um",
+        )
+    } == expected_spacing
+    assert {
+        field: metadata["compatibility"][field] for field in expected_spacing
+    } == expected_spacing
+
+
+def test_embed_regions_dense_reads_flat_source_through_hs2p_pil(tmp_path):
+    from PIL import Image
+
+    image_path = tmp_path / "source.png"
+    Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8)).save(image_path)
+
+    artifacts = dense_stage.embed_regions_dense(
+        _FakeModel(_encoder()),
+        [
+            _regions(
+                image_path=image_path,
+                coords=((0, 0),),
+                spacing_at_level_0=0.5,
+            )
+        ],
+        dense=_dense(target_size=32),
+        execution=ExecutionOptions(
+            output_dir=tmp_path / "out",
+            num_gpus=1,
+            num_workers_per_gpu=0,
+            precision="fp32",
+        ),
+    )
+
+    metadata = json.loads(artifacts[0].metadata_path.read_text())
+    assert metadata["backend"] == "pil"
+    assert metadata["spacing_at_level_0"] == pytest.approx(0.5)
+    assert metadata["source_spacing_um"] == pytest.approx(0.5)
+    assert metadata["effective_spacing_um"] == pytest.approx(0.5)
 
 
 def test_embed_regions_dense_num_gpus_gt_one_launches_dense_worker(fake_backend, stub_read_plan, tmp_path, monkeypatch):

--- a/tests/test_dense_stage.py
+++ b/tests/test_dense_stage.py
@@ -217,7 +217,9 @@ def test_embed_regions_dense_reads_flat_source_through_hs2p_pil(tmp_path):
     from PIL import Image
 
     image_path = tmp_path / "source.png"
-    Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8)).save(image_path)
+    palette = Image.fromarray(np.zeros((64, 64), dtype=np.uint8), mode="P")
+    palette.putpalette([255, 0, 0] + [0] * (256 * 3 - 3))
+    palette.save(image_path)
 
     artifacts = dense_stage.embed_regions_dense(
         _FakeModel(_encoder()),
@@ -379,14 +381,41 @@ def test_model_embed_regions_dense_delegates_and_requires_output_dir(monkeypatch
 
 def test_region_specs_round_trip_through_request(tmp_path):
     """The npz + request rebuild the exact flat spec list the parent sharded (worker inverse)."""
+    from slide2vec.runtime.dense_image_reading import DenseImageReadPlan
     from slide2vec.runtime.dense_shard import RegionSpec
 
+    def plan(*, level, read, requested):
+        return DenseImageReadPlan(
+            reader_regime="spacing-readable",
+            spacing_source="explicit",
+            declared_spacing_um=0.5,
+            source_spacing_um=0.25,
+            spacing_at_level_0=None,
+            read_spacing_um=0.5,
+            effective_spacing_um=0.5,
+            requested_backend="auto",
+            backend="cucim",
+            tolerance=0.05,
+            read_level=level,
+            is_within_tolerance=True,
+            read_size=(read, read),
+            output_size=(requested, requested),
+        )
+
     specs = [
-        RegionSpec("s0", "s0.tif", 0, 0, 0, 64, 64, "cucim", None),
-        RegionSpec("s0", "s0.tif", 64, 0, 0, 64, 64, "cucim", None),
-        RegionSpec("s1", "s1.tif", 10, 20, 1, 96, 64, "cucim", "tumor"),
+        RegionSpec("s0", "s0.tif", 0, 0, plan(level=0, read=64, requested=64)),
+        RegionSpec("s0", "s0.tif", 64, 0, plan(level=0, read=64, requested=64)),
+        RegionSpec(
+            "s1",
+            "s1.tif",
+            10,
+            20,
+            plan(level=1, read=96, requested=64),
+            "tumor",
+        ),
     ]
     request = dense_stage.build_dense_worker_request(
         specs, coordinates_npz_path=tmp_path / "coords.npz"
     )
+    assert request["slides"][1]["read_plan"] == specs[2].read_plan.to_dict()
     assert dense_stage.region_specs_from_request(request) == specs

--- a/tests/test_dense_worker.py
+++ b/tests/test_dense_worker.py
@@ -54,6 +54,7 @@ class _FakeBackend:
 
 
 def test_dense_worker_encodes_only_its_rank_shard(monkeypatch, tmp_path):
+    from slide2vec.runtime.dense_image_reading import DenseImageReadPlan
     backends: dict[str, _FakeBackend] = {}
     monkeypatch.setattr(
         tile_reader, "_open_wsi_backend",
@@ -80,7 +81,23 @@ def test_dense_worker_encodes_only_its_rank_shard(monkeypatch, tmp_path):
         )),
     )
 
-    specs = [RegionSpec("s0", "s0.tif", i * 64, 0, 0, 64, 64, "cucim", None) for i in range(4)]
+    plan = DenseImageReadPlan(
+        reader_regime="spacing-readable",
+        spacing_source="explicit",
+        declared_spacing_um=0.5,
+        source_spacing_um=0.25,
+        spacing_at_level_0=None,
+        read_spacing_um=0.5,
+        effective_spacing_um=0.5,
+        requested_backend="auto",
+        backend="cucim",
+        tolerance=0.05,
+        read_level=0,
+        is_within_tolerance=True,
+        read_size=(64, 64),
+        output_size=(64, 64),
+    )
+    specs = [RegionSpec("s0", "s0.tif", i * 64, 0, plan) for i in range(4)]
     request = {
         "model": {"name": "fake", "output_variant": None, "allow_non_recommended_settings": False},
         "dense": serialize_dense_options(DenseOptions(spacing_um=0.5, target_size=64)),

--- a/tests/test_hs2p_package_cutover.py
+++ b/tests/test_hs2p_package_cutover.py
@@ -23,7 +23,7 @@ def test_package_root_exports_api():
     assert hasattr(package, "DenseRegionArtifact")
 
 
-def test_dependency_declarations_require_hs2p_4_4_with_consistent_extras():
+def test_dependency_declarations_require_hs2p_4_4_1_with_consistent_extras():
     project = tomllib.loads(
         (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
             encoding="utf-8"
@@ -39,8 +39,8 @@ def test_dependency_declarations_require_hs2p_4_4_with_consistent_extras():
     ]
 
     assert hs2p_dependencies == [
-        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.0",
-        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.0",
+        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.1",
+        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.1",
     ]
 
 

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -4860,6 +4860,7 @@ def test_resolve_hierarchical_geometry_uses_hs2p_spacing_plan_for_tile_size(monk
             "level_downsamples": [(1.0, 1.0), (2.0, 2.0), (4.0, 4.0)],
             "target_size_px": (224, 224),
             "tolerance": 0.05,
+            "content_kind": "image",
         }
     ]
     assert geometry["read_tile_size_px"] == 415

--- a/tests/test_soma_migration.py
+++ b/tests/test_soma_migration.py
@@ -363,7 +363,8 @@ def test_dense_image_glossary_names_the_release_contract_terms():
     for term in (
         "raster image",
         "spacing-readable image",
-        "reader regime",
+        "source-spacing declaration",
+        "source spacing",
         "declared spacing",
         "effective spacing",
         "target size",
@@ -421,7 +422,13 @@ def gpu_parity_runs(tmp_path_factory) -> _GpuParityRuns:
         path = tmp_path / "gpu-inputs" / f"{sample_id}.png"
         path.parent.mkdir(parents=True, exist_ok=True)
         Image.fromarray(pixels).save(path)
-        specs.append(ImageSpec(sample_id=sample_id, image_path=path))
+        specs.append(
+            ImageSpec(
+                sample_id=sample_id,
+                image_path=path,
+                spacing_at_level_0=0.5,
+            )
+        )
 
     dense = DenseImageOptions(target_size=224, spacing_um=0.5)
     one_artifacts = Model.from_preset("lunit", device="cuda:0").embed_images_dense(


### PR DESCRIPTION
## Summary
- add a validated `spacing_at_level_0` declaration to dense image and region inputs
- resolve image and region reads through hs2p 4.4.1 spacing plans, including flat PNG/JPEG sources
- persist one shared read-plan vocabulary in metadata, worker requests, grouping, and resume compatibility
- document native, declared, effective, and requested spacing semantics

## Verification
- focused: 231 passed, 6 deselected
- full: 807 passed, 14 skipped, 6 deselected
- docs: `python -m sphinx -W -b html docs ...`
- Standards and Spec re-reviews: no actionable findings remain

Closes #268