### PR TITLE
Expose PRISM2 diagnostic slide embeddings

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -319,8 +319,8 @@ Slide-level encoders
      - `PRISM2 <https://huggingface.co/paige-ai/Prism2>`_
      - ``virchow2`` (CLS only)
      - ``0.5``
-     - 2560
-     - Base embedding; Shaikovski et al. (2026)
+     - 2560 (base); 3072 (diagnostic)
+     - Base is default; Shaikovski et al. (2026)
    * - ``moozy-slide``
      - `MOOZY <https://huggingface.co/AtlasAnalyticsLab/MOOZY>`_
      - ``lunit``
@@ -332,10 +332,14 @@ Slide-level encoders
 PRISM2 gated-use contract
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``prism2`` exposes only PRISM2's 2560-dimensional **base embedding** (the
-Perceiver-pool output) through slide2vec's slide-embedding API. Diagnostic
-embeddings, text generation, yes/no scoring, and concatenating multiple slides
-into one specimen are not part of this preset.
+``prism2`` defaults to PRISM2's 2560-dimensional **base embedding**, the
+Perceiver-pool output used for general slide representation. Select
+``output_variant="diagnostic"`` for the documented 3072-dimensional
+**diagnostic embedding**. That representation is the Phi-3 final-layer hidden
+state at the ``<|assistant|>`` position after PRISM2's fixed image-only prompt;
+the official ``get_diagnostic_embedding`` method owns that prompt and hidden-state
+selection. Free-form text generation, yes/no scoring, and concatenating multiple
+slides into one specimen remain outside this preset.
 
 The upstream repository is gated. Request access individually, accept its terms,
 then authenticate the machine that runs slide2vec with ``hf auth login`` (or set
@@ -347,9 +351,12 @@ isolated runtime only where this preset is needed:
 
    python -m pip install "slide2vec[prism2]"
 
-PRISM2 requires a CUDA-capable GPU and ``flash-attn>=2.6.3``; flash attention is
-mandatory because its Perceiver cross-attention uses the training-time
-``flash_attn_varlen_func`` kernel. The recommended compute precision is bf16.
+The pinned PRISM2 revision declares Transformers 4.51.3, which the isolated
+``prism2`` extra installs exactly; newer Transformers releases can remove Phi-3
+internals used by the gated custom code. PRISM2 also requires a CUDA-capable GPU
+and ``flash-attn>=2.6.3``. Flash attention is mandatory because its Perceiver
+cross-attention uses the training-time ``flash_attn_varlen_func`` kernel. The
+recommended compute precision is bf16.
 Because numpy-backed slide artifacts cannot persist bf16, slide2vec's existing
 default output-dtype policy widens bf16 results to fp32 on disk; pass an explicit
 supported ``output_dtype`` only when a different persisted dtype is intended.
@@ -363,11 +370,13 @@ override. The default slide2vec preprocessing path segments and samples tissue;
 review custom masks and filtering overrides carefully so background tiles do not
 enter the bag.
 
-Coordinates are intentionally not supplied to PRISM2: at tested revision
+Both output variants use this identical tile extraction and preprocessing path;
+changing ``output_variant`` changes only the slide representation. Coordinates
+are intentionally not supplied to PRISM2: at tested revision
 ``450352d0ddc6b42b21ce20794ce0fbefe6b5a47a``, the official processor accepts
-only tile embeddings (plus an optional attention mask), and
-``get_base_embedding`` consumes only the processed tile tensor and mask. The
-same revision was used for the deterministic contract tests and CUDA smoke:
+only tile embeddings (plus an optional attention mask), and both official
+embedding methods consume that same processed batch. The same revision was used
+for the deterministic contract tests and CUDA diagnostic smoke:
 
 .. code-block:: bash
 
@@ -376,11 +385,17 @@ same revision was used for the deterministic contract tests and CUDA smoke:
    from slide2vec.encoders.models.prism2 import PRISM2_REVISION, Prism2SlideEncoder
 
    assert PRISM2_REVISION == "450352d0ddc6b42b21ce20794ce0fbefe6b5a47a"
-   encoder = Prism2SlideEncoder().to("cuda")
+   encoder = Prism2SlideEncoder(output_variant="diagnostic").to("cuda")
    with torch.autocast("cuda", torch.bfloat16):
        output = encoder.encode_slide(torch.zeros(2, 1280))
-   assert output.shape == (2560,)
+   assert output.shape == (3072,)
    PY
+
+The diagnostic path moves only the modules used by the official method
+(``image_resampler``, ``img_projection``, and ``text_decoder``) to CUDA and casts
+them to bf16. This avoids materializing the pinned checkpoint's roughly 16.7 GiB
+fp32 diagnostic path on-device while preserving the upstream computation. The
+default base path remains unchanged and moves only ``image_resampler``.
 
 PRISM2 is released under CC-BY-NC-ND-4.0 and its additional gated terms. It is
 for non-commercial academic research/evaluation only and must not be used for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ prism = [
 ]
 prism2 = [
     "torch>=2.3",
-    "transformers>=4.51",
+    "transformers==4.51.3",
     "safetensors",
     "einops",
     "flash-attn>=2.6.3",

--- a/slide2vec/encoders/models/prism2.py
+++ b/slide2vec/encoders/models/prism2.py
@@ -19,7 +19,10 @@ PRISM2_REVISION = "450352d0ddc6b42b21ce20794ce0fbefe6b5a47a"
     level="slide",
     tile_encoder="virchow2",
     tile_encoder_output_variant="cls",
-    output_variants={"base": {"encode_dim": 2560}},
+    output_variants={
+        "base": {"encode_dim": 2560},
+        "diagnostic": {"encode_dim": 3072},
+    },
     default_output_variant="base",
     supported_spacing_um=0.5,
     precision="bf16",
@@ -27,6 +30,11 @@ PRISM2_REVISION = "450352d0ddc6b42b21ce20794ce0fbefe6b5a47a"
 )
 class Prism2SlideEncoder(SlideEncoder):
     def __init__(self, *, output_variant: str | None = None):
+        self._output_variant = resolve_requested_output_variant(
+            output_variant,
+            default="base",
+            allowed=("base", "diagnostic"),
+        )
         shared_load_kwargs = {
             "revision": PRISM2_REVISION,
             "trust_remote_code": True,
@@ -41,15 +49,10 @@ class Prism2SlideEncoder(SlideEncoder):
             **shared_load_kwargs,
         )
         self._device = preferred_default_device()
-        self._output_variant = resolve_requested_output_variant(
-            output_variant,
-            default="base",
-            allowed=("base",),
-        )
 
     @property
     def encode_dim(self) -> int:
-        return 2560
+        return 2560 if self._output_variant == "base" else 3072
 
     @property
     def device(self) -> torch.device:
@@ -57,10 +60,22 @@ class Prism2SlideEncoder(SlideEncoder):
 
     def to(self, device: torch.device | str) -> "Prism2SlideEncoder":
         self._device = torch.device(device)
-        # The pinned upstream get_base_embedding path uses image_resampler only.
-        # Keep the excluded Phi-3 decoder on CPU instead of spending GPU memory
-        # on text-generation parameters this base-only preset can never call.
-        self._model.image_resampler.to(self._device)
+        if self._output_variant == "base":
+            # The pinned upstream get_base_embedding path uses image_resampler only.
+            # Keep the excluded Phi-3 decoder on CPU instead of spending GPU memory
+            # on text-generation parameters this base-only preset can never call.
+            self._model.image_resampler.to(self._device)
+        else:
+            diagnostic_modules = (
+                self._model.image_resampler,
+                self._model.img_projection,
+                self._model.text_decoder,
+            )
+            for module in diagnostic_modules:
+                if self._device.type == "cuda":
+                    module.to(self._device, dtype=torch.bfloat16)
+                else:
+                    module.to(self._device)
         return self
 
     def encode_slide(
@@ -71,4 +86,9 @@ class Prism2SlideEncoder(SlideEncoder):
         tile_size_lv0: int | None = None,
     ) -> torch.Tensor:
         batch = self._processor(tile_embeddings=[tile_features]).to(self._device)
-        return self._model.get_base_embedding(**batch).squeeze(0)
+        embedding_method = (
+            self._model.get_base_embedding
+            if self._output_variant == "base"
+            else self._model.get_diagnostic_embedding
+        )
+        return embedding_method(**batch).squeeze(0)

--- a/tests/test_prism2.py
+++ b/tests/test_prism2.py
@@ -227,15 +227,39 @@ def test_prism2_rejects_unsupported_variant_before_gated_load(monkeypatch):
     assert load_calls == []
 
 
-def test_prism2_processes_one_slide_on_device_and_returns_exact_base_vector(
+@pytest.mark.parametrize(
+    ("output_variant", "processed_value", "expected_method", "expected"),
+    [
+        pytest.param(
+            None,
+            3.0,
+            "base",
+            torch.arange(2560, dtype=torch.float32).reshape(1, 2560),
+            id="base-default",
+        ),
+        pytest.param(
+            "diagnostic",
+            7.0,
+            "diagnostic",
+            torch.arange(3072, dtype=torch.float32).reshape(1, 3072),
+            id="diagnostic",
+        ),
+    ],
+)
+def test_prism2_processes_one_slide_and_returns_exact_selected_vector(
     monkeypatch,
+    output_variant,
+    processed_value,
+    expected_method,
+    expected,
 ):
     from slide2vec.encoders.models.prism2 import Prism2SlideEncoder
 
     processor_calls = []
     model_calls = []
     device_moves = []
-    expected = torch.arange(2560, dtype=torch.float32).reshape(1, 2560)
+    expected_processed_tiles = torch.full((1, 2, 1280), processed_value)
+    expected_attention_mask = torch.tensor([[1, 1]], dtype=torch.int32)
 
     class FakeBatch(dict):
         def to(self, device):
@@ -246,82 +270,17 @@ def test_prism2_processes_one_slide_on_device_and_returns_exact_base_vector(
         def __call__(self, *, tile_embeddings):
             processor_calls.append(tile_embeddings)
             return FakeBatch(
-                tile_embeddings=torch.full((1, 2, 1280), 3.0),
-                attention_mask=torch.tensor([[1, 1]], dtype=torch.int32),
+                tile_embeddings=expected_processed_tiles.clone(),
+                attention_mask=expected_attention_mask.clone(),
             )
 
     class FakeModel(torch.nn.Module):
         def get_base_embedding(self, **batch):
-            model_calls.append(batch)
+            model_calls.append(("base", batch))
             return expected
-
-    monkeypatch.setattr(
-        transformers.AutoModel,
-        "from_pretrained",
-        lambda *args, **kwargs: FakeModel(),
-    )
-    monkeypatch.setattr(
-        transformers.AutoProcessor,
-        "from_pretrained",
-        lambda *args, **kwargs: FakeProcessor(),
-    )
-    encoder = Prism2SlideEncoder()
-    tiles = torch.arange(2 * 1280, dtype=torch.float32).reshape(2, 1280)
-    coordinates = torch.tensor([[100, 200], [300, 400]])
-
-    output = encoder.encode_slide(
-        tiles,
-        coordinates,
-        tile_size_lv0=448,
-    )
-
-    assert processor_calls == [[tiles]]
-    assert device_moves == [torch.device("cpu")]
-    assert list(model_calls[0]) == ["tile_embeddings", "attention_mask"]
-    torch.testing.assert_close(
-        model_calls[0]["tile_embeddings"],
-        torch.full((1, 2, 1280), 3.0),
-        rtol=0,
-        atol=0,
-    )
-    torch.testing.assert_close(
-        model_calls[0]["attention_mask"],
-        torch.tensor([[1, 1]], dtype=torch.int32),
-        rtol=0,
-        atol=0,
-    )
-    torch.testing.assert_close(output, expected[0], rtol=0, atol=0)
-
-
-def test_prism2_processes_one_slide_and_returns_exact_diagnostic_vector(
-    monkeypatch,
-):
-    from slide2vec.encoders.models.prism2 import Prism2SlideEncoder
-
-    processor_calls = []
-    model_calls = []
-    device_moves = []
-    expected = torch.arange(3072, dtype=torch.float32).reshape(1, 3072)
-
-    class FakeBatch(dict):
-        def to(self, device):
-            device_moves.append(torch.device(device))
-            return self
-
-    class FakeProcessor:
-        def __call__(self, *, tile_embeddings):
-            processor_calls.append(tile_embeddings)
-            return FakeBatch(
-                tile_embeddings=torch.full((1, 2, 1280), 7.0),
-                attention_mask=torch.tensor([[1, 1]], dtype=torch.int32),
-            )
-
-    class FakeModel(torch.nn.Module):
-        def get_base_embedding(self, **batch):
-            raise AssertionError("diagnostic must not dispatch to the base method")
 
         def get_diagnostic_embedding(self, **batch):
-            model_calls.append(batch)
+            model_calls.append(("diagnostic", batch))
             return expected
 
     monkeypatch.setattr(
@@ -334,7 +293,7 @@ def test_prism2_processes_one_slide_and_returns_exact_diagnostic_vector(
         "from_pretrained",
         lambda *args, **kwargs: FakeProcessor(),
     )
-    encoder = Prism2SlideEncoder(output_variant="diagnostic")
+    encoder = Prism2SlideEncoder(output_variant=output_variant)
     tiles = torch.arange(2 * 1280, dtype=torch.float32).reshape(2, 1280)
     coordinates = torch.tensor([[100, 200], [300, 400]])
 
@@ -346,16 +305,18 @@ def test_prism2_processes_one_slide_and_returns_exact_diagnostic_vector(
 
     assert processor_calls == [[tiles]]
     assert device_moves == [torch.device("cpu")]
-    assert list(model_calls[0]) == ["tile_embeddings", "attention_mask"]
+    assert model_calls[0][0] == expected_method
+    processed_batch = model_calls[0][1]
+    assert list(processed_batch) == ["tile_embeddings", "attention_mask"]
     torch.testing.assert_close(
-        model_calls[0]["tile_embeddings"],
-        torch.full((1, 2, 1280), 7.0),
+        processed_batch["tile_embeddings"],
+        expected_processed_tiles,
         rtol=0,
         atol=0,
     )
     torch.testing.assert_close(
-        model_calls[0]["attention_mask"],
-        torch.tensor([[1, 1]], dtype=torch.int32),
+        processed_batch["attention_mask"],
+        expected_attention_mask,
         rtol=0,
         atol=0,
     )

--- a/tests/test_prism2.py
+++ b/tests/test_prism2.py
@@ -29,6 +29,8 @@ def _fake_prism2_model(
         def __init__(self):
             super().__init__()
             self.image_resampler = FakeImageResampler()
+            self.img_projection = FakeImageResampler()
+            self.text_decoder = FakeImageResampler()
 
         def to(self, *args, **kwargs):
             if forbid_full_model_move:
@@ -53,7 +55,10 @@ def test_prism2_registry_contract():
 
     assert encoder_registry.info("prism2") == {
         "name": "prism2",
-        "output_variants": {"base": {"encode_dim": 2560}},
+        "output_variants": {
+            "base": {"encode_dim": 2560},
+            "diagnostic": {"encode_dim": 3072},
+        },
         "default_output_variant": "base",
         "level": "slide",
         "input_size": None,
@@ -67,6 +72,54 @@ def test_prism2_registry_contract():
         "precision": "bf16",
         "source": "paige-ai/Prism2",
     }
+
+
+@pytest.mark.parametrize(
+    ("output_variant", "expected_dim"),
+    [(None, 2560), ("diagnostic", 3072)],
+)
+def test_prism2_public_model_lifecycle_reports_selected_dimension(
+    monkeypatch,
+    output_variant,
+    expected_dim,
+):
+    import timm
+
+    from slide2vec import Model
+
+    class FakeVirchow2Model(torch.nn.Module):
+        pretrained_cfg = {
+            "input_size": (3, 224, 224),
+            "mean": (0.485, 0.456, 0.406),
+            "std": (0.229, 0.224, 0.225),
+            "interpolation": "bicubic",
+            "crop_pct": 1.0,
+        }
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: _fake_prism2_model([]),
+    )
+    monkeypatch.setattr(
+        transformers.AutoProcessor,
+        "from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        timm,
+        "create_model",
+        lambda *args, **kwargs: FakeVirchow2Model(),
+    )
+
+    model = Model.from_preset(
+        "prism2",
+        output_variant=output_variant,
+        device="cpu",
+    )
+
+    assert model.feature_dim == expected_dim
+    assert model.device == torch.device("cpu")
 
 
 def test_prism2_resolves_virchow2_geometry_at_its_only_supported_spacing():
@@ -140,6 +193,40 @@ def test_prism2_loads_the_official_model_and_processor_contract(monkeypatch):
     assert fake_model.training is False
 
 
+def test_prism2_rejects_unsupported_variant_before_gated_load(monkeypatch):
+    from slide2vec.encoders.models.prism2 import Prism2SlideEncoder
+
+    load_calls = []
+
+    def forbidden_model_load(*args, **kwargs):
+        load_calls.append("model")
+        raise AssertionError("invalid variants must fail before gated model loading")
+
+    def forbidden_processor_load(*args, **kwargs):
+        load_calls.append("processor")
+        raise AssertionError("invalid variants must fail before gated processor loading")
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        forbidden_model_load,
+    )
+    monkeypatch.setattr(
+        transformers.AutoProcessor,
+        "from_pretrained",
+        forbidden_processor_load,
+    )
+
+    with pytest.raises(ValueError) as error:
+        Prism2SlideEncoder(output_variant="not-a-variant")
+
+    assert str(error.value) == (
+        "Unsupported output_variant 'not-a-variant'. "
+        "Available: base, diagnostic"
+    )
+    assert load_calls == []
+
+
 def test_prism2_processes_one_slide_on_device_and_returns_exact_base_vector(
     monkeypatch,
 ):
@@ -206,6 +293,75 @@ def test_prism2_processes_one_slide_on_device_and_returns_exact_base_vector(
     torch.testing.assert_close(output, expected[0], rtol=0, atol=0)
 
 
+def test_prism2_processes_one_slide_and_returns_exact_diagnostic_vector(
+    monkeypatch,
+):
+    from slide2vec.encoders.models.prism2 import Prism2SlideEncoder
+
+    processor_calls = []
+    model_calls = []
+    device_moves = []
+    expected = torch.arange(3072, dtype=torch.float32).reshape(1, 3072)
+
+    class FakeBatch(dict):
+        def to(self, device):
+            device_moves.append(torch.device(device))
+            return self
+
+    class FakeProcessor:
+        def __call__(self, *, tile_embeddings):
+            processor_calls.append(tile_embeddings)
+            return FakeBatch(
+                tile_embeddings=torch.full((1, 2, 1280), 7.0),
+                attention_mask=torch.tensor([[1, 1]], dtype=torch.int32),
+            )
+
+    class FakeModel(torch.nn.Module):
+        def get_base_embedding(self, **batch):
+            raise AssertionError("diagnostic must not dispatch to the base method")
+
+        def get_diagnostic_embedding(self, **batch):
+            model_calls.append(batch)
+            return expected
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: FakeModel(),
+    )
+    monkeypatch.setattr(
+        transformers.AutoProcessor,
+        "from_pretrained",
+        lambda *args, **kwargs: FakeProcessor(),
+    )
+    encoder = Prism2SlideEncoder(output_variant="diagnostic")
+    tiles = torch.arange(2 * 1280, dtype=torch.float32).reshape(2, 1280)
+    coordinates = torch.tensor([[100, 200], [300, 400]])
+
+    output = encoder.encode_slide(
+        tiles,
+        coordinates,
+        tile_size_lv0=448,
+    )
+
+    assert processor_calls == [[tiles]]
+    assert device_moves == [torch.device("cpu")]
+    assert list(model_calls[0]) == ["tile_embeddings", "attention_mask"]
+    torch.testing.assert_close(
+        model_calls[0]["tile_embeddings"],
+        torch.full((1, 2, 1280), 7.0),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        model_calls[0]["attention_mask"],
+        torch.tensor([[1, 1]], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(output, expected[0], rtol=0, atol=0)
+
+
 def test_prism2_moves_only_the_base_embedding_component_to_device(monkeypatch):
     from slide2vec.encoders.models.prism2 import Prism2SlideEncoder
 
@@ -231,6 +387,54 @@ def test_prism2_moves_only_the_base_embedding_component_to_device(monkeypatch):
     assert result is encoder
     assert encoder.device == torch.device("cuda:0")
     assert moves == [torch.device("cuda:0")]
+
+
+def test_prism2_moves_the_official_diagnostic_path_to_cuda_in_bfloat16(
+    monkeypatch,
+):
+    from slide2vec.encoders.models.prism2 import Prism2SlideEncoder
+
+    moves = []
+
+    class FakeComponent:
+        def __init__(self, name):
+            self.name = name
+
+        def to(self, device, *, dtype=None):
+            moves.append((self.name, torch.device(device), dtype))
+            return self
+
+    class FakePrism2Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.image_resampler = FakeComponent("image_resampler")
+            self.img_projection = FakeComponent("img_projection")
+            self.text_decoder = FakeComponent("text_decoder")
+
+        def to(self, *args, **kwargs):
+            raise AssertionError("the full fp32 wrapper does not fit on this GPU")
+
+    monkeypatch.setattr(
+        transformers.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: FakePrism2Model(),
+    )
+    monkeypatch.setattr(
+        transformers.AutoProcessor,
+        "from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+    encoder = Prism2SlideEncoder(output_variant="diagnostic")
+
+    result = encoder.to("cuda:0")
+
+    assert result is encoder
+    assert encoder.device == torch.device("cuda:0")
+    assert moves == [
+        ("image_resampler", torch.device("cuda:0"), torch.bfloat16),
+        ("img_projection", torch.device("cuda:0"), torch.bfloat16),
+        ("text_decoder", torch.device("cuda:0"), torch.bfloat16),
+    ]
 
 
 def test_prism2_load_model_seam_attaches_cls_tile_encoder_and_dimensions(
@@ -298,7 +502,7 @@ def test_prism2_optional_extra_matches_the_upstream_cuda_runtime():
 
     assert extras["prism2"] == [
         "torch>=2.3",
-        "transformers>=4.51",
+        "transformers==4.51.3",
         "safetensors",
         "einops",
         "flash-attn>=2.6.3",


### PR DESCRIPTION
Closes #278

## What changed

- Added the PRISM2 `diagnostic` output variant, dispatching to the pinned gated model's official `get_diagnostic_embedding(**batch)` path.
- Kept the 2560-dimensional `base` representation as the unchanged default; diagnostic outputs one 3072-dimensional slide vector.
- Preserved the shared Virchow2 CLS-only dependency and 224 px / 0.5 µm/px preprocessing contract.
- Validated unsupported variants before gated model/processor loading and named the available variants.
- Added an evidence-backed device boundary: base still moves only `image_resampler`; diagnostic moves exactly `image_resampler`, `img_projection`, and `text_decoder` to CUDA in bf16.
- Pinned the isolated PRISM2 extra to upstream-declared Transformers 4.51.3 after proving 4.57.6 breaks the pinned Phi-3 custom-code API.
- Updated the model catalog and gated-use documentation with semantics, dimensions, runtime requirements, and a reproducible smoke command.

## Acceptance criteria

- [x] Public `Model.from_preset` lifecycle reports 2560 by default and 3072 for `output_variant="diagnostic"`.
- [x] Diagnostic encoding dispatches official `get_diagnostic_embedding(**batch)` with exact processed inputs and returns one 3072-vector.
- [x] Base remains the unchanged 2560 default.
- [x] Unsupported variants fail before gated loading and list `base, diagnostic`.
- [x] Both variants share Virchow2 CLS-only, 1280-dimensional tile features, 224 px tiles, and 0.5 µm/px.
- [x] Real-weight CUDA smoke exercised the official diagnostic path at revision `450352d0ddc6b42b21ce20794ce0fbefe6b5a47a`.
- [x] Catalog/docs explain the semantic and dimensional difference.
- [x] Focused, relevant static, and docs checks pass.

## Test-first evidence

Red checkpoints:

- Registry lacked `diagnostic`; public lifecycle rejected it as unavailable.
- Invalid variants invoked the gated loader before validation.
- Diagnostic encoding incorrectly called `get_base_embedding`.
- Diagnostic device placement moved only `image_resampler` without bf16.
- The PRISM2 extra admitted incompatible Transformers 4.57.6.

Green checkpoints:

- `python -m pytest -q --no-cov tests/test_prism2.py` — **14 passed**.
- `python -m pytest -q --no-cov tests/test_encoder_registry.py tests/test_patch_size_metadata.py tests/test_regression_core.py -m 'not heavy'` — **194 passed, 25 deselected**.
- Dense-image segmented remainder — **38 passed, 1 deselected**.
- `python -m flake8 slide2vec/encoders/models/prism2.py tests/test_prism2.py` — clean.
- `python -m mypy --follow-imports=skip slide2vec/encoders/models/prism2.py` — clean.
- `python -m sphinx -E -W -b html docs /tmp/slide2vec-issue-278-docs-html` — clean fresh build.

The monolithic local non-GPU run reached 20% and then hit the known `tests/test_dense_image_stage.py::test_worker_encodes_only_its_rank_shard` subprocess hang. The same node timed out when isolated at 90 seconds; all other tests in that file passed. CI remains the authoritative full-suite gate for this draft.

## Real-weight CUDA smoke

Environment: RTX 3080 Ti, authenticated existing HF cache, pinned PRISM2 revision.

- Transformers 4.57.6 reached the official diagnostic method but failed in pinned upstream code because `Phi3Model._prepare_4d_causal_attention_mask_with_cache_position` was removed.
- Upstream-declared Transformers 4.51.3 passed the official `encode_slide` → `get_diagnostic_embedding` path.
- Result: shape `(3072,)`, output/modules `torch.bfloat16`, peak allocated **8.411 GiB**.
- Measured fp32 official diagnostic modules total 17,879,902,208 bytes, so selective bf16 placement is required on the 11.63 GiB GPU.

## Self-review

Independent two-axis review against `origin/main`:

- **Standards:** pass; no actionable findings. Duplicate test scaffolding was consolidated; the simple two-variant branches were retained instead of adding speculative strategy machinery.
- **Spec:** pass; no missing, partial, scope-creep, or incorrect requirements.
