### PR TITLE
Add Phaet pooled and dense tile embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ pip install git+https://github.com/prov-gigapath/prov-gigapath.git
 
 AtlasPatch-backed tissue segmentation is available through hs2p's `sam2` path in the bundled install.
 
+Waiv encoders use a separately tested Transformers 5 runtime. Install them in
+their own environment with `pip install "slide2vec[waiv]"`; the `waiv` extra is
+incompatible with the existing `fm`, `prism`, and `titan` dependency pins.
+
 ## Python API
 
 ```python
@@ -119,7 +123,8 @@ The package writes explicit artifact directories:
 
 ### Supported Models
 
-`slide2vec` currently ships preset configs for 22 tile-level models and 3 slide-level models.  
+`slide2vec` currently ships presets for 24 tile-level models, 4 slide-level models,
+and 1 patient-level model.
 For the full catalog and preset names, see [`docs/models.md`](docs/models.md).
 
 ## CLI

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -63,6 +63,11 @@ Tile-level encoders
      - 1024
      - ``0.5``
      - Filiot et al. (2024)
+   * - ``phaet``
+     - `Phaet <https://huggingface.co/wearewaiv/phaet>`_
+     - 1024
+     - ``0.5`` (inferred)
+     - Waiv (2026); spacing inferred from the Phikon-v2 base model
    * - ``hibou-l``
      - `Hibou-L <https://huggingface.co/histai/hibou-L>`_
      - 1024
@@ -212,7 +217,7 @@ The following built-in tile presets are covered by the dense encoder interface:
 ``conch``, ``conchv15``, ``dinov2-vitb14``, ``genbio-pathfm``, ``gigapath``,
 ``gpfm``, ``h0-mini``, ``h-optimus-0``, ``h-optimus-1``, ``hibou-b``,
 ``hibou-l``, ``isight``, ``lunit``, ``midnight``, ``mstar``, ``musk``,
-``phikon``, ``phikonv2``, ``prost40m``, ``uni``, ``uni2``, ``virchow``, and
+``phaet``, ``phikon``, ``phikonv2``, ``prost40m``, ``uni``, ``uni2``, ``virchow``, and
 ``virchow2``.
 
 Notes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,11 @@ titan = [
     "einops-exts==0.0.4",
     "transformers==4.46.0",
 ]
+waiv = [
+    "transformers>=5.14,<6",
+    "safetensors>=0.8",
+    "huggingface_hub==1.25.1",
+]
 fm = [
     "omegaconf>=2.3.0",
     "matplotlib",

--- a/slide2vec/encoders/models/__init__.py
+++ b/slide2vec/encoders/models/__init__.py
@@ -23,6 +23,7 @@ from . import (
     titan,
     uni,
     virchow,
+    waiv,
 )
 
 __all__ = [
@@ -45,4 +46,5 @@ __all__ = [
     "titan",
     "uni",
     "virchow",
+    "waiv",
 ]

--- a/slide2vec/encoders/models/waiv.py
+++ b/slide2vec/encoders/models/waiv.py
@@ -22,6 +22,7 @@ class _WaivEncoder(TileEncoder):
     """Shared runtime boundary for Waiv's reviewed Hugging Face remote code."""
 
     _encode_dim: int
+    _patch_size: int
 
     def __init__(
         self,
@@ -74,7 +75,7 @@ class _WaivEncoder(TileEncoder):
                 f"{tuple(batch.shape)}."
             )
         _, _, height, width = batch.shape
-        patch = int(self._model.config.patch_size)
+        patch = self._patch_size
         if height % patch != 0 or width % patch != 0:
             raise ValueError(
                 f"Dense extraction for '{type(self).__name__}' requires input "
@@ -96,8 +97,7 @@ class _WaivEncoder(TileEncoder):
 
     @property
     def patch_size(self) -> tuple[int, int]:
-        patch = int(self._model.config.patch_size)
-        return patch, patch
+        return self._patch_size, self._patch_size
 
     @property
     def device(self) -> torch.device:
@@ -124,6 +124,7 @@ class Phaet(_WaivEncoder):
     """Phaet tile encoder."""
 
     _encode_dim = 1024
+    _patch_size = 16
 
     def __init__(self, *, output_variant: str | None = None):
         super().__init__(

--- a/slide2vec/encoders/models/waiv.py
+++ b/slide2vec/encoders/models/waiv.py
@@ -16,12 +16,15 @@ from slide2vec.encoders.base import (
 from slide2vec.encoders.registry import register_encoder
 
 _PHAET_REVISION = "e0ce6e0ee248470bd8604823e412ca64048a2495"
+_PHAET_INPUT_SIZE = 224
+_PHAET_PATCH_SIZE = 16
 
 
 class _WaivEncoder(TileEncoder):
     """Shared runtime boundary for Waiv's reviewed Hugging Face remote code."""
 
     _encode_dim: int
+    _input_size: int
     _patch_size: int
 
     def __init__(
@@ -49,8 +52,8 @@ class _WaivEncoder(TileEncoder):
         return v2.Compose(
             [
                 v2.ToImage(),
-                v2.Resize(224),
-                v2.CenterCrop(224),
+                v2.Resize(self._input_size),
+                v2.CenterCrop(self._input_size),
                 v2.ToDtype(torch.float32, scale=True),
                 self._normalization(),
             ]
@@ -113,9 +116,9 @@ class _WaivEncoder(TileEncoder):
     "phaet",
     output_variants={"default": {"encode_dim": 1024}},
     default_output_variant="default",
-    input_size=224,
+    input_size=_PHAET_INPUT_SIZE,
     supports_variable_input_size=False,
-    patch_size=16,
+    patch_size=_PHAET_PATCH_SIZE,
     supported_spacing_um=0.5,
     precision="fp32",
     source="wearewaiv/phaet",
@@ -124,7 +127,8 @@ class Phaet(_WaivEncoder):
     """Phaet tile encoder."""
 
     _encode_dim = 1024
-    _patch_size = 16
+    _input_size = _PHAET_INPUT_SIZE
+    _patch_size = _PHAET_PATCH_SIZE
 
     def __init__(self, *, output_variant: str | None = None):
         super().__init__(

--- a/slide2vec/encoders/models/waiv.py
+++ b/slide2vec/encoders/models/waiv.py
@@ -1,0 +1,133 @@
+"""Waiv tile encoders."""
+
+from typing import Callable
+
+import torch
+from torch import Tensor
+from torchvision.transforms import v2
+from transformers import AutoModel
+
+from slide2vec.encoders.base import (
+    TileEncoder,
+    preferred_default_device,
+    reshape_tokens_to_grid,
+    resolve_requested_output_variant,
+)
+from slide2vec.encoders.registry import register_encoder
+
+_PHAET_REVISION = "e0ce6e0ee248470bd8604823e412ca64048a2495"
+
+
+class _WaivEncoder(TileEncoder):
+    """Shared runtime boundary for Waiv's reviewed Hugging Face remote code."""
+
+    _encode_dim: int
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        revision: str,
+        output_variant: str | None,
+    ):
+        self._model = AutoModel.from_pretrained(
+            model_name,
+            trust_remote_code=True,
+            revision=revision,
+        ).eval()
+        self._device = preferred_default_device()
+        self._output_variant = resolve_requested_output_variant(output_variant)
+
+    def _normalization(self) -> v2.Normalize:
+        return v2.Normalize(
+            mean=self._model.config.pixel_mean,
+            std=self._model.config.pixel_std,
+        )
+
+    def get_transform(self) -> Callable:
+        return v2.Compose(
+            [
+                v2.ToImage(),
+                v2.Resize(224),
+                v2.CenterCrop(224),
+                v2.ToDtype(torch.float32, scale=True),
+                self._normalization(),
+            ]
+        )
+
+    def get_normalization_transform(self) -> Callable:
+        return v2.Compose(
+            [
+                v2.ToImage(),
+                v2.ToDtype(torch.float32, scale=True),
+                self._normalization(),
+            ]
+        )
+
+    def encode_tiles(self, batch: Tensor) -> Tensor:
+        return self._model.encode(batch)
+
+    def encode_tiles_dense(self, batch: Tensor) -> Tensor:
+        if batch.ndim != 4:
+            raise ValueError(
+                "encode_tiles_dense expects a (B, C, H, W) batch, got shape "
+                f"{tuple(batch.shape)}."
+            )
+        _, _, height, width = batch.shape
+        patch = int(self._model.config.patch_size)
+        if height % patch != 0 or width % patch != 0:
+            raise ValueError(
+                f"Dense extraction for '{type(self).__name__}' requires input "
+                f"divisible by the patch size: got {height}x{width}, patch "
+                f"{patch}. Pad the tile up to a patch multiple first."
+            )
+        output = self._model(pixel_values=batch)
+        return reshape_tokens_to_grid(
+            output.last_hidden_state,
+            grid_h=height // patch,
+            grid_w=width // patch,
+            num_prefix_tokens=1,
+            encoder_name=type(self).__name__,
+        )
+
+    @property
+    def encode_dim(self) -> int:
+        return self._encode_dim
+
+    @property
+    def patch_size(self) -> tuple[int, int]:
+        patch = int(self._model.config.patch_size)
+        return patch, patch
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    def to(self, device: torch.device | str) -> "_WaivEncoder":
+        self._device = torch.device(device)
+        self._model = self._model.to(self._device)
+        return self
+
+
+@register_encoder(
+    "phaet",
+    output_variants={"default": {"encode_dim": 1024}},
+    default_output_variant="default",
+    input_size=224,
+    supports_variable_input_size=False,
+    patch_size=16,
+    supported_spacing_um=0.5,
+    precision="fp32",
+    source="wearewaiv/phaet",
+)
+class Phaet(_WaivEncoder):
+    """Phaet tile encoder."""
+
+    _encode_dim = 1024
+
+    def __init__(self, *, output_variant: str | None = None):
+        super().__init__(
+            "wearewaiv/phaet",
+            revision=_PHAET_REVISION,
+            output_variant=output_variant,
+        )

--- a/tests/test_encoder_registry.py
+++ b/tests/test_encoder_registry.py
@@ -27,6 +27,7 @@ EXPECTED_TILE_ENCODERS = {
     "musk",
     "phikon",
     "phikonv2",
+    "phaet",
     "prost40m",
 }
 

--- a/tests/test_patch_size_metadata.py
+++ b/tests/test_patch_size_metadata.py
@@ -41,6 +41,7 @@ DENSE_PATCH_SIZES: dict[str, tuple[int, int]] = {
     "dinov2-vitb14": (14, 14),
     "phikon": (16, 16),
     "phikonv2": (16, 16),
+    "phaet": (16, 16),
     "midnight": (14, 14),
     "mstar": (16, 16),
     "musk": (16, 16),

--- a/tests/test_phaet.py
+++ b/tests/test_phaet.py
@@ -1,0 +1,340 @@
+"""Public contract tests for the Phaet tile-encoder preset."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+transformers = pytest.importorskip("transformers")
+
+
+def test_phaet_is_a_public_fixed_input_tile_preset():
+    from slide2vec import Model, list_models
+    from slide2vec.encoders import encoder_registry
+
+    model = Model.from_preset("phaet")
+
+    assert "phaet" in list_models("tile")
+    assert model.name == "phaet"
+    assert model.level == "tile"
+    assert encoder_registry.info("phaet") == {
+        "name": "phaet",
+        "output_variants": {"default": {"encode_dim": 1024}},
+        "default_output_variant": "default",
+        "level": "tile",
+        "input_size": 224,
+        "supports_variable_input_size": False,
+        "variable_input_model_kwargs": {},
+        "patch_size": 16,
+        "tile_encoder": None,
+        "tile_encoder_output_variant": None,
+        "supported_spacing_um": 0.5,
+        "default_spacing_um": None,
+        "precision": "fp32",
+        "source": "wearewaiv/phaet",
+    }
+
+
+def test_phaet_loads_the_reviewed_remote_code_revision_in_eval_mode(monkeypatch):
+    from types import SimpleNamespace
+
+    from slide2vec.encoders.models.waiv import Phaet
+
+    calls = []
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(patch_size=16)
+
+    fake_model = FakeModel()
+
+    def fake_from_pretrained(model_id, **kwargs):
+        calls.append((model_id, kwargs))
+        return fake_model
+
+    monkeypatch.setattr(transformers.AutoModel, "from_pretrained", fake_from_pretrained)
+
+    encoder = Phaet()
+
+    assert calls == [
+        (
+            "wearewaiv/phaet",
+            {
+                "trust_remote_code": True,
+                "revision": "e0ce6e0ee248470bd8604823e412ca64048a2495",
+            },
+        )
+    ]
+    assert encoder._model is fake_model
+    assert fake_model.training is False
+
+
+def test_phaet_pooled_transform_uses_shorter_side_crop_and_config_normalization(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from slide2vec.encoders.models.waiv import Phaet
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(
+                patch_size=16,
+                pixel_mean=[0.25, 0.5, 0.75],
+                pixel_std=[0.5, 0.25, 0.25],
+            )
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: FakeModel(),
+    )
+    encoder = Phaet()
+
+    transform = encoder.get_transform()
+    output = transform(torch.zeros(3, 112, 224, dtype=torch.uint8))
+
+    assert [type(step).__name__ for step in transform.transforms] == [
+        "ToImage",
+        "Resize",
+        "CenterCrop",
+        "ToDtype",
+        "Normalize",
+    ]
+    assert transform.transforms[1].size == [224]
+    assert transform.transforms[2].size == (224, 224)
+    assert output.shape == (3, 224, 224)
+    expected = torch.empty(3, 224, 224)
+    expected[0].fill_(-0.5)
+    expected[1].fill_(-2.0)
+    expected[2].fill_(-3.0)
+    torch.testing.assert_close(
+        output.as_subclass(torch.Tensor), expected, rtol=0, atol=0
+    )
+
+
+def test_phaet_dense_normalization_preserves_geometry(monkeypatch):
+    from types import SimpleNamespace
+
+    from slide2vec.encoders.models.waiv import Phaet
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(
+                patch_size=16,
+                pixel_mean=[0.25, 0.5, 0.75],
+                pixel_std=[0.5, 0.25, 0.25],
+            )
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: FakeModel(),
+    )
+    encoder = Phaet()
+
+    transform = encoder.get_normalization_transform()
+    output = transform(torch.zeros(3, 320, 288, dtype=torch.uint8))
+
+    assert [type(step).__name__ for step in transform.transforms] == [
+        "ToImage",
+        "ToDtype",
+        "Normalize",
+    ]
+    assert output.shape == (3, 320, 288)
+    expected = torch.empty(3, 320, 288)
+    expected[0].fill_(-0.5)
+    expected[1].fill_(-2.0)
+    expected[2].fill_(-3.0)
+    torch.testing.assert_close(
+        output.as_subclass(torch.Tensor), expected, rtol=0, atol=0
+    )
+
+
+def test_phaet_pooled_encoding_returns_upstream_normalized_cls_unchanged(monkeypatch):
+    from types import SimpleNamespace
+
+    from slide2vec.encoders.models.waiv import Phaet
+
+    expected = torch.tensor([[0.6, 0.8], [0.0, 1.0]])
+    calls = []
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(patch_size=16)
+
+        def encode(self, pixel_values):
+            calls.append(pixel_values)
+            return expected
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: FakeModel(),
+    )
+    encoder = Phaet()
+    batch = torch.ones(2, 3, 224, 224)
+
+    output = encoder.encode_tiles(batch)
+
+    assert calls == [batch]
+    assert output is expected
+
+
+def test_phaet_dense_encoding_strips_cls_into_row_major_14_by_14_grid(monkeypatch):
+    from types import SimpleNamespace
+
+    from slide2vec.encoders.models.waiv import Phaet
+
+    calls = []
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(patch_size=16)
+
+        def forward(self, *, pixel_values):
+            calls.append(pixel_values)
+            cls = torch.full((2, 1, 1024), -1000.0)
+            patches = torch.arange(196, dtype=torch.float32).reshape(1, 196, 1)
+            patches = patches.expand(2, 196, 1024)
+            return SimpleNamespace(last_hidden_state=torch.cat([cls, patches], dim=1))
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: FakeModel(),
+    )
+    encoder = Phaet()
+    batch = torch.ones(2, 3, 224, 224)
+
+    output = encoder.encode_tiles_dense(batch)
+
+    assert calls == [batch]
+    assert output.shape == (2, 1024, 14, 14)
+    assert output[0, 0, 0, 0].item() == 0.0
+    assert output[0, 0, 0, 13].item() == 13.0
+    assert output[0, 0, 1, 0].item() == 14.0
+    assert output[0, 0, 13, 13].item() == 195.0
+
+
+def test_phaet_dense_encoding_rejects_invalid_rank_clearly(monkeypatch):
+    from types import SimpleNamespace
+
+    from slide2vec.encoders.models.waiv import Phaet
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(patch_size=16)
+
+        def forward(self, *, pixel_values):  # pragma: no cover - rejected first
+            raise AssertionError("model must not run for invalid input rank")
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: FakeModel(),
+    )
+    encoder = Phaet()
+
+    with pytest.raises(
+        ValueError,
+        match=r"encode_tiles_dense expects a \(B, C, H, W\) batch, got shape \(3, 224, 224\)",
+    ):
+        encoder.encode_tiles_dense(torch.ones(3, 224, 224))
+
+
+def test_phaet_dense_encoding_rejects_indivisible_geometry_clearly(monkeypatch):
+    from types import SimpleNamespace
+
+    from slide2vec.encoders.models.waiv import Phaet
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(patch_size=16)
+
+        def forward(self, *, pixel_values):  # pragma: no cover - rejected first
+            raise AssertionError("model must not run for indivisible geometry")
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: FakeModel(),
+    )
+    encoder = Phaet()
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Dense extraction for 'Phaet' requires input divisible by the patch "
+            r"size: got 224x225, patch 16"
+        ),
+    ):
+        encoder.encode_tiles_dense(torch.ones(1, 3, 224, 225))
+
+
+def test_phaet_public_lifecycle_reports_dimension_and_moves_to_requested_device(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from slide2vec import Model
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.anchor = torch.nn.Parameter(torch.ones(1))
+            self.config = SimpleNamespace(
+                patch_size=16,
+                pixel_mean=[0.485, 0.456, 0.406],
+                pixel_std=[0.229, 0.224, 0.225],
+            )
+
+    fake_model = FakeModel()
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: fake_model,
+    )
+
+    model = Model.from_preset("phaet", device="cpu")
+
+    assert model.feature_dim == 1024
+    assert model.device == torch.device("cpu")
+    assert fake_model.anchor.device == torch.device("cpu")
+
+
+@pytest.mark.heavy
+def test_phaet_real_weights_pooled_and_dense_shape_contract():
+    from slide2vec.encoders.models.waiv import Phaet
+
+    transformers_major = int(transformers.__version__.split(".", maxsplit=1)[0])
+    if transformers_major < 5:
+        pytest.skip(
+            "Phaet real weights require the slide2vec[waiv] Transformers 5 runtime"
+        )
+
+    try:
+        encoder = Phaet().to("cpu")
+    except (ImportError, OSError) as exc:
+        pytest.skip(f"Phaet weights/runtime unavailable: {type(exc).__name__}: {exc}")
+
+    pixel_values = encoder.get_transform()(
+        torch.zeros(3, 224, 224, dtype=torch.uint8)
+    ).unsqueeze(0)
+    with torch.no_grad():
+        pooled = encoder.encode_tiles(pixel_values)
+        dense = encoder.encode_tiles_dense(pixel_values)
+
+    assert pooled.shape == (1, 1024)
+    torch.testing.assert_close(
+        pooled.norm(dim=-1),
+        torch.ones(1),
+        rtol=0,
+        atol=1e-5,
+    )
+    assert dense.shape == (1, 1024, 14, 14)

--- a/tests/test_phaet.py
+++ b/tests/test_phaet.py
@@ -43,7 +43,7 @@ def test_phaet_loads_the_reviewed_remote_code_revision_in_eval_mode(monkeypatch)
     class FakeModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.config = SimpleNamespace(patch_size=16)
+            self.config = SimpleNamespace()
 
     fake_model = FakeModel()
 
@@ -79,7 +79,6 @@ def test_phaet_pooled_transform_uses_shorter_side_crop_and_config_normalization(
         def __init__(self):
             super().__init__()
             self.config = SimpleNamespace(
-                patch_size=16,
                 pixel_mean=[0.25, 0.5, 0.75],
                 pixel_std=[0.5, 0.25, 0.25],
             )
@@ -122,7 +121,6 @@ def test_phaet_dense_normalization_preserves_geometry(monkeypatch):
         def __init__(self):
             super().__init__()
             self.config = SimpleNamespace(
-                patch_size=16,
                 pixel_mean=[0.25, 0.5, 0.75],
                 pixel_std=[0.5, 0.25, 0.25],
             )
@@ -163,7 +161,7 @@ def test_phaet_pooled_encoding_returns_upstream_normalized_cls_unchanged(monkeyp
     class FakeModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.config = SimpleNamespace(patch_size=16)
+            self.config = SimpleNamespace()
 
         def encode(self, pixel_values):
             calls.append(pixel_values)
@@ -193,7 +191,7 @@ def test_phaet_dense_encoding_strips_cls_into_row_major_14_by_14_grid(monkeypatc
     class FakeModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.config = SimpleNamespace(patch_size=16)
+            self.config = SimpleNamespace()
 
         def forward(self, *, pixel_values):
             calls.append(pixel_values)
@@ -228,7 +226,7 @@ def test_phaet_dense_encoding_rejects_invalid_rank_clearly(monkeypatch):
     class FakeModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.config = SimpleNamespace(patch_size=16)
+            self.config = SimpleNamespace()
 
         def forward(self, *, pixel_values):  # pragma: no cover - rejected first
             raise AssertionError("model must not run for invalid input rank")
@@ -255,7 +253,7 @@ def test_phaet_dense_encoding_rejects_indivisible_geometry_clearly(monkeypatch):
     class FakeModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.config = SimpleNamespace(patch_size=16)
+            self.config = SimpleNamespace()
 
         def forward(self, *, pixel_values):  # pragma: no cover - rejected first
             raise AssertionError("model must not run for indivisible geometry")
@@ -289,7 +287,6 @@ def test_phaet_public_lifecycle_reports_dimension_and_moves_to_requested_device(
             super().__init__()
             self.anchor = torch.nn.Parameter(torch.ones(1))
             self.config = SimpleNamespace(
-                patch_size=16,
                 pixel_mean=[0.485, 0.456, 0.406],
                 pixel_std=[0.229, 0.224, 0.225],
             )

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -472,6 +472,7 @@ def test_list_models_can_filter_by_level():
         "midnight",
         "mstar",
         "musk",
+        "phaet",
         "phikon",
         "phikonv2",
         "prost40m",


### PR DESCRIPTION
## Summary

- register `phaet` as a fixed-input fp32 tile encoder with 1024-d pooled output and 14 x 14 dense grids
- add a reusable Waiv remote-code boundary with pinned reviewed revision, upstream normalized CLS pooling, config-owned preprocessing, and dense validation
- isolate the Transformers 5 Waiv runtime in its own extra and update the supported-model catalog/count

Closes #271

## TDD evidence

Each public slice was run red before its minimal implementation, then green:

- preset discovery: `KeyError: 'phaet' not found in encoders registry` -> registered public metadata/list/preset contract
- reviewed loading: abstract `Phaet` construction failure -> exact `from_pretrained` arguments and eval mode pass
- pooled transform: `NotImplementedError` -> exact shorter-side resize/crop/config-normalization pass
- dense normalization: inherited `NotImplementedError` -> geometry-preserving normalization pass
- pooled output: `NotImplementedError` -> unchanged upstream `encode(pixel_values)` result pass
- dense grid: inherited `NotImplementedError` -> CLS-stripped row-major `(2, 1024, 14, 14)` pass
- rank validation: generic unpack error -> explicit shape error pass
- divisibility validation: model was reached -> explicit pre-forward patch-geometry error pass

Literal expected metadata, load arguments, normalized pixel values, pooled values, dense coordinates, shapes, and error messages are retained in `tests/test_phaet.py`.

## Verification

- focused: `191 passed, 25 deselected in 8.06s`
- full ordinary non-GPU/non-heavy: `852 passed, 34 deselected, 6 warnings in 136.53s`
  - warnings are existing third-party SciPy/SWIG deprecations
- `git diff --check main...HEAD`: pass
- focused Flake8: pass
- Black check on new files: pass
- isolated mypy on Waiv runtime: pass
- compile/import/TOML dependency checks: pass
- Sphinx warning-as-error HTML build: pass
- opt-in real-weight contract without Waiv runtime: `1 skipped in 7.08s`

## Self-review

- Standards: no hard findings; retained the one heuristic single-use-base smell because #271 explicitly requires the reusable Waiv boundary for Mascaret
- Spec: no actionable findings or scope creep

## Retry 1 follow-up

- red: removing the undocumented fake `config.patch_size` produced `AttributeError: SimpleNamespace has no attribute patch_size`
- green: Phaet now owns patch size 16; runtime `patch_size`, dense validation, and dense grid dimensions use that declaration
- offline fakes now contain only documented `pixel_mean` / `pixel_std`, or no config fields when normalization is unused
- production geometry constants are shared by registry metadata and runtime behavior to prevent drift
- focused: `191 passed, 25 deselected in 10.22s`
- full ordinary non-GPU/non-heavy: `852 passed, 34 deselected, 6 warnings in 147.23s`
- final diff, Flake8, Black, isolated mypy, compile, and Sphinx `-W`: pass
- final Standards and Spec review axes: no findings
