### PR TITLE
Support declared slide output variants

### DIFF
--- a/slide2vec/encoders/registry.py
+++ b/slide2vec/encoders/registry.py
@@ -176,8 +176,9 @@ def resolve_preprocessing_requirements(
 ) -> dict[str, Any]:
     """Resolve encoder-driven preprocessing requirements.
 
-    Tile encoders define their own `input_size` and `supported_spacing_um`.
-    Slide encoders inherit both values from their declared tile encoder.
+    Tile encoders define their own image geometry and spacing contract. Slide
+    encoders inherit image geometry from their declared tile encoder while
+    retaining their own supported spacing contract.
     """
     info = metadata if metadata is not None else encoder_registry.info(encoder_name)
     level = resolve_encoder_level(encoder_name, info)
@@ -199,7 +200,16 @@ def resolve_preprocessing_requirements(
             require_encoder_metadata_field(encoder_name, info, "tile_encoder")
         )
         tile_metadata = encoder_registry.info(tile_encoder_name)
-        return resolve_preprocessing_requirements(tile_encoder_name, tile_metadata)
+        tile_requirements = resolve_preprocessing_requirements(
+            tile_encoder_name, tile_metadata
+        )
+        if level == "slide":
+            return {
+                "tile_size_px": tile_requirements["tile_size_px"],
+                "spacing_um": info.get("supported_spacing_um"),
+                "source_encoder": tile_requirements["source_encoder"],
+            }
+        return tile_requirements
     raise AssertionError("unreachable")
 
 
@@ -253,13 +263,17 @@ def resolve_preprocessing_defaults(
     when the encoder advertises several supported spacings without an explicit
     ``default_spacing_um``.
     """
-    reqs = resolve_preprocessing_requirements(encoder_name, metadata)
+    info = metadata if metadata is not None else encoder_registry.info(encoder_name)
+    reqs = resolve_preprocessing_requirements(encoder_name, info)
     source_encoder = reqs["source_encoder"]
-    # Resolve the default off the *tile* encoder's metadata: slide/patient
-    # encoders inherit both tile size and spacing from their tile encoder, so
-    # source_encoder already points at the model that carries the spacing fields.
-    source_info = encoder_registry.info(source_encoder)
-    spacing_um = _resolve_default_spacing(source_encoder, source_info)
+    level = resolve_encoder_level(encoder_name, info)
+    if level == "slide":
+        spacing_encoder = encoder_name
+        spacing_info = info
+    else:
+        spacing_encoder = source_encoder
+        spacing_info = encoder_registry.info(source_encoder)
+    spacing_um = _resolve_default_spacing(spacing_encoder, spacing_info)
     return {
         "tile_size_px": int(reqs["tile_size_px"]),
         "spacing_um": float(spacing_um),
@@ -319,13 +333,20 @@ def resolve_encoder_output(
             f"Encoder '{encoder_name}' has invalid default_output_variant "
             f"'{default_output_variant}'"
         )
-    if requested_output_variant is not None and level in {"slide", "patient"}:
+    fixed_hierarchical_output = level == "patient" or (
+        level == "slide" and len(output_variants) == 1
+    )
+    if requested_output_variant is not None and fixed_hierarchical_output:
         raise ValueError(
             f"Slide encoder '{encoder_name}' (level={level}) has a fixed output_variant; "
             "do not override output_variant for slide or patient encoders."
         )
 
-    output_variant = requested_output_variant or str(default_output_variant)
+    output_variant = (
+        str(default_output_variant)
+        if requested_output_variant is None
+        else requested_output_variant
+    )
     if output_variant not in output_variants:
         available = ", ".join(sorted(output_variants))
         raise ValueError(

--- a/tests/test_encoder_registry.py
+++ b/tests/test_encoder_registry.py
@@ -185,6 +185,59 @@ def test_resolve_preprocessing_requirements_for_slide_encoder_inherits_from_tile
     assert reqs["spacing_um"] == virchow_reqs["spacing_um"]
 
 
+def test_slide_preprocessing_combines_tile_geometry_with_own_spacing_contract():
+    from slide2vec.encoders.registry import resolve_preprocessing_requirements
+
+    reqs = resolve_preprocessing_requirements(
+        "prism2-like",
+        metadata={
+            "level": "slide",
+            "tile_encoder": "virchow2",
+            "supported_spacing_um": 0.5,
+        },
+    )
+
+    assert reqs == {
+        "tile_size_px": 224,
+        "spacing_um": 0.5,
+        "source_encoder": "virchow2",
+    }
+
+
+def test_slide_preprocessing_uses_own_default_spacing_with_tile_geometry():
+    from slide2vec.encoders.registry import resolve_preprocessing_defaults
+
+    defaults = resolve_preprocessing_defaults(
+        "prism2-like",
+        metadata={
+            "level": "slide",
+            "tile_encoder": "virchow2",
+            "supported_spacing_um": [0.5],
+            "default_spacing_um": 0.5,
+        },
+    )
+
+    assert defaults == {
+        "tile_size_px": 224,
+        "spacing_um": 0.5,
+        "source_encoder": "virchow2",
+    }
+
+
+def test_slide_preprocessing_inherits_tile_variable_input_capability():
+    from slide2vec.encoders.registry import resolve_variable_input_capability
+
+    capability = resolve_variable_input_capability(
+        "prism2-like",
+        metadata={
+            "level": "slide",
+            "tile_encoder": "virchow2",
+        },
+    )
+
+    assert capability is True
+
+
 def test_resolve_encoder_output_for_default_variant():
     from slide2vec.encoders.registry import resolve_encoder_output
 
@@ -193,12 +246,88 @@ def test_resolve_encoder_output_for_default_variant():
     assert result["encode_dim"] == 2560
 
 
+def test_single_output_slide_encoder_keeps_its_default_output():
+    from slide2vec.encoders.registry import resolve_encoder_output
+
+    assert resolve_encoder_output("prism") == {
+        "output_variant": "default",
+        "encode_dim": 1280,
+    }
+
+
 def test_resolve_encoder_output_for_explicit_variant():
     from slide2vec.encoders.registry import resolve_encoder_output
 
     result = resolve_encoder_output("virchow2", requested_output_variant="cls")
     assert result["output_variant"] == "cls"
     assert result["encode_dim"] == 1280
+
+
+def test_resolve_encoder_output_accepts_declared_slide_variant():
+    from slide2vec.encoders.registry import resolve_encoder_output
+
+    result = resolve_encoder_output(
+        "multi-output-slide",
+        requested_output_variant="projection",
+        metadata={
+            "level": "slide",
+            "output_variants": {
+                "embedding": {"encode_dim": 1280},
+                "projection": {"encode_dim": 768},
+            },
+            "default_output_variant": "embedding",
+        },
+    )
+
+    assert result == {"output_variant": "projection", "encode_dim": 768}
+
+
+def test_resolve_encoder_output_names_available_slide_variants_on_rejection():
+    from slide2vec.encoders.registry import resolve_encoder_output
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Unsupported output_variant 'unknown' for encoder 'multi-output-slide'. "
+            "Available: embedding, projection"
+        ),
+    ):
+        resolve_encoder_output(
+            "multi-output-slide",
+            requested_output_variant="unknown",
+            metadata={
+                "level": "slide",
+                "output_variants": {
+                    "embedding": {"encode_dim": 1280},
+                    "projection": {"encode_dim": 768},
+                },
+                "default_output_variant": "embedding",
+            },
+        )
+
+
+def test_resolve_encoder_output_rejects_an_empty_slide_variant():
+    from slide2vec.encoders.registry import resolve_encoder_output
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Unsupported output_variant '' for encoder 'multi-output-slide'. "
+            "Available: embedding, projection"
+        ),
+    ):
+        resolve_encoder_output(
+            "multi-output-slide",
+            requested_output_variant="",
+            metadata={
+                "level": "slide",
+                "output_variants": {
+                    "embedding": {"encode_dim": 1280},
+                    "projection": {"encode_dim": 768},
+                },
+                "default_output_variant": "embedding",
+            },
+        )
 
 
 def test_resolve_encoder_output_raises_for_unknown_variant():
@@ -213,6 +342,46 @@ def test_resolve_encoder_output_raises_when_overriding_slide_encoder():
 
     with pytest.raises(ValueError, match="Slide encoder"):
         resolve_encoder_output("prism", requested_output_variant="cls")
+
+
+def test_slide_config_accepts_a_declared_output_variant():
+    from slide2vec.encoders.validation import validate_encoder_config
+
+    result = validate_encoder_config(
+        "multi-output-slide",
+        info={
+            "level": "slide",
+            "output_variants": {
+                "embedding": {"encode_dim": 1280},
+                "projection": {"encode_dim": 768},
+            },
+            "default_output_variant": "embedding",
+            "precision": "fp16",
+            "supported_spacing_um": 0.5,
+        },
+        output_variant="projection",
+    )
+
+    assert result is None
+
+
+def test_slide_config_rejects_spacing_supported_only_by_its_tile_encoder():
+    from slide2vec.encoders.validation import validate_encoder_config
+
+    with pytest.raises(
+        ValueError,
+        match=r"requested_spacing_um=0.25 \(recommended: \[0.5\]\)",
+    ):
+        validate_encoder_config(
+            "prism2-like",
+            info={
+                "level": "slide",
+                "tile_encoder": "virchow2",
+                "precision": "fp16",
+                "supported_spacing_um": 0.5,
+            },
+            requested_spacing_um=0.25,
+        )
 
 
 def test_encoder_not_in_registry_raises_key_error():


### PR DESCRIPTION
## Summary

- Allow slide encoders with multiple declared outputs to select any registered variant while preserving the fixed-output behavior of existing single-output slide encoders.
- Resolve slide preprocessing geometry and variable-input capability from the tile dependency, but supported/default spacing from the slide encoder itself.
- Add public registry and configuration regression tests, including undeclared and explicitly empty output variants.

This separates image-geometry ownership from slide-spacing ownership so a future PRISM2 preset can use Virchow2's 224 px geometry while narrowing preprocessing to 0.5 µm/px.

## Acceptance criteria

- [x] Work test-first from the public registry and configuration seams.
- [x] A slide encoder may select any output variant declared in its registry metadata, and undeclared variants fail with the available variants named.
- [x] Existing single-output slide encoders remain fixed to their sole declared output and retain their current default behavior.
- [x] Slide preprocessing inherits tile size and variable-input capability from the declared tile encoder.
- [x] A slide encoder's own supported/default spacing takes precedence over the broader spacing capabilities of its tile encoder.
- [x] Existing tile-, slide-, and patient-level preset behavior remains unchanged outside the new declared slide-output capability.
- [x] Focused registry/configuration tests, the full non-GPU test suite, and relevant static checks pass.

## Validation

- `python -m pytest -q tests/test_encoder_registry.py tests/test_pooled_geometry.py::test_slide_and_patient_models_inherit_tile_dependency_geometry` — 33 passed
- `python -m pytest -q --durations=15 tests` — 889 passed, 16 skipped, 6 deselected
- `python -m flake8 slide2vec/encoders/registry.py tests/test_encoder_registry.py tests/test_pooled_geometry.py` — passed
- `python -m mypy --follow-imports=skip slide2vec/encoders/registry.py slide2vec/encoders/validation.py` — passed
- `git diff --check main...HEAD` — passed
- Two-axis review against `main` — no remaining Standards or Spec findings

Closes #276