### PR TITLE
Verify Waiv attention remains unsupported

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -273,6 +273,11 @@ Notes:
   colour channels as independent single-channel images, so there is no single
   coherent CLS-over-patches attention to extract; ``encode_tiles_attention`` raises
   ``NotImplementedError`` (dense patch-token extraction is still available).
+- ``phaet`` / ``mascaret`` are **not** covered: their pinned Waiv wrappers accept
+  ``output_attentions=True`` through ``**kwargs`` but do not forward it to the
+  inner backbone, and return ``attentions=None``. Their
+  ``encode_tiles_attention`` methods therefore raise ``NotImplementedError``
+  (dense patch-token extraction is still available).
 - ``hibou-b`` / ``hibou-l`` carry register tokens; pass ``include_registers=True``
   to add their query rows as extra channels.
 - ``conch`` / ``conchv15`` recover attention from their inner timm ViT trunk, the

--- a/tests/test_dense_encode_kit.py
+++ b/tests/test_dense_encode_kit.py
@@ -239,8 +239,14 @@ def test_prepare_dense_encoder_rejects_invalid_requests_before_loading(
     assert load_attempted is False
 
 
-def test_prepare_dense_encoder_rejects_unsupported_attention_before_loading(monkeypatch):
-    model = Model(name="musk", device="cpu")
+@pytest.mark.parametrize(
+    ("model_name", "target_size"),
+    [("musk", 384), ("phaet", 224), ("mascaret", 224)],
+)
+def test_prepare_dense_encoder_rejects_unsupported_attention_before_loading(
+    model_name, target_size, monkeypatch
+):
+    model = Model(name=model_name, device="cpu")
     load_attempted = False
 
     def _unexpected_load():
@@ -252,7 +258,7 @@ def test_prepare_dense_encoder_rejects_unsupported_attention_before_loading(monk
 
     with pytest.raises(ValueError, match="does not support cls_attention"):
         model.prepare_dense_encoder(
-            dense=_dense_image(target_size=384, feature_kind="cls_attention"),
+            dense=_dense_image(target_size=target_size, feature_kind="cls_attention"),
             execution=ExecutionOptions(num_gpus=1, precision="fp32"),
         )
 

--- a/tests/test_mascaret.py
+++ b/tests/test_mascaret.py
@@ -353,7 +353,7 @@ def test_mascaret_public_lifecycle_reports_dimension_and_moves_to_requested_devi
 
 
 @pytest.mark.heavy
-def test_mascaret_real_weights_pooled_and_dense_shape_contract():
+def test_mascaret_real_weights_pooled_dense_and_attention_contract():
     from slide2vec.encoders.models.waiv import Mascaret
 
     transformers_major = int(transformers.__version__.split(".", maxsplit=1)[0])
@@ -363,11 +363,12 @@ def test_mascaret_real_weights_pooled_and_dense_shape_contract():
         )
 
     try:
-        encoder = Mascaret().to("cpu")
+        encoder = Mascaret()
     except (ImportError, OSError) as exc:
         pytest.skip(
             f"Mascaret weights/runtime unavailable: {type(exc).__name__}: {exc}"
         )
+    encoder.to("cpu")
 
     pixel_values = encoder.get_transform()(
         torch.zeros(3, 224, 224, dtype=torch.uint8)
@@ -375,6 +376,10 @@ def test_mascaret_real_weights_pooled_and_dense_shape_contract():
     with torch.no_grad():
         pooled = encoder.encode_tiles(pixel_values)
         dense = encoder.encode_tiles_dense(pixel_values)
+        wrapper_output = encoder._model(
+            pixel_values=pixel_values,
+            output_attentions=True,
+        )
 
     assert pooled.shape == (1, 1536)
     torch.testing.assert_close(
@@ -384,3 +389,5 @@ def test_mascaret_real_weights_pooled_and_dense_shape_contract():
         atol=1e-5,
     )
     assert dense.shape == (1, 1536, 16, 16)
+    assert wrapper_output.last_hidden_state.shape == (1, 257, 1536)
+    assert wrapper_output.attentions is None

--- a/tests/test_phaet.py
+++ b/tests/test_phaet.py
@@ -306,7 +306,7 @@ def test_phaet_public_lifecycle_reports_dimension_and_moves_to_requested_device(
 
 
 @pytest.mark.heavy
-def test_phaet_real_weights_pooled_and_dense_shape_contract():
+def test_phaet_real_weights_pooled_dense_and_attention_contract():
     from slide2vec.encoders.models.waiv import Phaet
 
     transformers_major = int(transformers.__version__.split(".", maxsplit=1)[0])
@@ -316,9 +316,10 @@ def test_phaet_real_weights_pooled_and_dense_shape_contract():
         )
 
     try:
-        encoder = Phaet().to("cpu")
+        encoder = Phaet()
     except (ImportError, OSError) as exc:
         pytest.skip(f"Phaet weights/runtime unavailable: {type(exc).__name__}: {exc}")
+    encoder.to("cpu")
 
     pixel_values = encoder.get_transform()(
         torch.zeros(3, 224, 224, dtype=torch.uint8)
@@ -326,6 +327,10 @@ def test_phaet_real_weights_pooled_and_dense_shape_contract():
     with torch.no_grad():
         pooled = encoder.encode_tiles(pixel_values)
         dense = encoder.encode_tiles_dense(pixel_values)
+        wrapper_output = encoder._model(
+            pixel_values=pixel_values,
+            output_attentions=True,
+        )
 
     assert pooled.shape == (1, 1024)
     torch.testing.assert_close(
@@ -335,3 +340,5 @@ def test_phaet_real_weights_pooled_and_dense_shape_contract():
         atol=1e-5,
     )
     assert dense.shape == (1, 1024, 14, 14)
+    assert wrapper_output.last_hidden_state.shape == (1, 197, 1024)
+    assert wrapper_output.attentions is None


### PR DESCRIPTION
## Summary

- verify the exact pinned Phaet and Mascaret Waiv wrappers with real weights
- keep both presets explicitly outside the public dense-attention capability gate
- pin the loaded-wrapper `attentions=None` contract in real-weight tests
- document the exact upstream wrapper limitation without gated-access or licensing text

## Why

Both wrappers accept `output_attentions=True` only through `**kwargs`, do not forward it to their inner DINOv2 backbone, and return `BaseModelOutputWithPooling` without attention tensors. Exposing attention grids would therefore claim a contract the pinned wrappers do not provide.

## Evidence

- Phaet `e0ce6e0ee248470bd8604823e412ca64048a2495`: 24 layers, 16 heads, `last_hidden_state=(1, 197, 1024)`, `attentions=None`
- Mascaret `e95e7ea15e039e78d74def101415e19d9a67ba80`: 40 layers, 24 heads, `last_hidden_state=(1, 257, 1536)`, `attentions=None`
- focused final gate: 67 passed, 2 heavy tests deselected
- exact real-weight gate under Transformers 5.14.1: 2 passed
- partitioned conventional non-GPU coverage: 862 passed, 1 skipped; three unrelated multiprocessing cases were host-sensitive and are left to the clean Docker CI gate
- flake8, Black 23.11 synchronous check, `git diff --check`, and Sphinx `-W`: passed
- two-axis `/code-review main`: no remaining standards or spec findings

## Acceptance

- [x] Inspected and probed both exact pinned custom wrapper revisions with real weights.
- [x] Recorded flag acceptance and the absence of a complete ordered per-layer attention tuple for each loaded wrapper.
- [x] Preserved the public unsupported capability gate; no approximate attention weights are reconstructed.
- [x] Added focused pre-load capability tests and concise documentation of the exact upstream limitation.
- [x] Restricted real-weight skips to model-load unavailability; loaded-model contract checks fail loudly.
- [x] Kept Phaet and Mascaret out of the supported dense-attention catalog.
- [ ] Clean full non-GPU Docker suite (pending GitHub Actions; three local multiprocessing cases were host-sensitive).

Closes #273