### PR TITLE
Enable variable input sizes for verified ViT encoders

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -157,23 +157,26 @@ source and protocol, stored as lossy 3000x3000 JPEGs. Expect it to be useful on
 IHC and unproven elsewhere.
 
 **Tiles are 336 px, not 224 or 256.** At the ``0.5`` µm/px default that is a
-168 µm field of view. ``supports_variable_input_size`` is ``False``: the model
-was only ever trained at 336.
+168 µm field of view. The CLIP backbone can interpolate its positional
+embeddings for other patch-divisible geometries, but 336 remains the trained,
+registered default. A different pooled size is an explicit non-recommended
+override; dense extraction can select a different geometry automatically.
 
 **The spacing is inferred.** HPA acquires at 20x, giving ~0.5 µm/px for its
 3000x3000 px images of ~1.5 mm cores, but HPA10M's dataset card does not state
 µm/px directly.
 
 **Only the tile level is exposed.** iSight's gated-attention pooler operates on
-token sequences rather than pooled tile vectors — each of the 577 token positions
-carries its own distribution over tiles — so it cannot be expressed through
+token sequences rather than pooled tile vectors — each runtime token position
+carries its own distribution over tiles (577 positions at 336 x 336) — so it
+cannot be expressed through
 :class:`~slide2vec.encoders.base.SlideEncoder`, whose ``encode_slide`` receives
 ``(N, D)``. Its five classification heads are also specific to the HPA tasks.
 Use downstream MIL for slide-level pooling.
 
-**Output variants.** ``token_mean`` (default) is the mean over all 577 tokens
-including CLS, matching the reference implementation; ``cls`` selects the CLS
-token alone. Both are 1024-d.
+**Output variants.** ``token_mean`` (default) is the mean over all runtime tokens
+including CLS (577 at 336 x 336), matching the reference implementation;
+``cls`` selects the CLS token alone. Both are 1024-d.
 
 **The download is a raw training checkpoint** (~4.8 GB), of which roughly 3.7 GB
 is optimizer state that is read and discarded. There is no smaller artifact
@@ -239,6 +242,10 @@ Notes:
   patch multiple, and optional sliding-window blending on top of this encoder
   API — see the "Dense Tile Feature Extraction" section of :doc:`api`.
 - ``musk`` dense extraction currently requires its native 384 x 384 input size.
+- ``conch``, ``conchv15``, ``phikon``, ``phikonv2``, and ``isight`` accept
+  patch-divisible square or rectangular encoder inputs. Their positional
+  embeddings are interpolated by the checkpoint's timm/Hugging Face backbone;
+  no variable-input constructor setting is required.
 - H-Optimus dense extraction at non-native input sizes requires
   ``dynamic_img_size=True`` and ``allow_non_recommended_settings=True`` when
   constructing the encoder directly. Through ``Model.embed_regions_dense`` the

--- a/slide2vec/encoders/models/conch.py
+++ b/slide2vec/encoders/models/conch.py
@@ -78,7 +78,7 @@ def _encode_trunk_dense(*, trunk, batch: Tensor, encoder_name: str) -> Tensor:
     output_variants={"default": {"encode_dim": 512}},
     default_output_variant="default",
     input_size=448,
-    supports_variable_input_size=False,
+    supports_variable_input_size=True,
     patch_size=16,
     supported_spacing_um=0.5,
     precision="fp32",
@@ -145,9 +145,8 @@ class CONCH(TileEncoder):
 
     @property
     def patch_size(self) -> tuple[int, int]:
-        # The CONCH vision trunk is a timm ViT-B/16; expose its patch size so the
-        # dense path can resolve the token grid. open_clip builds the trunk without
-        # dynamic_img_size, so dense extraction must use the native 448 window.
+        # The CONCH vision trunk is a dynamic timm ViT-B/16; expose its patch size
+        # so dense and attention paths can resolve each runtime token grid.
         return _patch_size_from_trunk(self._model.visual.trunk)
 
     @property
@@ -165,7 +164,7 @@ class CONCH(TileEncoder):
     output_variants={"default": {"encode_dim": 768}},
     default_output_variant="default",
     input_size=448,
-    supports_variable_input_size=False,
+    supports_variable_input_size=True,
     patch_size=16,
     supported_spacing_um=0.5,
     precision="fp16",

--- a/slide2vec/encoders/models/isight.py
+++ b/slide2vec/encoders/models/isight.py
@@ -19,11 +19,11 @@ Every numerically-relevant choice mirrors https://github.com/zhihuanglab/iSight
 * Tile features are ``vision_model(..., output_hidden_states=True)
   .hidden_states[-1]`` passed through the learned ``visual_token_projection``
   — ``patch_encoder_with_clam.py:217-219``.
-* Reduction to one vector per tile is the **mean over all 577 tokens**
-  (CLS included) — ``patch_encoder_with_clam.py:254-255``, where the CLS line
-  is immediately overwritten by the token-mean line, and corroborated by
-  ``model_version = v3_all_tokens`` in ``config/config.ini:3``. The dead CLS
-  branch is still offered as the non-default ``cls`` output variant.
+* Reduction to one vector per tile is the **mean over all tokens** (577 at the
+  native 336 x 336 input, CLS included) — ``patch_encoder_with_clam.py:254-255``,
+  where the CLS line is immediately overwritten by the token-mean line, and
+  corroborated by ``model_version = v3_all_tokens`` in ``config/config.ini:3``.
+  The dead CLS branch is still offered as the non-default ``cls`` output variant.
 * Preprocessing is the model's own ``AutoProcessor`` — the reference builds it
   as ``self.patch_processor`` (``patch_encoder_with_clam.py:128``) and applies
   it per tile in ``dataset/hpadataset.py:152``.
@@ -65,12 +65,13 @@ check on the download.
 Slide level is deliberately absent
 ----------------------------------
 iSight's gated attention runs at *token* level, not tile level: ``A`` has shape
-``(n_tiles, n_tokens, 1)`` and is softmaxed over tiles, so each of the 577 token
-positions gets its own distribution over tiles
+``(n_tiles, n_tokens, 1)`` and is softmaxed over tiles, so every token position
+gets its own distribution over tiles
 (``patch_encoder_with_clam.py:230-255``). The pooled result is therefore not a
 function of per-tile ``(N, D)`` vectors, which is what
 :meth:`SlideEncoder.encode_slide` receives. Reproducing it would require caching
-``577 x 1024`` per tile. The heads are also specific to the five HPA tasks, so
+``n_tokens x 1024`` per tile (577 x 1024 at the native input). The heads are
+also specific to the five HPA tasks, so
 the pooled vector is not a general slide representation. Downstream MIL should
 do the pooling instead.
 """
@@ -125,7 +126,7 @@ def _load_isight_state_dict() -> dict[str, Tensor]:
     },
     default_output_variant="token_mean",
     input_size=336,
-    supports_variable_input_size=False,
+    supports_variable_input_size=True,
     patch_size=14,
     supported_spacing_um=0.5,
     precision="fp16",
@@ -208,15 +209,19 @@ class ISight(TileEncoder):
         ])
 
     def _token_features(self, batch: Tensor) -> Tensor:
-        """Projected token sequence ``(B, 577, 1024)`` — patch_encoder_with_clam.py:217-219."""
-        outputs = self._vision(batch, output_hidden_states=True)
+        """Projected ``(B, 1 + H/14 * W/14, 1024)`` token sequence."""
+        outputs = self._vision(
+            batch,
+            output_hidden_states=True,
+            interpolate_pos_encoding=True,
+        )
         return self._projection(outputs.hidden_states[-1])
 
     def encode_tiles(self, batch: Tensor) -> Tensor:
         features = self._token_features(batch)
         if self._output_variant == "cls":
             return features[:, 0]
-        # Mean over all 577 tokens, CLS included — patch_encoder_with_clam.py:255.
+        # Mean over every runtime token, CLS included — 577 at the native input.
         return features.mean(dim=1)
 
     def encode_tiles_dense(self, batch: Tensor) -> Tensor:
@@ -273,7 +278,11 @@ class ISight(TileEncoder):
             )
         # SDPA silently returns attentions=None; flip the PreTrainedModel to eager.
         with hf_eager_attention(self._clip):
-            outputs = self._vision(batch, output_attentions=True)
+            outputs = self._vision(
+                batch,
+                output_attentions=True,
+                interpolate_pos_encoding=True,
+            )
         return attentions_tuple_to_grids(
             outputs.attentions,
             num_prefix_tokens=1,

--- a/slide2vec/encoders/models/phikon.py
+++ b/slide2vec/encoders/models/phikon.py
@@ -24,6 +24,7 @@ class _PhikonBase(TileEncoder):
     """Base for Phikon models using HuggingFace transformers."""
 
     _encode_dim: int
+    _interpolate_pos_encoding = False
 
     def __init__(self, model_name: str, *, output_variant: str | None = None):
         self._model = AutoModel.from_pretrained(model_name).eval()
@@ -42,8 +43,8 @@ class _PhikonBase(TileEncoder):
 
     def get_normalization_transform(self) -> Callable:
         # Normalization only — no resize/crop.
-        # Reuses the HF processor's normalization so it matches pooled extraction;
-        # Phikon is pinned to its native 224, so the dense pipeline must feed 224.
+        # Reuses the HF processor's normalization so it matches pooled extraction
+        # while preserving whatever patch-divisible geometry the caller selected.
         from torchvision.transforms import v2
 
         return v2.Compose([
@@ -58,16 +59,14 @@ class _PhikonBase(TileEncoder):
         return patch, patch
 
     def encode_tiles(self, batch: Tensor) -> Tensor:
-        output = self._model(pixel_values=batch)
+        output = self._forward_model(batch)
         return output.last_hidden_state[:, 0, :]  # CLS token
 
     def encode_tiles_dense(self, batch: Tensor) -> Tensor:
         """Encode tiles into a dense spatial grid. (B, C, H, W) -> (B, d, h, w).
 
         Phikon's ViT emits ``[CLS, patch tokens...]`` (one prefix token, no
-        register tokens). The model is pinned to its native input size, so the
-        grid is ``input_size / patch_size`` (e.g. 224/16 -> 14x14); feeding a
-        larger tile raises inside the HF backbone (positional-embedding mismatch).
+        register tokens). The runtime input and patch size determine the grid.
         """
         if batch.ndim != 4:
             raise ValueError(
@@ -82,7 +81,7 @@ class _PhikonBase(TileEncoder):
                 f"divisible by the patch size: got {height}x{width}, patch "
                 f"{patch}. Pad the tile up to a patch multiple first."
             )
-        output = self._model(pixel_values=batch)
+        output = self._forward_model(batch)
         return reshape_tokens_to_grid(
             output.last_hidden_state,
             grid_h=height // patch,
@@ -120,7 +119,7 @@ class _PhikonBase(TileEncoder):
                 f"{patch}. Pad the tile up to a patch multiple first."
             )
         with hf_eager_attention(self._model):
-            output = self._model(pixel_values=batch, output_attentions=True)
+            output = self._forward_model(batch, output_attentions=True)
         return attentions_tuple_to_grids(
             output.attentions,  # tuple: per-layer (B, nh, N, N)
             num_prefix_tokens=1,
@@ -135,6 +134,11 @@ class _PhikonBase(TileEncoder):
     def encode_dim(self) -> int:
         return self._encode_dim
 
+    def _forward_model(self, batch: Tensor, **kwargs):
+        if self._interpolate_pos_encoding:
+            kwargs["interpolate_pos_encoding"] = True
+        return self._model(pixel_values=batch, **kwargs)
+
     @property
     def device(self) -> torch.device:
         return self._device
@@ -143,12 +147,14 @@ class _PhikonBase(TileEncoder):
         self._device = torch.device(device)
         self._model = self._model.to(self._device)
         return self
+
+
 @register_encoder(
     "phikon",
     output_variants={"default": {"encode_dim": 768}},
     default_output_variant="default",
     input_size=224,
-    supports_variable_input_size=False,
+    supports_variable_input_size=True,
     patch_size=16,
     supported_spacing_um=0.5,
     precision="fp32",
@@ -156,10 +162,10 @@ class _PhikonBase(TileEncoder):
 )
 class Phikon(_PhikonBase):
     _encode_dim = 768
+    _interpolate_pos_encoding = True
 
     def __init__(self, *, output_variant: str | None = None):
         super().__init__("owkin/phikon", output_variant=output_variant)
-
 
 
 @register_encoder(
@@ -167,7 +173,7 @@ class Phikon(_PhikonBase):
     output_variants={"default": {"encode_dim": 1024}},
     default_output_variant="default",
     input_size=224,
-    supports_variable_input_size=False,
+    supports_variable_input_size=True,
     patch_size=16,
     supported_spacing_um=0.5,
     precision="fp32",

--- a/tests/test_attention_extraction.py
+++ b/tests/test_attention_extraction.py
@@ -21,7 +21,9 @@ from slide2vec.encoders.base import (  # noqa: E402
     TileEncoder,
     TimmTileEncoder,
     attentions_tuple_to_grids,
+    hf_eager_attention,
     prefix_attention_to_grid,
+    reshape_tokens_to_grid,
     resolve_block_indices,
     timm_self_attention_weights,
     timm_trunk_attention,
@@ -169,12 +171,12 @@ def test_conch_reuses_timm_trunk_attention():
     trunk = _make_timm_encoder("vit_tiny_patch16_224", dynamic_img_size=True)._model
     enc = CONCH.__new__(CONCH)
     enc._model = SimpleNamespace(visual=SimpleNamespace(trunk=trunk))
-    x = torch.randn(1, 3, 224, 224)
+    x = torch.randn(1, 3, 224, 256)
     with torch.no_grad():
         out = enc.encode_tiles_attention(x, blocks=(-1,))
         direct = timm_trunk_attention(trunk, x, blocks=(-1,), encoder_name="CONCH")
     nh = trunk.blocks[-1].attn.num_heads
-    assert out.shape == (1, nh, 14, 14)
+    assert out.shape == (1, nh, 14, 16)
     torch.testing.assert_close(out, direct, rtol=0, atol=0)
 
 
@@ -257,6 +259,84 @@ class _FakeHFAttnOutput:
         self.attentions = attentions
 
 
+def _tiny_phikon_encoder():
+    """A real tiny HF ViT wired behind the public Phikon extraction API."""
+    from transformers import ViTConfig, ViTModel
+
+    from slide2vec.encoders.models.phikon import Phikon
+
+    enc = Phikon.__new__(Phikon)
+    enc._model = ViTModel(
+        ViTConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            image_size=32,
+            patch_size=16,
+        )
+    ).eval()
+    enc._device = torch.device("cpu")
+    enc._output_variant = "default"
+    return enc
+
+
+def test_phikon_interpolates_positions_for_every_variable_extraction_path():
+    enc = _tiny_phikon_encoder()
+    rectangular = torch.randn(1, 3, 48, 32)
+
+    with torch.no_grad():
+        tokens = enc._model(
+            pixel_values=rectangular,
+            interpolate_pos_encoding=True,
+        ).last_hidden_state
+        pooled = enc.encode_tiles(rectangular)
+        dense = enc.encode_tiles_dense(rectangular)
+        attention = enc.encode_tiles_attention(rectangular)
+
+    assert pooled.shape == (1, 32)
+    assert dense.shape == (1, 32, 3, 2)
+    assert attention.shape == (1, 4, 3, 2)
+    expected_dense = tokens[:, 1:].transpose(1, 2).reshape(1, 32, 3, 2)
+    torch.testing.assert_close(dense, expected_dense, rtol=0, atol=0)
+
+
+def test_phikon_positional_interpolation_is_exactly_inert_at_native_size():
+    enc = _tiny_phikon_encoder()
+    native = torch.randn(1, 3, 32, 32)
+
+    with torch.no_grad():
+        prior = enc._model(pixel_values=native)
+        pooled = enc.encode_tiles(native)
+        dense = enc.encode_tiles_dense(native)
+        with hf_eager_attention(enc._model):
+            prior_with_attention = enc._model(
+                pixel_values=native,
+                output_attentions=True,
+            )
+        attention = enc.encode_tiles_attention(native)
+
+    prior_dense = reshape_tokens_to_grid(
+        prior.last_hidden_state,
+        grid_h=2,
+        grid_w=2,
+        num_prefix_tokens=1,
+        encoder_name="Phikon",
+    )
+    prior_attention = attentions_tuple_to_grids(
+        prior_with_attention.attentions,
+        num_prefix_tokens=1,
+        blocks=(-1,),
+        include_registers=False,
+        grid_h=2,
+        grid_w=2,
+        encoder_name="Phikon",
+    )
+    assert torch.equal(pooled, prior.last_hidden_state[:, 0])
+    assert torch.equal(dense, prior_dense)
+    assert torch.equal(attention, prior_attention)
+
+
 class _FakeHFViTWithAttn:
     """Minimal HF ViT double exposing per-layer output_attentions."""
 
@@ -265,8 +345,15 @@ class _FakeHFViTWithAttn:
         self._num_heads = num_heads
         self._num_layers = num_layers
 
-    def __call__(self, *, pixel_values, output_attentions=False):
+    def __call__(
+        self,
+        *,
+        pixel_values,
+        output_attentions=False,
+        interpolate_pos_encoding=False,
+    ):
         assert output_attentions is True
+        assert interpolate_pos_encoding is True
         b, _, h, w = pixel_values.shape
         n = 1 + (h // self.config.patch_size) * (w // self.config.patch_size)
         # Per-layer softmax-normalized attention so the slice invariants hold.
@@ -343,7 +430,13 @@ class _FakeSdpaHFViT:
     def set_attn_implementation(self, impl):
         self.config._attn_implementation = impl
 
-    def __call__(self, pixel_values=None, *, output_attentions=False):
+    def __call__(
+        self,
+        pixel_values=None,
+        *,
+        output_attentions=False,
+        interpolate_pos_encoding=False,
+    ):
         b, _, h, w = pixel_values.shape
         n = 1 + (h // self.config.patch_size) * (w // self.config.patch_size)
         if self.config._attn_implementation != "eager" or not output_attentions:

--- a/tests/test_dense_encode_kit.py
+++ b/tests/test_dense_encode_kit.py
@@ -211,7 +211,7 @@ def test_prepare_dense_encoder_accepts_both_option_types_and_ignores_source_fiel
             "attention_include_registers must be a boolean",
         ),
         (
-            "phikon",
+            "musk",
             _dense_image(target_size=512),
             "does not support a variable encoder input",
         ),

--- a/tests/test_dense_encoder_input.py
+++ b/tests/test_dense_encoder_input.py
@@ -31,15 +31,26 @@ from slide2vec.runtime.encoder_input_contract import EncoderInputContract  # noq
 # --------------------------------------------------------------------------------------
 
 
-def test_dense_whole_tile_at_a_non_native_size_is_rejected_without_the_capability():
-    """phikon declares supports_variable_input_size=False; a 512px whole tile must raise.
+@pytest.mark.parametrize(
+    "name,target_size",
+    [
+        ("conch", (464, 480)),
+        ("conchv15", (464, 480)),
+        ("phikon", (240, 256)),
+        ("phikonv2", (240, 256)),
+        ("isight", (350, 364)),
+    ],
+)
+def test_dense_whole_tile_accepts_verified_non_native_rectangles_without_kwargs(
+    name, target_size
+):
+    contract = EncoderInputContract.declared_dense(
+        name, target_size_px=target_size, window_size=None
+    )
 
-    The old route hand-passed ``dynamic_img_size=True`` to ``load_model``, which silently
-    dropped it because phikon's constructor takes no such parameter — the run proceeded to
-    feed the encoder a size it cannot accept.
-    """
-    with pytest.raises(ValueError, match="does not support a variable encoder input"):
-        EncoderInputContract.declared_dense("phikon", target_size_px=512, window_size=None)
+    assert contract.plan.effective_encoder_input_size_px == target_size
+    assert contract.plan.requires_variable_model_input is True
+    assert contract.construction_kwargs_for(name) == {}
 
 
 def test_dense_whole_tile_derives_the_registry_variable_input_kwargs():
@@ -77,10 +88,14 @@ def test_dense_sliding_at_the_native_window_needs_no_variable_input():
     assert contract.construction_kwargs_for("phikon") == {}
 
 
-def test_dense_sliding_above_the_native_window_still_asks_the_capability_question():
-    """A 256px window on a 224px fixed-input encoder is as unsupported as a 512px tile."""
-    with pytest.raises(ValueError, match="does not support a variable encoder input"):
-        EncoderInputContract.declared_dense("phikon", target_size_px=512, window_size=256)
+def test_dense_sliding_above_the_native_window_uses_verified_capability():
+    contract = EncoderInputContract.declared_dense(
+        "phikon", target_size_px=512, window_size=256
+    )
+
+    assert contract.plan.effective_encoder_input_size_px == (256, 256)
+    assert contract.plan.requires_variable_model_input is True
+    assert contract.construction_kwargs_for("phikon") == {}
 
 
 def test_dense_sliding_window_is_clamped_to_the_encoded_extent():
@@ -291,17 +306,17 @@ def test_public_api_reaches_whole_tile_dense_at_a_non_native_size(
     assert model._encoder_input.plan.effective_encoder_input_size_px == (518, 518)
 
 
-def test_public_api_refuses_whole_tile_dense_the_encoder_cannot_accept(
+def test_public_api_refuses_whole_tile_dense_for_fixed_size_musk(
     stand_in_virchow2, tmp_path, monkeypatch
 ):
-    """phikon at 512px whole-tile raises before a single region is read."""
+    """MUSK at 400px whole-tile raises before a single region is read."""
     import slide2vec.inference as inference
 
     monkeypatch.setattr(
         inference.encoder_registry, "require",
         lambda name: pytest.fail("the model must not be constructed"),
     )
-    model = Model.from_preset("phikon", device="cpu")
+    model = Model.from_preset("musk", device="cpu")
     regions = SlideRegions(
         sample_id="s0",
         image_path="s0.tif",
@@ -311,7 +326,7 @@ def test_public_api_refuses_whole_tile_dense_the_encoder_cannot_accept(
     with pytest.raises(ValueError, match="does not support a variable encoder input"):
         model.embed_regions_dense(
             [regions],
-            dense=DenseOptions(spacing_um=0.5, target_size=512),
+            dense=DenseOptions(spacing_um=0.5, target_size=400),
             execution=ExecutionOptions(
                 output_dir=tmp_path, num_gpus=1, batch_size=1, precision="fp32"
             ),

--- a/tests/test_dense_extraction.py
+++ b/tests/test_dense_extraction.py
@@ -308,9 +308,9 @@ def test_conch_dense_uses_visual_trunk_not_attentional_tokens():
 
     enc = CONCH.__new__(CONCH)
     enc._model = SimpleNamespace(visual=_Visual())
-    grid = enc.encode_tiles_dense(torch.randn(1, 3, 448, 448))
-    assert grid.shape == (1, 768, 28, 28)
-    expected = torch.arange(28 * 28, dtype=torch.float32).reshape(28, 28)
+    grid = enc.encode_tiles_dense(torch.randn(1, 3, 448, 464))
+    assert grid.shape == (1, 768, 28, 29)
+    expected = torch.arange(28 * 29, dtype=torch.float32).reshape(28, 29)
     assert torch.equal(grid[0, 0], expected)
 
 
@@ -319,8 +319,8 @@ def test_conchv15_dense_uses_returned_conch_trunk():
 
     enc = CONCHv15.__new__(CONCHv15)
     enc._model = SimpleNamespace(trunk=_FakeTrunk(hidden_size=1024))
-    grid = enc.encode_tiles_dense(torch.randn(1, 3, 448, 448))
-    assert grid.shape == (1, 1024, 28, 28)
+    grid = enc.encode_tiles_dense(torch.randn(1, 3, 448, 464))
+    assert grid.shape == (1, 1024, 28, 29)
 
 
 class _FakeMUSKModel:

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -990,10 +990,10 @@ def test_model_embed_images_dense_delegates_and_requires_output_dir(monkeypatch,
 
 
 def test_declaring_the_dense_contract_rejects_a_geometry_the_encoder_cannot_take(tmp_path):
-    """The #233 capability check runs before any image is decoded: phikon is fixed-input."""
+    """The #233 capability check runs before any image is decoded: MUSK is fixed-input."""
     from slide2vec.api import Model
 
-    model = Model(name="phikon", device="cpu")
+    model = Model(name="musk", device="cpu")
     execution = ExecutionOptions(output_dir=tmp_path / "out", num_gpus=1, precision="fp32")
 
     with pytest.raises(ValueError, match="does not support a variable encoder input"):

--- a/tests/test_encoder_input_contract.py
+++ b/tests/test_encoder_input_contract.py
@@ -91,8 +91,8 @@ def test_declared_geometry_rejects_an_encoder_without_variable_input_capability(
 
     with pytest.raises(ValueError, match="does not support a variable encoder input"):
         EncoderInputContract.declared_pooled(
-            "conch",
-            requested_tile_size_px=464,
+            "musk",
+            requested_tile_size_px=400,
             allow_non_recommended_settings=True,
         )
 
@@ -181,7 +181,7 @@ def test_load_model_rejects_a_contract_declared_for_another_encoder(stand_in_gig
     import slide2vec.inference as inference
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
-    # conch is fixed-input, so resolving 288px against conch would have raised outright.
+    # The contract remains bound to gigapath even though conch can accept 288px too.
     contract = EncoderInputContract.declared_pooled(
         "gigapath",
         requested_tile_size_px=288,

--- a/tests/test_isight.py
+++ b/tests/test_isight.py
@@ -87,7 +87,7 @@ def test_isight_metadata_contract():
     assert info["supported_spacing_um"] == pytest.approx(0.5)
     assert info["precision"] == "fp16"
     assert info["source"] == "nirschl-lab/iSight"
-    assert info["supports_variable_input_size"] is False
+    assert info["supports_variable_input_size"] is True
     assert info["output_variants"]["token_mean"]["encode_dim"] == 1024
     assert info["output_variants"]["cls"]["encode_dim"] == 1024
     assert info["default_output_variant"] == "token_mean"
@@ -165,6 +165,57 @@ def test_isight_dense_applies_projection_and_preserves_row_major_grid():
     assert grid.shape == (2, _HIDDEN, 2, 2)
     expected = (2.0 * tokens[:, 1:]).transpose(1, 2).reshape(2, _HIDDEN, 2, 2)
     torch.testing.assert_close(grid, expected, rtol=0, atol=1e-6)
+
+
+def test_isight_interpolates_positions_for_every_variable_extraction_path():
+    enc = _tiny_encoder()
+    rectangular = torch.randn(1, 3, 42, 28)
+
+    with torch.no_grad():
+        tokens = enc._projection(
+            enc._vision(
+                rectangular,
+                output_hidden_states=True,
+                interpolate_pos_encoding=True,
+            ).hidden_states[-1]
+        )
+        pooled = enc.encode_tiles(rectangular)
+        dense = enc.encode_tiles_dense(rectangular)
+        attention = enc.encode_tiles_attention(rectangular)
+
+    assert pooled.shape == (1, _HIDDEN)
+    assert dense.shape == (1, _HIDDEN, 3, 2)
+    assert attention.shape == (1, _HEADS, 3, 2)
+    expected_dense = tokens[:, 1:].transpose(1, 2).reshape(1, _HIDDEN, 3, 2)
+    torch.testing.assert_close(dense, expected_dense, rtol=0, atol=0)
+
+
+def test_isight_positional_interpolation_is_exactly_inert_at_native_size():
+    from slide2vec.encoders.base import attentions_tuple_to_grids, hf_eager_attention
+
+    enc = _tiny_encoder()
+    native = torch.randn(1, 3, _IMAGE, _IMAGE)
+
+    with torch.no_grad():
+        prior_tokens = enc._projection(
+            enc._vision(native, output_hidden_states=True).hidden_states[-1]
+        )
+        tokens = enc._token_features(native)
+        with hf_eager_attention(enc._clip):
+            prior_with_attention = enc._vision(native, output_attentions=True)
+        attention = enc.encode_tiles_attention(native)
+
+    prior_attention = attentions_tuple_to_grids(
+        prior_with_attention.attentions,
+        num_prefix_tokens=1,
+        blocks=(-1,),
+        include_registers=False,
+        grid_h=2,
+        grid_w=2,
+        encoder_name="ISight",
+    )
+    assert torch.equal(tokens, prior_tokens)
+    assert torch.equal(attention, prior_attention)
 
 
 def test_isight_dense_rejects_indivisible_input():

--- a/tests/test_pooled_encoder_input.py
+++ b/tests/test_pooled_encoder_input.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from torchvision.transforms import v2
 
@@ -74,23 +75,76 @@ def test_every_tile_registration_declares_variable_input_capability():
     assert resolve_variable_input_capability("moozy") is True
 
 
-def test_fixed_size_encoder_rejects_permitted_non_preset_request():
+def test_musk_rejects_permitted_non_preset_request():
     import pytest
 
     from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
 
     with pytest.raises(ValueError) as error:
         PooledEncoderInputPlan.resolve(
-            "conch",
-            requested_tile_size_px=464,
+            "musk",
+            requested_tile_size_px=400,
             allow_non_recommended_settings=True,
         )
 
     assert str(error.value) == (
-        "Encoder 'conch' does not support a variable encoder input; its registered "
-        "input size is 448px, so an effective encoder input of 464px "
-        "(requested_tile_size_px=464) is unsupported."
+        "Encoder 'musk' does not support a variable encoder input; its registered "
+        "input size is 384px, so an effective encoder input of 400px "
+        "(requested_tile_size_px=400) is unsupported."
     )
+
+
+@pytest.mark.parametrize(
+    "name,requested_size",
+    [
+        ("conch", 464),
+        ("conchv15", 464),
+        ("phikon", 240),
+        ("phikonv2", 240),
+        ("isight", 350),
+    ],
+)
+def test_verified_vit_encoder_plans_exact_non_preset_input_without_constructor_kwargs(
+    name, requested_size
+):
+    from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+
+    plan = PooledEncoderInputPlan.resolve(
+        name,
+        requested_tile_size_px=requested_size,
+        allow_non_recommended_settings=True,
+    )
+
+    assert plan.requires_variable_model_input is True
+    assert plan.expected_encoder_input_size_px == requested_size
+    assert plan.model_construction_kwargs == {}
+
+
+@pytest.mark.parametrize(
+    "name,default_size",
+    [
+        ("conch", 448),
+        ("conchv15", 448),
+        ("phikon", 224),
+        ("phikonv2", 224),
+        ("isight", 336),
+    ],
+)
+def test_variable_vit_native_defaults_still_select_shipped_preprocessing(
+    name, default_size
+):
+    from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+
+    plan = PooledEncoderInputPlan.resolve(
+        name,
+        requested_tile_size_px=default_size,
+        allow_non_recommended_settings=False,
+    )
+
+    assert plan.preset_input_size_px == default_size
+    assert plan.preprocessing_kind == "shipped"
+    assert plan.requires_variable_model_input is False
+    assert plan.model_construction_kwargs == {}
 
 
 def test_permitted_variable_plan_preserves_exact_geometry_with_normalization_only():


### PR DESCRIPTION
## Summary

- enable verified variable input metadata for CONCH, CONCH v1.5, Phikon, Phikon-v2, and iSight
- opt Phikon and iSight into Hugging Face positional interpolation on pooled, dense, and attention paths
- preserve native defaults and shipped preprocessing while keeping MUSK fixed-size
- cover rectangular row-major grids, native-path parity, pooled/dense planning, and stale fixed-size regressions

## Exact-checkpoint verification

- CONCH (`f9ca9f877171a28ade80228fb195ac5d79003357`): 464×464 and 448×464 pooled, dense, and attention paths
- TITAN-returned CONCH v1.5 remote code (`dac6773d9961cfc75503440676ff157a2c6e8d2e`): 464×464 and 448×464 pooled, dense, and attention paths
- Phikon (`057cc0295895c2df3dd7681a89680da6015cbefe`): 256×256 and 224×256 paths plus bit-exact native pooled/dense/attention parity
- Phikon-v2 (`2ae989a9c40cffaa27f0a6cb29cc94d1d6f9a5fd`): 256×256 and 224×256 paths without constructor overrides
- iSight checkpoint (`0f5800dbd0620c805afec2c55de41c95fc3054dd`): 350×350 and 336×350 paths plus bit-exact native token/attention parity

## Validation

- focused model/planning/extraction suite: `110 passed`
- full non-heavy suite after review fixes: `893 passed, 6 skipped, 30 deselected`
- changed-file flake8 and `git diff --check`: passed

Closes #281
