### PR TITLE
Publish a resolved live dense encoding kit

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -155,59 +155,84 @@ Enable hierarchical mode by setting ``region_tile_multiple`` in
 The tile embeddings tensor will have shape ``(R, T, D)`` instead of ``(N, D)``.
 See :doc:`hierarchical` for the full explanation.
 
-Dense Tile Feature Extraction
------------------------------
+Live Dense Encoding after Augmentation
+--------------------------------------
 
-Some tile encoders can return the spatial grid of ViT patch-token features
-instead of a single pooled vector per tile. This is useful for dense downstream
-tasks where patch-token features must stay registered to the input tile.
-
-Dense extraction is a low-level encoder API:
-
-- ``get_dense_transform()`` applies the encoder's photometric normalization
-  without resize or center-crop, so tile geometry is preserved.
-- ``encode_tiles_dense(batch)`` accepts a normalized ``(B, C, H, W)`` tensor and
-  returns ``(B, d, h, w)``.
-- ``h`` and ``w`` are resolved from the input size and encoder patch size
-  (for example, a 224 px tile with an 8 px patch size returns a 28 x 28 grid).
-
-Example:
+Use :meth:`Model.prepare_dense_encoder` when a training or inference loop
+already owns image/mask reading and joint augmentation. The handoff is one CPU
+RGB ``uint8`` tensor in ``(3, H, W)`` layout. slide2vec then owns the shipped
+normalization, geometry check, bottom/right padding, device transfer, frozen
+evaluation-mode encoder, autocast, whole/sliding encode, attention selection,
+and output dtype.
 
 .. code-block:: python
 
    import torch
-   from PIL import Image
 
-   from slide2vec.encoders import encoder_registry
+   from slide2vec import DenseImageOptions, ExecutionOptions, Model
 
-   encoder = encoder_registry.require("lunit")().to("cuda")
-   transform = encoder.get_dense_transform()
+   model = Model.from_preset("virchow2", device="cuda")
+   kit = model.prepare_dense_encoder(
+       dense=DenseImageOptions(
+           target_size=(1024, 768),
+           window_size=224,
+           overlap=0.5,
+           feature_kind="patch_features",
+       ),
+       execution=ExecutionOptions(precision="fp16", output_dtype="fp32"),
+   )
 
-   tile = Image.open("/data/tile.png").convert("RGB")
-   batch = transform(tile).unsqueeze(0).to(encoder.device)
+   preprocess = kit.preprocessor()  # lightweight and safe to pickle into workers
+   items = [preprocess(augmented_rgb_uint8_chw) for augmented_rgb_uint8_chw in images]
+   cpu_batch = torch.stack(items)    # batching starts after item preprocessing
+   grids = kit.encode(cpu_batch)
 
-   with torch.no_grad():
-       dense = encoder.encode_tiles_dense(batch)
+   print(cpu_batch.shape)            # (B, 3, Henc, Wenc), on CPU
+   print(grids.shape)                # (B, D, Gh, Gw), on the model device
 
-   print(dense.shape)  # torch.Size([1, 384, 28, 28]) for a 224 px Lunit tile
+``preprocessor()`` accepts exactly one unbatched CPU ``uint8`` RGB tensor. It
+does not resize or crop: the post-augmentation ``(H, W)`` must equal
+``kit.geometry.target_size``. It applies the encoder's normalization-only
+recipe and bottom/right padding, returning one CPU floating-point tensor with
+shape ``(3, Henc, Wenc)`` for normal DataLoader collation.
 
-The dense transform deliberately does not resize, crop, or pad. The input
-height and width passed to ``encode_tiles_dense`` must be divisible by the
-encoder patch size, unless the specific encoder is pinned to a native input
-size. Unsupported encoders raise ``NotImplementedError``.
+``encode(batch)`` accepts the resulting collated CPU tensor, transfers it to
+the model device, and returns an on-device grid with no gradient history.
+``D`` is the patch-feature dimension for ``feature_kind="patch_features"``;
+for ``"cls_attention"`` it is the selected block/head/prefix-query channel
+count, including register-token queries when requested. The result uses
+``ExecutionOptions.output_dtype``, or the same precision-derived default as
+persisted dense extraction.
 
-For H-Optimus encoders, non-native dense extraction requires opting into the
-variable-size model setting:
+The immutable ``kit.geometry`` is authoritative:
 
-.. code-block:: python
+- ``target_size`` — required augmented input ``(H, W)``;
+- ``patch_size`` — encoder patch ``(Ph, Pw)``;
+- ``encoded_size`` — padded encoder input ``(Henc, Wenc)``;
+- ``grid_shape`` — output ``(Gh, Gw)``;
+- ``pad`` — ``(bottom, right)`` padding;
+- ``crop_box`` — top-left ``(left, top, right, bottom)`` box for mapping the
+  padded extent back to the target.
 
-   encoder = encoder_registry.require("h-optimus-0")(
-       dynamic_img_size=True,
-       allow_non_recommended_settings=True,
-   ).to("cuda")
+Both :class:`DenseImageOptions` and :class:`DenseOptions` are accepted. Only
+their shared encoding fields apply: ``target_size``, padding, window/overlap,
+feature kind, and attention selection. Source-reading fields such as spacing,
+backend, and tolerance are outside this augmented-pixel interface and are
+ignored. This path never reads a source or creates caches, sidecars, artifacts,
+or output directories; corresponding persistence/execution fields have no
+effect. Reuse one prepared kit across loops or folds with the same resolved
+geometry and encoding recipe.
 
-Region-level streaming
-~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: slide2vec.DenseEncodeKit
+   :members:
+   :undoc-members:
+
+.. autoclass:: slide2vec.DenseEncodeGeometry
+   :members:
+   :undoc-members:
+
+Persisted Region Grids
+----------------------
 
 The public region entry point accepts level-0 point coordinates and the same
 optional source-spacing declaration as dense images:
@@ -230,71 +255,6 @@ optional source-spacing declaration as dense images:
 The coordinates remain in the source level-0 pixel frame. hs2p resolves the
 source declaration, backend, level, native read spacing, and effective encoded
 spacing once per source; every fact is persisted and checked by resume.
-
-The encoder-level API above operates on tiles you have already read and
-normalized. To extract dense grids over the regions of an hs2p ``TilingResult``,
-slide2vec provides a higher-level streaming primitive,
-``iter_regions_dense`` (from ``slide2vec.runtime.dense_regions``), that wraps the
-region reads, padding, and encoding into a single generator:
-
-.. code-block:: python
-
-   from slide2vec.runtime.dense_regions import iter_regions_dense
-
-   # ``tiling_result`` is an hs2p TilingResult (from annotation/tissue sampling);
-   # it already resolved spacing -> level (read_level / read_tile_size_px /
-   # requested_tile_size_px) and carries the region coordinates and slide path.
-   for grid in iter_regions_dense(
-       model=model,
-       device=model.device,
-       tiling_result=tiling_result,
-       num_workers=4,
-   ):
-       print(grid.shape)  # (d, grid_h, grid_w), float32
-
-Reads go through the **same shared batched reader the pooled path uses**
-(``WSIRegionReader``, cuCIM ``read_regions(num_workers=…)``). For each region the
-reader reads ``read_tile_size_px`` at ``read_level`` and, when that differs from
-``requested_tile_size_px``, **area-resizes** to the supervision size reusing
-hs2p's own ``resize_array(..., "area")`` — the identical operation the tiling
-planner assumed — so the read pixels are unchanged. Each region is then run
-through the encoder's normalization-only ``get_dense_transform``, padded on the
-bottom/right up to the encoder's patch multiple, and encoded into a
-``(d, grid_h, grid_w)`` token grid. The low-level backend is opened lazily via
-``slide2vec.data.tile_reader._open_wsi_backend``, so the loop runs offline in
-tests by monkeypatching that seam with a fake backend.
-
-Streaming contract:
-
-- Grids are yielded **one per coordinate, in coordinate order**; an empty
-  ``tiling_result`` yields nothing.
-- Regions are read and encoded one ``batch_size`` chunk at a time, so resident
-  host memory is bounded by ``batch_size`` rather than by the slide's coordinate
-  count — there is no per-slide accumulation.
-- Each yielded grid is a standalone C-contiguous ``float32`` copy, so consuming
-  one grid does not pin the rest of its batch's memory alive.
-- Arguments and geometry are validated **eagerly** at the call site (an invalid
-  ``pad_mode`` or ``feature_kind`` raises before any region is read); iteration
-  itself is lazy and advances one batch at a time.
-
-The ``window_size`` / ``overlap`` parameters select the encode strategy:
-
-- ``window_size=None`` (the default) runs a single whole-region forward —
-  byte-identical to encoding the full padded tile in one pass.
-- A ``window_size`` smaller than the encoded region slides the encoder's native
-  field over patch-aligned windows and blends the per-window token grids with a
-  separable raised-cosine map; ``overlap`` (in ``[0, 1)``) sets the fractional
-  window overlap and the stride is ``window * (1 - overlap)``. This lets a
-  native-field encoder serve a larger region without interpolating its position
-  embeddings. The output grid is always the whole region's ``(grid_h, grid_w)``
-  either way — sliding is internal to extraction.
-
-``feature_kind`` selects which dense map is streamed. ``"patch_features"`` (the
-default) uses ``encode_tiles_dense`` to produce the ``(d, grid_h, grid_w)``
-patch-token grid; ``"cls_attention"`` uses ``encode_tiles_attention`` to produce
-a ``(K, grid_h, grid_w)`` CLS-attention grid, with ``attention_blocks`` and
-``attention_include_registers`` forwarded to that call. Both feature kinds share
-the same read / pad / window path.
 
 Variable encoder input for dense runs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/release-notes/5.6.0.rst
+++ b/docs/release-notes/5.6.0.rst
@@ -1,6 +1,25 @@
 slide2vec 5.6.0
 ===============
 
+Live dense encoding after augmentation
+--------------------------------------
+
+``Model.prepare_dense_encoder`` now returns a shareable ``DenseEncodeKit`` for
+training and inference loops that already own paired reading and augmentation.
+Its pickle-safe item preprocessor accepts one CPU RGB ``uint8`` ``(3, H, W)``
+tensor and returns the normalized, bottom/right-padded ``(3, Henc, Wenc)``
+tensor. ``encode`` accepts the collated CPU batch and returns an on-device
+``(B, D, Gh, Gw)`` grid with the frozen encoder in evaluation/no-grad/autocast
+mode and the resolved output dtype.
+
+The immutable geometry records target, patch, encoded and grid sizes, padding,
+and the top-left crop box. Whole/sliding patch features and CLS attention use
+the same implementation as persisted dense extraction. This live path performs
+no source reading, caching, persistence, sidecar, artifact, or output-directory
+work. ``DenseImageOptions`` and ``DenseOptions`` are both accepted; their
+spacing, backend, and tolerance fields are outside the augmented-pixel handoff
+and therefore ignored.
+
 Dense-image migration
 ---------------------
 

--- a/slide2vec/__init__.py
+++ b/slide2vec/__init__.py
@@ -20,6 +20,7 @@ from slide2vec.artifacts import (
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
 )
+from slide2vec.runtime.dense_encode import DenseEncodeGeometry, DenseEncodeKit
 
 
 __version__ = "5.6.0"
@@ -31,6 +32,8 @@ __all__ = [
     "PreprocessingConfig",
     "DenseOptions",
     "DenseImageOptions",
+    "DenseEncodeGeometry",
+    "DenseEncodeKit",
     "SlideRegions",
     "ImageSpec",
     "ExecutionOptions",

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -322,9 +322,10 @@ class ExecutionOptions:
     #: Forward-pass dtype — ``"fp16"``, ``"bf16"``, ``"fp32"``,
     #: or ``None`` (auto-determined from the model preset).
     precision: str | None = None
-    #: On-disk feature dtype — ``"fp16"``, ``"fp32"``, or ``None`` to follow
-    #: :attr:`precision` (fp16 → fp16, else fp32). Applies to tile, slide, hierarchical,
-    #: and patient artifacts; ``"bf16"`` is rejected (numpy has no bfloat16).
+    #: Feature output dtype — ``"fp16"``, ``"fp32"``, or ``None`` to follow
+    #: :attr:`precision` (fp16 → fp16, else fp32). Applies to live dense grids and to
+    #: tile, slide, hierarchical, and patient artifacts; ``"bf16"`` is rejected because
+    #: persisted features cross a numpy boundary.
     output_dtype: str | None = None
     #: DataLoader prefetch queue depth per worker (default ``4``).
     prefetch_factor: int = 4
@@ -672,6 +673,33 @@ class Model:
     def feature_dim(self) -> int:
         # Construction fact, not an encode: see _load_backend_without_transform.
         return int(self._load_backend_without_transform().feature_dim)
+
+    def prepare_dense_encoder(
+        self,
+        *,
+        dense: "DenseImageOptions | DenseOptions",
+        execution: ExecutionOptions | None = None,
+    ):
+        """Prepare live dense encoding for one augmented RGB tensor at a time.
+
+        Only the encoding fields shared by :class:`DenseImageOptions` and
+        :class:`DenseOptions` apply after the augmented-pixel handoff. Source-reading
+        fields (spacing, tolerance, and backend) are intentionally ignored.
+        """
+        from slide2vec.runtime.dense_encode import _prepare_dense_encode_kit
+
+        if not isinstance(dense, (DenseImageOptions, DenseOptions)):
+            raise TypeError(
+                "Model.prepare_dense_encoder(dense=...) expects DenseImageOptions "
+                f"or DenseOptions, got {type(dense).__name__}"
+            )
+        if self.level != "tile":
+            raise ValueError(
+                "Model.prepare_dense_encoder(...) requires a tile-level foundation "
+                f"encoder; model {self.name!r} is registered at level {self.level!r}."
+            )
+        resolved = _coerce_execution_options(execution, model=self)
+        return _prepare_dense_encode_kit(self, dense=dense, execution=resolved)
 
     def embed_tiles(
         self,

--- a/slide2vec/runtime/dense_encode.py
+++ b/slide2vec/runtime/dense_encode.py
@@ -1,0 +1,334 @@
+"""Resolved tensor-in/tensor-out dense encoding for augmented pixels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+import torch
+
+from slide2vec.encoders.base import TileEncoder
+from slide2vec.encoders.registry import encoder_registry, resolve_patch_size
+from slide2vec.runtime.dense_regions import (
+    DenseGridGeometry,
+    DenseGridEncoder,
+    compute_dense_geometry,
+    pad_image_to_encoded,
+    validate_dense_request_settings,
+)
+from slide2vec.runtime.dense_encoder_input import DenseEncoderInputPlan
+from slide2vec.runtime.model_settings import output_torch_dtype, resolve_output_precision
+from slide2vec.runtime.slide_encode import slide_encode_autocast_ctx
+from slide2vec.runtime.worker_io import uses_cuda_runtime
+
+if TYPE_CHECKING:
+    from slide2vec.api import DenseImageOptions, DenseOptions, ExecutionOptions
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+    from slide2vec.runtime.types import LoadedModel
+
+
+@dataclass(frozen=True)
+class DenseEncodeGeometry:
+    """Immutable geometry of a live dense encoding run.
+
+    All sizes are ``(height, width)`` except ``crop_box``, which follows the common
+    ``(left, top, right, bottom)`` convention. Padding is bottom/right only.
+    """
+
+    target_size: tuple[int, int]
+    patch_size: tuple[int, int]
+    encoded_size: tuple[int, int]
+    grid_shape: tuple[int, int]
+    pad: tuple[int, int]
+    crop_box: tuple[int, int, int, int]
+
+    @classmethod
+    def _from_grid_geometry(cls, geometry) -> "DenseEncodeGeometry":
+        target_h, target_w = geometry.target_size
+        return cls(
+            target_size=geometry.target_size,
+            patch_size=geometry.patch_size,
+            encoded_size=geometry.encoded_size,
+            grid_shape=geometry.grid_shape,
+            pad=geometry.pad,
+            crop_box=(0, 0, target_w, target_h),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class _DenseEncodePlan:
+    geometry: DenseEncodeGeometry
+    grid_geometry: DenseGridGeometry
+    pad_mode: str
+    image_pad_value: float | None
+    window_size: int | None
+    overlap: float
+    feature_kind: str
+    attention_blocks: tuple[int, ...]
+    attention_include_registers: bool
+    precision: str
+    output_dtype: torch.dtype
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        contract: "EncoderInputContract",
+        dense: "DenseImageOptions | DenseOptions",
+        execution: "ExecutionOptions",
+    ) -> "_DenseEncodePlan":
+        contract_plan = contract.plan
+        if not isinstance(contract_plan, DenseEncoderInputPlan):
+            raise ValueError("Live dense encoding requires a declared encoder-input plan")
+        patch_size = resolve_patch_size(contract_plan.tile_encoder_name)
+        grid_geometry = compute_dense_geometry(
+            target_size=contract_plan.target_size_px,
+            patch_size=patch_size,
+        )
+        validate_dense_request_settings(
+            grid_geometry,
+            pad_mode=dense.pad_mode,
+            window_size=dense.window_size,
+            overlap=dense.overlap,
+            feature_kind=dense.feature_kind,
+            attention_blocks=dense.attention_blocks,
+            attention_include_registers=dense.attention_include_registers,
+        )
+        _validate_registered_feature_capability(
+            contract_plan.tile_encoder_name,
+            feature_kind=str(dense.feature_kind),
+        )
+        if execution.precision is None:
+            raise ValueError("Live dense encoder precision must be resolved before loading")
+        output_precision = resolve_output_precision(
+            execution.output_dtype, execution.precision
+        )
+        return cls(
+            geometry=DenseEncodeGeometry._from_grid_geometry(grid_geometry),
+            grid_geometry=grid_geometry,
+            pad_mode=str(dense.pad_mode),
+            image_pad_value=(
+                None if dense.image_pad_value is None else float(dense.image_pad_value)
+            ),
+            window_size=(
+                None if dense.window_size is None else int(dense.window_size)
+            ),
+            overlap=float(dense.overlap),
+            feature_kind=str(dense.feature_kind),
+            attention_blocks=tuple(int(block) for block in dense.attention_blocks),
+            attention_include_registers=bool(dense.attention_include_registers),
+            precision=str(execution.precision),
+            output_dtype=output_torch_dtype(output_precision),
+        )
+
+
+def _validate_registered_feature_capability(
+    encoder_name: str, *, feature_kind: str
+) -> None:
+    """Reject a feature method left at ``TileEncoder``'s unsupported default."""
+    encoder_cls = encoder_registry.require(encoder_name)
+    method_name = {
+        "patch_features": "encode_tiles_dense",
+        "cls_attention": "encode_tiles_attention",
+    }[feature_kind]
+    if getattr(encoder_cls, method_name) is getattr(TileEncoder, method_name):
+        raise ValueError(
+            f"Encoder {encoder_name!r} does not support {feature_kind}; choose a "
+            "registered dense feature kind implemented by this encoder."
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class _DenseItemPreprocessor:
+    """Pickle-safe normalization and padding recipe for one DataLoader item."""
+
+    transform: Callable[[object], object]
+    geometry: DenseGridGeometry
+    pad_mode: str
+    image_pad_value: float | None
+
+    def __call__(self, item: torch.Tensor) -> torch.Tensor:
+        if not torch.is_tensor(item):
+            raise TypeError(
+                "Dense preprocessing expects one CPU torch.Tensor in 3-D CHW layout; "
+                f"got {type(item).__name__}."
+            )
+        if item.device.type != "cpu":
+            raise ValueError(
+                "Dense preprocessing expects a CPU tensor so it is safe in DataLoader "
+                f"workers; got device {item.device}."
+            )
+        if item.ndim != 3:
+            raise ValueError(
+                "Dense preprocessing expects one unbatched RGB item in 3-D CHW layout "
+                f"(3, H, W); got shape {tuple(item.shape)}. Batching begins after "
+                "preprocessing."
+            )
+        if int(item.shape[0]) != 3:
+            raise ValueError(
+                "Dense preprocessing expects exactly 3 RGB channels in CHW layout; "
+                f"got shape {tuple(item.shape)}."
+            )
+        if item.dtype != torch.uint8:
+            raise TypeError(
+                "Dense preprocessing expects RGB pixels with dtype torch.uint8; "
+                f"got {item.dtype}."
+            )
+        tensor = torch.as_tensor(self.transform(item)).as_subclass(torch.Tensor)
+        if tensor.ndim != 3 or int(tensor.shape[0]) != 3:
+            raise ValueError(
+                "The shipped dense normalization transform must return one RGB tensor "
+                f"in (3, H, W) layout; got shape {tuple(tensor.shape)}."
+            )
+        observed = tuple(int(size) for size in tensor.shape[-2:])
+        if observed != self.geometry.target_size:
+            raise ValueError(
+                "Dense preprocessing received geometry "
+                f"{observed}, but the declared target_size is "
+                f"{self.geometry.target_size}. Supply one augmented tensor at the "
+                "declared geometry; slide2vec does not resize or crop this live path."
+            )
+        padded = pad_image_to_encoded(
+            tensor,
+            # The padding kernel reads only the five shared geometry fields.
+            self.geometry,
+            pad_mode=self.pad_mode,
+            image_pad_value=self.image_pad_value,
+        )
+        return padded.as_subclass(torch.Tensor)
+
+
+class DenseEncodeKit:
+    """A shareable live dense encoder for already-augmented RGB tensors.
+
+    This is deliberately a plain object rather than :class:`torch.nn.Module`; the
+    foundation encoder is private and cannot be registered accidentally by assigning
+    the kit to a trainable decoder.
+    """
+
+    __slots__ = ("__loaded", "__plan", "__grid_encoder")
+
+    def __init__(self, loaded: "LoadedModel", plan: _DenseEncodePlan) -> None:
+        encoder = cast(Any, loaded.model)
+        runtime_patch = tuple(int(value) for value in encoder.patch_size)
+        if runtime_patch != plan.geometry.patch_size:
+            raise ValueError(
+                "Loaded encoder patch geometry does not match the preflight plan: "
+                f"runtime {runtime_patch}, planned {plan.geometry.patch_size}."
+            )
+        self.__loaded = loaded
+        self.__plan = plan
+        _freeze_encoder(encoder)
+        self.__grid_encoder = DenseGridEncoder._from_resolved(
+            model=encoder,
+            geometry=plan.grid_geometry,
+            dense_transform=cast(Callable[[object], object], loaded.transforms),
+            target_size_origin="the declared target_size",
+            pad_mode=plan.pad_mode,
+            image_pad_value=plan.image_pad_value,
+            window_size=plan.window_size,
+            overlap=plan.overlap,
+            feature_kind=plan.feature_kind,
+            attention_blocks=plan.attention_blocks,
+            attention_include_registers=plan.attention_include_registers,
+            output_dtype=plan.output_dtype,
+        )
+
+    @property
+    def geometry(self) -> DenseEncodeGeometry:
+        """The authoritative immutable input, padding, and output-grid geometry."""
+        return self.__plan.geometry
+
+    def preprocessor(self) -> Callable[[torch.Tensor], torch.Tensor]:
+        """Return the serializable itemwise CPU preprocessor."""
+        return _DenseItemPreprocessor(
+            transform=self.__grid_encoder.dense_transform,
+            geometry=self.__plan.grid_geometry,
+            pad_mode=self.__plan.pad_mode,
+            image_pad_value=self.__plan.image_pad_value,
+        )
+
+    def encode(self, batch: torch.Tensor) -> torch.Tensor:
+        """Encode a collated CPU batch into a live on-device grid."""
+        if not torch.is_tensor(batch):
+            raise TypeError(
+                "DenseEncodeKit.encode expects a collated CPU torch.Tensor with shape "
+                f"(B, 3, Henc, Wenc); got {type(batch).__name__}."
+            )
+        if batch.device.type != "cpu":
+            raise ValueError(
+                "DenseEncodeKit.encode expects a collated CPU batch and owns transfer "
+                f"to the encoder device; got device {batch.device}."
+            )
+        if batch.ndim != 4:
+            raise ValueError(
+                "DenseEncodeKit.encode expects a collated 4-D batch in "
+                f"(B, 3, Henc, Wenc) layout; got shape {tuple(batch.shape)}."
+            )
+        if int(batch.shape[1]) != 3:
+            raise ValueError(
+                "DenseEncodeKit.encode expects exactly 3 RGB channels; got shape "
+                f"{tuple(batch.shape)}."
+            )
+        observed = tuple(int(size) for size in batch.shape[-2:])
+        if observed != self.geometry.encoded_size:
+            raise ValueError(
+                f"DenseEncodeKit.encode expected encoded_size {self.geometry.encoded_size}; "
+                f"got {observed}. Collate outputs from kit.preprocessor() without "
+                "resizing or cropping them."
+            )
+        if not batch.is_floating_point():
+            raise TypeError(
+                "DenseEncodeKit.encode expects a preprocessed floating-point batch; "
+                f"got {batch.dtype}. Apply kit.preprocessor() itemwise before collation."
+            )
+        loaded = self.__loaded
+        _freeze_encoder(cast(Any, loaded.model))
+        device_batch = batch.to(
+            loaded.device,
+            non_blocking=uses_cuda_runtime(loaded.device),
+        )
+        with torch.no_grad(), slide_encode_autocast_ctx(
+            loaded.device, self.__plan.precision
+        ):
+            output = self.__grid_encoder.encode_tensor(device_batch)
+        if output.device != torch.device(loaded.device):
+            raise ValueError(
+                "Dense encoder returned a grid on the wrong device: "
+                f"got {output.device}, expected {loaded.device}."
+            )
+        return output.detach()
+
+
+def _freeze_encoder(encoder) -> None:
+    """Freeze/evaluate every torch module owned directly by an encoder wrapper."""
+    modules = []
+    if isinstance(encoder, torch.nn.Module):
+        modules.append(encoder)
+    modules.extend(
+        value
+        for value in getattr(encoder, "__dict__", {}).values()
+        if isinstance(value, torch.nn.Module)
+    )
+    for module in modules:
+        module.requires_grad_(False)
+        module.eval()
+
+
+def _prepare_dense_encode_kit(
+    model,
+    *,
+    dense: "DenseImageOptions | DenseOptions",
+    execution: "ExecutionOptions",
+) -> DenseEncodeKit:
+    contract = model._declare_dense_encoder_input(dense, emit_run_info=True)
+    plan = _DenseEncodePlan.resolve(
+        contract=contract,
+        dense=dense,
+        execution=execution,
+    )
+    loaded = model._load_backend()
+    return DenseEncodeKit(loaded, plan)
+
+
+__all__ = ["DenseEncodeGeometry", "DenseEncodeKit"]

--- a/slide2vec/runtime/dense_encoder_input.py
+++ b/slide2vec/runtime/dense_encoder_input.py
@@ -65,6 +65,8 @@ class DenseEncoderInputPlan:
         from slide2vec.runtime.dense_regions import compute_dense_geometry
         from slide2vec.runtime.dense_sliding import resolve_window_geometry
 
+        if window_size is not None and int(window_size) <= 0:
+            raise ValueError("window_size must be positive")
         tile_encoder_name = str(
             resolve_preprocessing_requirements(encoder_name)["source_encoder"]
         )

--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -142,6 +142,15 @@ def validate_dense_request_settings(
         raise ValueError(
             f"unsupported pad_mode {pad_mode!r}; expected one of {sorted(_PAD_MODES)}"
         )
+    if pad_mode == "reflect":
+        target_h, target_w = geometry.target_size
+        pad_bottom, pad_right = geometry.pad
+        if pad_bottom >= target_h or pad_right >= target_w:
+            raise ValueError(
+                "reflect padding must be smaller than the input geometry in each "
+                f"dimension; target_size={geometry.target_size} requires bottom/right "
+                f"pad={geometry.pad}. Choose a larger target or another pad_mode."
+            )
     if feature_kind not in {"patch_features", "cls_attention"}:
         raise ValueError(
             f"unsupported feature_kind {feature_kind!r}; "
@@ -279,7 +288,7 @@ class DenseGridEncoder:
             attention_blocks=attention_blocks,
             attention_include_registers=attention_include_registers,
         )
-        return cls(
+        return cls._from_resolved(
             model=model,
             geometry=geometry,
             dense_transform=(
@@ -287,19 +296,52 @@ class DenseGridEncoder:
                 if dense_transform is None
                 else dense_transform
             ),
+            target_size_origin=str(target_size_origin),
+            pad_mode=str(pad_mode),
+            image_pad_value=image_pad_value,
+            window_size=None if window_size is None else int(window_size),
+            overlap=float(overlap),
+            feature_kind=str(feature_kind),
+            attention_blocks=tuple(attention_blocks),
+            attention_include_registers=bool(attention_include_registers),
+            output_dtype=_resolve_output_dtype(output_dtype, precision),
+        )
+
+    @classmethod
+    def _from_resolved(
+        cls,
+        *,
+        model,
+        geometry: DenseGridGeometry,
+        dense_transform: Callable,
+        target_size_origin: str,
+        pad_mode: str,
+        image_pad_value: float | None,
+        window_size: int | None,
+        overlap: float,
+        feature_kind: str,
+        attention_blocks: tuple[int, ...],
+        attention_include_registers: bool,
+        output_dtype: torch.dtype,
+    ) -> "DenseGridEncoder":
+        """Build from an already-validated plan without resolving its fields again."""
+        return cls(
+            model=model,
+            geometry=geometry,
+            dense_transform=dense_transform,
             encode_fn=_resolve_encode_fn(
                 model,
                 feature_kind=feature_kind,
                 attention_blocks=attention_blocks,
                 attention_include_registers=attention_include_registers,
             ),
-            feature_kind=str(feature_kind),
-            target_size_origin=str(target_size_origin),
-            pad_mode=str(pad_mode),
+            feature_kind=feature_kind,
+            target_size_origin=target_size_origin,
+            pad_mode=pad_mode,
             image_pad_value=image_pad_value,
-            window_size=None if window_size is None else int(window_size),
-            overlap=float(overlap),
-            output_dtype=_resolve_output_dtype(output_dtype, precision),
+            window_size=window_size,
+            overlap=overlap,
+            output_dtype=output_dtype,
         )
 
     def pad_to_encoded(self, tensor: torch.Tensor) -> torch.Tensor:
@@ -338,6 +380,15 @@ class DenseGridEncoder:
         short-circuits to a single whole-tile forward (byte-identical to the whole-region
         encode), so there is no separate whole-region branch.
         """
+        return self.encode_tensor(batch).detach().cpu().numpy()
+
+    def encode_tensor(self, batch: torch.Tensor) -> torch.Tensor:
+        """Padded batch → live ``(B, d, gh, gw)`` tensor on the input device.
+
+        The persisted path calls this same primitive before crossing its intentional
+        NumPy/CPU boundary in :meth:`encode_batch`; live consumers retain the tensor.
+        Autograd and autocast policy remain the owning caller's responsibility.
+        """
         out = encode_dense_sliding(
             self.model,
             batch,
@@ -350,7 +401,13 @@ class DenseGridEncoder:
             raise ValueError(
                 f"{self.feature_kind} encode returned a {out.ndim}-D tensor; expected (B, d, gh, gw)."
             )
-        return out.detach().to(self.output_dtype).cpu().numpy()
+        if int(out.shape[0]) != int(batch.shape[0]) or tuple(out.shape[-2:]) != self.geometry.grid_shape:
+            raise ValueError(
+                f"{self.feature_kind} encode returned shape {tuple(out.shape)}; expected "
+                f"(B, d, {self.geometry.grid_shape[0]}, {self.geometry.grid_shape[1]}) "
+                f"for batch size {int(batch.shape[0])}."
+            )
+        return out.to(self.output_dtype)
 
 
 def iter_regions_dense(

--- a/tests/test_dense_encode_kit.py
+++ b/tests/test_dense_encode_kit.py
@@ -1,0 +1,541 @@
+"""Public contract for live dense encoding after caller-owned augmentation."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import pickle
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torchvision.transforms import v2  # noqa: E402
+
+from slide2vec import (  # noqa: E402
+    DenseEncodeGeometry,
+    DenseEncodeKit,
+    DenseImageOptions,
+    DenseOptions,
+    ExecutionOptions,
+    Model,
+)
+from slide2vec.runtime.dense_regions import DenseGridEncoder  # noqa: E402
+
+
+class _LiteralBackbone(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.tensor(2.0))
+
+
+class _LiteralEncoder:
+    """Deterministic dense encoder used as an independent persisted/live oracle."""
+
+    def __init__(self) -> None:
+        self._model = _LiteralBackbone()
+        self._device = torch.device("cpu")
+        self.calls: list[tuple[str, bool, bool]] = []
+
+    @property
+    def patch_size(self):
+        return (14, 14)
+
+    @property
+    def device(self):
+        return self._device
+
+    def get_normalization_transform(self):
+        return v2.Compose(
+            [
+                v2.ToImage(),
+                v2.ToDtype(torch.float32, scale=True),
+                v2.Normalize(mean=(0.5, 0.25, 0.75), std=(0.25, 0.5, 0.125)),
+            ]
+        )
+
+    def encode_tiles_dense(self, batch):
+        self.calls.append(("patch_features", self._model.training, torch.is_grad_enabled()))
+        base = batch.mean(dim=1, keepdim=True)[:, :, ::14, ::14] * self._model.scale
+        return torch.cat((base, base + 1), dim=1)
+
+    def encode_tiles_attention(self, batch, *, blocks=(-1,), include_registers=False):
+        self.calls.append(("cls_attention", self._model.training, torch.is_grad_enabled()))
+        base = batch.mean(dim=1, keepdim=True)[:, :, ::14, ::14] * self._model.scale
+        channels = []
+        for block in blocks:
+            channels.append(base + float(block))
+            if include_registers:
+                channels.append(base - float(block))
+        return torch.cat(channels, dim=1)
+
+    def to(self, device):
+        self._device = torch.device(device)
+        self._model.to(device)
+        return self
+
+
+def _live_kit(monkeypatch, dense):
+    encoder = _LiteralEncoder()
+    loaded = SimpleNamespace(
+        model=encoder,
+        transforms=encoder.get_normalization_transform(),
+        device=torch.device("cpu"),
+    )
+    model = Model(name="virchow2", device="cpu")
+    monkeypatch.setattr(model, "_load_backend", lambda: loaded)
+    kit = model.prepare_dense_encoder(
+        dense=dense,
+        execution=ExecutionOptions(num_gpus=1, precision="fp32"),
+    )
+    return kit, encoder
+
+
+def _run_live_encode(monkeypatch, *, retrain=False, input_requires_grad=False):
+    kit, encoder = _live_kit(monkeypatch, _dense_image(target_size=28))
+    if retrain:
+        encoder._model.train()
+    batch = torch.zeros((1, 3, 28, 28), dtype=torch.float32)
+    batch.requires_grad_(input_requires_grad)
+    return kit.encode(batch), encoder
+
+
+def _decoder_with_kit(monkeypatch):
+    kit, _encoder = _live_kit(monkeypatch, _dense_image(target_size=28))
+
+    class Decoder(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dense_kit = kit
+            self.head = torch.nn.Conv2d(2, 1, kernel_size=1)
+
+    return Decoder()
+
+
+def _dense_image(**overrides) -> DenseImageOptions:
+    values = {"target_size": (29, 31), "spacing_um": 0.5}
+    values.update(overrides)
+    return DenseImageOptions(**values)
+
+
+def test_prepare_dense_encoder_returns_only_the_plain_kit_surface(monkeypatch):
+    kit, _encoder = _live_kit(monkeypatch, _dense_image())
+    assert isinstance(kit, DenseEncodeKit)
+    assert not isinstance(kit, torch.nn.Module)
+    assert not hasattr(kit, "model")
+    assert not hasattr(kit, "encoder")
+    assert not hasattr(kit, "parameters")
+    assert not hasattr(kit, "state_dict")
+
+
+def test_prepare_dense_encoder_exposes_the_complete_resolved_geometry(monkeypatch):
+    kit, _encoder = _live_kit(monkeypatch, _dense_image())
+    assert kit.geometry == DenseEncodeGeometry(
+        target_size=(29, 31),
+        patch_size=(14, 14),
+        encoded_size=(42, 42),
+        grid_shape=(3, 3),
+        pad=(13, 11),
+        crop_box=(0, 0, 31, 29),
+    )
+
+
+def test_dense_encode_geometry_is_immutable(monkeypatch):
+    kit, _encoder = _live_kit(monkeypatch, _dense_image())
+    with pytest.raises(FrozenInstanceError):
+        kit.geometry.pad = (0, 0)
+
+
+@pytest.mark.parametrize(
+    "dense",
+    [
+        DenseImageOptions(
+            target_size=28,
+            spacing_um=0.25,
+            tolerance=0.01,
+            backend="pil",
+        ),
+        DenseOptions(
+            target_size=28,
+            spacing_um=2.0,
+            tolerance=0.2,
+            backend="openslide",
+        ),
+    ],
+    ids=["dense-image-options", "dense-region-options"],
+)
+def test_prepare_dense_encoder_accepts_both_option_types_and_ignores_source_fields(
+    dense, monkeypatch
+):
+    kit, _encoder = _live_kit(monkeypatch, dense)
+
+    assert kit.geometry == DenseEncodeGeometry(
+        target_size=(28, 28),
+        patch_size=(14, 14),
+        encoded_size=(28, 28),
+        grid_shape=(2, 2),
+        pad=(0, 0),
+        crop_box=(0, 0, 28, 28),
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "dense", "message"),
+    [
+        ("virchow2", _dense_image(target_size=0), "target_size must be positive"),
+        ("virchow2", _dense_image(pad_mode="edge"), "unsupported pad_mode"),
+        (
+            "virchow2",
+            _dense_image(target_size=7, pad_mode="reflect"),
+            "reflect padding.*smaller than the input geometry",
+        ),
+        ("virchow2", _dense_image(window_size=0), "window_size must be positive"),
+        (
+            "virchow2",
+            _dense_image(window_size=14, overlap=1.0),
+            r"overlap must be in \[0, 1\)",
+        ),
+        ("virchow2", _dense_image(feature_kind="pooled"), "unsupported feature_kind"),
+        (
+            "virchow2",
+            _dense_image(feature_kind="cls_attention", attention_blocks=()),
+            "attention_blocks must contain at least one block",
+        ),
+        (
+            "virchow2",
+            _dense_image(attention_blocks=("last",)),
+            "attention_blocks must contain only integers",
+        ),
+        (
+            "virchow2",
+            _dense_image(attention_include_registers=1),
+            "attention_include_registers must be a boolean",
+        ),
+        (
+            "phikon",
+            _dense_image(target_size=512),
+            "does not support a variable encoder input",
+        ),
+    ],
+)
+def test_prepare_dense_encoder_rejects_invalid_requests_before_loading(
+    model_name, dense, message, monkeypatch
+):
+    model = Model(name=model_name, device="cpu")
+    load_attempted = False
+
+    def _unexpected_load():
+        nonlocal load_attempted
+        load_attempted = True
+        raise AssertionError("large encoder must not load for an invalid request")
+
+    monkeypatch.setattr(model, "_load_backend", _unexpected_load)
+
+    with pytest.raises(ValueError, match=message):
+        model.prepare_dense_encoder(
+            dense=dense,
+            execution=ExecutionOptions(num_gpus=1, precision="fp32"),
+        )
+
+    assert load_attempted is False
+
+
+def test_prepare_dense_encoder_rejects_unsupported_attention_before_loading(monkeypatch):
+    model = Model(name="musk", device="cpu")
+    load_attempted = False
+
+    def _unexpected_load():
+        nonlocal load_attempted
+        load_attempted = True
+        raise AssertionError("unsupported attention must fail from the registered class")
+
+    monkeypatch.setattr(model, "_load_backend", _unexpected_load)
+
+    with pytest.raises(ValueError, match="does not support cls_attention"):
+        model.prepare_dense_encoder(
+            dense=_dense_image(target_size=384, feature_kind="cls_attention"),
+            execution=ExecutionOptions(num_gpus=1, precision="fp32"),
+        )
+
+    assert load_attempted is False
+
+
+def test_prepare_dense_encoder_rejects_non_tile_models_before_loading(monkeypatch):
+    model = Model(name="gigapath-slide", device="cpu")
+    load_attempted = False
+
+    def _unexpected_load():
+        nonlocal load_attempted
+        load_attempted = True
+        raise AssertionError("non-tile model must fail from registry metadata")
+
+    monkeypatch.setattr(model, "_load_backend", _unexpected_load)
+
+    with pytest.raises(ValueError, match="tile-level foundation encoder"):
+        model.prepare_dense_encoder(
+            dense=_dense_image(target_size=224),
+            execution=ExecutionOptions(num_gpus=1, precision="fp32"),
+        )
+
+    assert load_attempted is False
+
+
+def test_prepare_dense_encoder_asserts_runtime_patch_metadata(monkeypatch):
+    class _WrongPatchEncoder(_LiteralEncoder):
+        @property
+        def patch_size(self):
+            return (16, 16)
+
+    encoder = _WrongPatchEncoder()
+    loaded = SimpleNamespace(
+        model=encoder,
+        transforms=encoder.get_normalization_transform(),
+        device=torch.device("cpu"),
+    )
+    model = Model(name="virchow2", device="cpu")
+    monkeypatch.setattr(model, "_load_backend", lambda: loaded)
+
+    with pytest.raises(ValueError, match="runtime.*planned"):
+        model.prepare_dense_encoder(
+            dense=_dense_image(target_size=28),
+            execution=ExecutionOptions(num_gpus=1, precision="fp32"),
+        )
+
+
+def test_worker_preprocessor_exactly_matches_persisted_dense_preprocessing(monkeypatch):
+    dense = _dense_image(
+        target_size=(13, 14),
+        pad_mode="constant",
+        image_pad_value=7.0,
+    )
+    kit, encoder = _live_kit(monkeypatch, dense)
+    pixels = torch.zeros((3, 13, 14), dtype=torch.uint8)
+    persisted = DenseGridEncoder.resolve(
+        encoder,
+        target_size=(13, 14),
+        target_size_origin="the declared target_size",
+        pad_mode="constant",
+        image_pad_value=7.0,
+        precision="fp32",
+        output_dtype=torch.float32,
+    ).transform_and_pad(pixels.permute(1, 2, 0).numpy(), origin="literal")
+    expected = torch.empty((3, 14, 14), dtype=torch.float32)
+    expected[0, :13].fill_(-2.0)
+    expected[1, :13].fill_(-0.5)
+    expected[2, :13].fill_(-6.0)
+    expected[:, 13].fill_(7.0)
+
+    live = kit.preprocessor()(pixels)
+
+    assert torch.equal(persisted, expected)
+    assert torch.equal(live, expected)
+
+
+def test_worker_preprocessor_is_serializable_without_the_encoder(monkeypatch):
+    kit, _encoder = _live_kit(monkeypatch, _dense_image(target_size=(27, 25)))
+    preprocess = kit.preprocessor()
+    restored = pickle.loads(pickle.dumps(preprocess))
+    pixels = torch.zeros((3, 27, 25), dtype=torch.uint8)
+
+    assert not hasattr(restored, "encoder")
+    assert not hasattr(restored, "model")
+    assert torch.equal(restored(pixels), preprocess(pixels))
+
+
+@pytest.mark.parametrize(
+    ("item", "message"),
+    [
+        (torch.zeros((1, 3, 27, 25), dtype=torch.uint8), "one unbatched.*3-D CHW"),
+        (torch.zeros((27, 25), dtype=torch.uint8), "one unbatched.*3-D CHW"),
+        (torch.zeros((1, 27, 25), dtype=torch.uint8), "exactly 3 RGB channels"),
+        (torch.zeros((3, 27, 25), dtype=torch.float32), "dtype torch.uint8"),
+        (torch.zeros((3, 26, 25), dtype=torch.uint8), "declared target_size.*27, 25"),
+        (torch.zeros((3, 27, 25), dtype=torch.uint8, device="meta"), "CPU tensor"),
+    ],
+    ids=["batched", "non-chw", "non-rgb", "wrong-dtype", "wrong-geometry", "non-cpu"],
+)
+def test_worker_preprocessor_rejects_invalid_items_with_actionable_errors(
+    item, message, monkeypatch
+):
+    kit, _encoder = _live_kit(monkeypatch, _dense_image(target_size=(27, 25)))
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        kit.preprocessor()(item)
+
+
+@pytest.mark.parametrize(
+    ("target_size", "window_size", "feature_kind", "expected_values", "expected_shape"),
+    [
+        (28, None, "patch_features", (0.0, 1.0), (2, 2, 2, 2)),
+        (56, 28, "patch_features", (0.0, 1.0), (2, 2, 4, 4)),
+        (28, None, "cls_attention", (-1.0, 1.0, -2.0, 2.0), (2, 4, 2, 2)),
+        (56, 28, "cls_attention", (-1.0, 1.0, -2.0, 2.0), (2, 4, 4, 4)),
+    ],
+    ids=[
+        "whole-patch-features",
+        "sliding-patch-features",
+        "whole-cls-attention",
+        "sliding-cls-attention",
+    ],
+)
+def test_live_encode_is_torch_equal_to_persisted_extraction(
+    target_size, window_size, feature_kind, expected_values, expected_shape, monkeypatch
+):
+    dense = _dense_image(
+        target_size=target_size,
+        window_size=window_size,
+        overlap=0.5,
+        feature_kind=feature_kind,
+        attention_blocks=(-1, -2),
+        attention_include_registers=True,
+    )
+    kit, encoder = _live_kit(monkeypatch, dense)
+    batch = torch.zeros((2, 3, target_size, target_size), dtype=torch.float32)
+    persisted_encoder = DenseGridEncoder.resolve(
+        encoder,
+        target_size=target_size,
+        target_size_origin="the declared target_size",
+        pad_mode="reflect",
+        window_size=window_size,
+        overlap=0.5,
+        feature_kind=feature_kind,
+        attention_blocks=(-1, -2),
+        attention_include_registers=True,
+        precision="fp32",
+        output_dtype=torch.float32,
+        dense_transform=encoder.get_normalization_transform(),
+    )
+    with torch.no_grad():
+        persisted = torch.from_numpy(persisted_encoder.encode_batch(batch))
+    expected = (
+        torch.tensor(expected_values, dtype=torch.float32)
+        .reshape(1, len(expected_values), 1, 1)
+        .expand(expected_shape)
+    )
+
+    live = kit.encode(batch)
+
+    assert torch.equal(persisted, expected)
+    assert torch.equal(live, expected)
+
+
+def test_prepare_dense_encoder_freezes_foundation_parameters(monkeypatch):
+    _kit, encoder = _live_kit(monkeypatch, _dense_image(target_size=28))
+    assert all(parameter.requires_grad is False for parameter in encoder._model.parameters())
+
+
+def test_prepare_dense_encoder_sets_foundation_eval_mode(monkeypatch):
+    _kit, encoder = _live_kit(monkeypatch, _dense_image(target_size=28))
+    assert encoder._model.training is False
+
+
+def test_live_encode_restores_foundation_eval_mode(monkeypatch):
+    _output, encoder = _run_live_encode(monkeypatch, retrain=True)
+    assert encoder._model.training is False
+
+
+def test_live_encode_disables_grad_during_the_forward(monkeypatch):
+    _output, encoder = _run_live_encode(monkeypatch, input_requires_grad=True)
+    assert encoder.calls[-1][2] is False
+
+
+def test_live_encode_output_has_no_gradient_history(monkeypatch):
+    output, _encoder = _run_live_encode(monkeypatch, input_requires_grad=True)
+    assert output.requires_grad is False
+    assert output.grad_fn is None
+
+
+def test_kit_does_not_register_encoder_as_a_decoder_module(monkeypatch):
+    decoder = _decoder_with_kit(monkeypatch)
+    assert set(dict(decoder.named_modules())) == {"", "head"}
+
+
+def test_kit_does_not_register_encoder_in_a_decoder_checkpoint(monkeypatch):
+    decoder = _decoder_with_kit(monkeypatch)
+    assert set(decoder.state_dict()) == {"head.weight", "head.bias"}
+
+
+def test_kit_does_not_register_encoder_in_a_decoder_optimizer(monkeypatch):
+    decoder = _decoder_with_kit(monkeypatch)
+    optimizer = torch.optim.SGD(decoder.parameters(), lr=0.1)
+    assert optimizer.param_groups[0]["params"] == list(decoder.head.parameters())
+
+
+def test_live_encode_returns_the_resolved_output_dtype(monkeypatch):
+    encoder = _LiteralEncoder()
+    loaded = SimpleNamespace(
+        model=encoder,
+        transforms=encoder.get_normalization_transform(),
+        device=torch.device("cpu"),
+    )
+    model = Model(name="virchow2", device="cpu")
+    monkeypatch.setattr(model, "_load_backend", lambda: loaded)
+    kit = model.prepare_dense_encoder(
+        dense=_dense_image(target_size=28),
+        execution=ExecutionOptions(
+            num_gpus=1,
+            precision="fp32",
+            output_dtype="fp16",
+        ),
+    )
+    batch = torch.stack(
+        [kit.preprocessor()(torch.zeros((3, 28, 28), dtype=torch.uint8))]
+    )
+
+    output = kit.encode(batch)
+
+    assert output.dtype == torch.float16
+
+
+def test_live_encode_returns_on_the_encoder_device(monkeypatch):
+    kit, _encoder = _live_kit(monkeypatch, _dense_image(target_size=28))
+    output = kit.encode(torch.zeros((1, 3, 28, 28), dtype=torch.float32))
+
+    assert output.device == torch.device("cpu")
+
+
+@pytest.mark.parametrize(
+    ("batch", "message"),
+    [
+        (torch.zeros((3, 28, 28)), "collated 4-D.*B, 3, Henc, Wenc"),
+        (torch.zeros((2, 1, 28, 28)), "exactly 3 RGB channels"),
+        (torch.zeros((2, 3, 14, 28)), "encoded_size.*28, 28"),
+        (torch.zeros((2, 3, 28, 28), dtype=torch.uint8), "preprocessed floating-point"),
+        (torch.zeros((2, 3, 28, 28), device="meta"), "collated CPU batch"),
+    ],
+    ids=["unbatched", "non-rgb", "wrong-geometry", "not-preprocessed", "non-cpu"],
+)
+def test_live_encode_rejects_invalid_batches_with_actionable_errors(
+    batch, message, monkeypatch
+):
+    kit, _encoder = _live_kit(monkeypatch, _dense_image(target_size=28))
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        kit.encode(batch)
+
+
+def test_live_kit_has_no_filesystem_or_artifact_side_effects(tmp_path, monkeypatch):
+    output_dir = tmp_path / "must-not-be-created"
+    encoder = _LiteralEncoder()
+    loaded = SimpleNamespace(
+        model=encoder,
+        transforms=encoder.get_normalization_transform(),
+        device=torch.device("cpu"),
+    )
+    model = Model(name="virchow2", device="cpu")
+    monkeypatch.setattr(model, "_load_backend", lambda: loaded)
+
+    kit = model.prepare_dense_encoder(
+        dense=_dense_image(target_size=28),
+        execution=ExecutionOptions(
+            output_dir=output_dir,
+            num_gpus=1,
+            precision="fp32",
+        ),
+    )
+    batch = torch.stack(
+        [kit.preprocessor()(torch.zeros((3, 28, 28), dtype=torch.uint8))]
+    )
+    kit.encode(batch)
+
+    assert not output_dir.exists()
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
Closes #267

## Summary
- add the public plain-object DenseEncodeKit and immutable DenseEncodeGeometry
- prepare worker-safe RGB uint8 preprocessing and on-device frozen dense encoding from Model.prepare_dense_encoder
- share the persisted DenseGridEncoder tensor substrate while preserving exact whole/sliding patch-feature and CLS-attention behavior
- validate geometry, padding, feature capability, attention options, and variable-input support before loading weights
- document augmented-pixel ownership, tensor shapes, ignored source-reading fields, and the no-I/O contract

## Verification
- focused public contract: 46 passed
- adjacent dense suite: 176 passed
- full non-heavy/non-GPU suite: 841 passed, 32 deselected
- Sphinx warnings-as-errors build passed
- new-module flake8 and isolated mypy passed
- repeated Standards and Spec reviews found no remaining findings