### PR TITLE
Expose preflight-safe Encoder capabilities

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -461,6 +461,44 @@ the Python API).
      - Kotp et al. (2026)
 
 
+Preflight capability reports
+----------------------------
+
+Use :func:`slide2vec.encoders.resolve_encoder_capabilities` to inspect a registered
+preset before constructing its encoder or loading weights:
+
+.. code-block:: python
+
+   from slide2vec.encoders import resolve_encoder_capabilities
+
+   capabilities = resolve_encoder_capabilities("uni2")
+   print(capabilities.level)       # "tile"
+   print(capabilities.pooled)      # True
+   print(capabilities.dense)       # True
+   print(capabilities.attention)   # True
+   print(capabilities.patch_size)  # (14, 14)
+
+The frozen :class:`slide2vec.encoders.EncoderCapabilities` report is the preflight
+view of the existing :class:`~slide2vec.encoders.base.Encoder` contract. It is
+*derived* from the registered class behavior and the preset's existing static
+registry metadata; it is not a second capability declaration. Resolution does not
+instantiate the encoder, load weights, select a GPU, download files, or access the
+network.
+
+``level`` identifies tile, slide, or patient presets. The ``pooled``, ``dense``,
+``attention``, ``slide``, and ``patient`` flags identify the corresponding public
+Encoder methods supported by that class. Dense reports include the normalized static
+``patch_size``. Slide and patient reports include ``tile_encoder`` and
+``tile_encoder_output_variant``, so callers can preflight the fixed tile dependency
+through the same report.
+
+Registration rejects mismatches between the class contract and static metadata. A
+dense tile class, for example, must override ``encode_tiles_dense``, ``patch_size``,
+and ``get_normalization_transform`` together and must declare the same kind of
+positive static ``patch_size`` accepted by ``register_encoder``. A pooled-only tile
+encoder needs none of those dense members and resolves with ``dense=False`` and
+``attention=False``.
+
 Custom registry-backed encoders
 --------------------------------
 

--- a/slide2vec/encoders/__init__.py
+++ b/slide2vec/encoders/__init__.py
@@ -15,9 +15,11 @@ from slide2vec.encoders.base import (
     resolve_requested_output_variant,
 )
 from slide2vec.encoders.registry import (
+    EncoderCapabilities,
     encoder_registry,
     normalize_patch_size,
     register_encoder,
+    resolve_encoder_capabilities,
     resolve_encoder_output,
     resolve_patch_size,
     resolve_preprocessing_requirements,
@@ -29,6 +31,7 @@ from slide2vec.encoders import models  # noqa: F401
 
 __all__ = [
     "Encoder",
+    "EncoderCapabilities",
     "PatientEncoder",
     "TileEncoder",
     "SlideEncoder",
@@ -39,6 +42,7 @@ __all__ = [
     "encoder_registry",
     "normalize_patch_size",
     "register_encoder",
+    "resolve_encoder_capabilities",
     "resolve_patch_size",
     "resolve_preprocessing_requirements",
     "resolve_encoder_output",

--- a/slide2vec/encoders/registry.py
+++ b/slide2vec/encoders/registry.py
@@ -1,10 +1,70 @@
 """Encoder registry with enforced metadata schema."""
 
+from dataclasses import dataclass
+import inspect
 from typing import Any
 
+from slide2vec.encoders.base import PatientEncoder, SlideEncoder, TileEncoder
 from slide2vec.runtime.registry import Registry
 
 encoder_registry = Registry("encoders")
+
+
+@dataclass(frozen=True)
+class EncoderCapabilities:
+    """Resolved, metadata-only preflight view of one registered Encoder preset."""
+
+    name: str
+    level: str
+    pooled: bool
+    dense: bool
+    attention: bool
+    slide: bool
+    patient: bool
+    patch_size: tuple[int, int] | None
+    tile_encoder: str | None
+    tile_encoder_output_variant: str | None
+
+
+def resolve_encoder_capabilities(encoder_name: str) -> EncoderCapabilities:
+    """Resolve supported extraction contracts without constructing the encoder."""
+    encoder_cls = encoder_registry.require(encoder_name)
+    metadata = encoder_registry.info(encoder_name)
+    _validate_encoder_capability_contract(encoder_name, encoder_cls, metadata)
+    level = resolve_encoder_level(encoder_name, metadata)
+    dense = all(_dense_class_contract(encoder_cls))
+    attention = _supports_attention(encoder_cls)
+    tile_encoder = None
+    tile_encoder_output_variant = None
+    if level in {"slide", "patient"}:
+        tile_encoder, tile_encoder_output_variant = (
+            _resolve_hierarchical_tile_dependency(encoder_name, metadata)
+        )
+        dependency_metadata = encoder_registry.info(tile_encoder)
+        dependency_level = resolve_encoder_level(tile_encoder, dependency_metadata)
+        if dependency_level != "tile":
+            raise ValueError(
+                f"Encoder '{encoder_name}' tile_encoder dependency '{tile_encoder}' "
+                f"must have level='tile', got level='{dependency_level}'."
+            )
+        dependency_output = resolve_tile_dependency_output(
+            encoder_name,
+            metadata=metadata,
+        )
+        tile_encoder_output_variant = str(dependency_output["output_variant"])
+        resolve_encoder_capabilities(tile_encoder)
+    return EncoderCapabilities(
+        name=encoder_name,
+        level=level,
+        pooled=issubclass(encoder_cls, TileEncoder),
+        dense=dense,
+        attention=attention,
+        slide=issubclass(encoder_cls, (SlideEncoder, PatientEncoder)),
+        patient=issubclass(encoder_cls, PatientEncoder),
+        patch_size=resolve_patch_size(encoder_name, metadata) if dense else None,
+        tile_encoder=tile_encoder,
+        tile_encoder_output_variant=tile_encoder_output_variant,
+    )
 
 
 def require_encoder_metadata_field(
@@ -29,6 +89,122 @@ def resolve_encoder_level(
     if level not in {"tile", "slide", "patient"}:
         raise ValueError(f"Unsupported encoder level '{level}'")
     return level
+
+
+_DENSE_CLASS_MEMBERS = (
+    "encode_tiles_dense",
+    "patch_size",
+    "get_normalization_transform",
+)
+
+
+def _dense_class_contract(encoder_cls: type) -> tuple[bool, ...]:
+    if not issubclass(encoder_cls, TileEncoder):
+        return (False,) * len(_DENSE_CLASS_MEMBERS)
+    return tuple(
+        getattr(encoder_cls, member) is not getattr(TileEncoder, member)
+        for member in _DENSE_CLASS_MEMBERS
+    )
+
+
+def _supports_attention(encoder_cls: type) -> bool:
+    return (
+        issubclass(encoder_cls, TileEncoder)
+        and getattr(encoder_cls, "encode_tiles_attention")
+        is not TileEncoder.encode_tiles_attention
+    )
+
+
+def _format_names(names: list[str]) -> str:
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return " and ".join(names)
+    return ", ".join(names[:-1]) + f", and {names[-1]}"
+
+
+def _validate_encoder_capability_contract(
+    encoder_name: str,
+    encoder_cls: type,
+    metadata: dict[str, Any],
+) -> None:
+    level = resolve_encoder_level(encoder_name, metadata)
+    required_base = {
+        "tile": TileEncoder,
+        "slide": SlideEncoder,
+        "patient": PatientEncoder,
+    }[level]
+    if not issubclass(encoder_cls, required_base):
+        raise ValueError(
+            f"Encoder '{encoder_name}' declares level='{level}', but class "
+            f"{encoder_cls.__name__} must subclass {required_base.__name__}."
+        )
+    if inspect.isabstract(encoder_cls):
+        missing = sorted(getattr(encoder_cls, "__abstractmethods__"))
+        raise ValueError(
+            f"Encoder '{encoder_name}' class {encoder_cls.__name__} is abstract; "
+            f"implement {_format_names(missing)} before registration."
+        )
+    if level in {"slide", "patient"}:
+        require_encoder_metadata_field(encoder_name, metadata, "tile_encoder")
+        require_encoder_metadata_field(
+            encoder_name,
+            metadata,
+            "tile_encoder_output_variant",
+        )
+    dense_members = _dense_class_contract(encoder_cls)
+    has_static_patch_size = metadata.get("patch_size") is not None
+    if any(dense_members) and not all(dense_members):
+        implemented = [
+            member
+            for member, is_implemented in zip(_DENSE_CLASS_MEMBERS, dense_members)
+            if is_implemented
+        ]
+        missing = [
+            member
+            for member, is_implemented in zip(_DENSE_CLASS_MEMBERS, dense_members)
+            if not is_implemented
+        ]
+        raise ValueError(
+            f"Encoder '{encoder_name}' has an incomplete dense class contract: "
+            f"{_format_names(implemented)} "
+            f"{'is' if len(implemented) == 1 else 'are'} overridden, but "
+            f"{_format_names(missing)} "
+            f"{'is' if len(missing) == 1 else 'are'} inherited as unsupported. "
+            "Override all three dense members together and declare patch_size metadata."
+        )
+    if has_static_patch_size and not all(dense_members):
+        raise ValueError(
+            f"Encoder '{encoder_name}' has an inconsistent dense contract: "
+            "patch_size metadata is declared, but the class must also override "
+            "encode_tiles_dense, patch_size, and get_normalization_transform."
+        )
+    if all(dense_members) and not has_static_patch_size:
+        raise ValueError(
+            f"Encoder '{encoder_name}' implements the dense class contract but does "
+            "not declare patch_size metadata. Add the encoder's static patch size "
+            "to @register_encoder."
+        )
+    if has_static_patch_size:
+        patch = metadata["patch_size"]
+        patch_values = patch if isinstance(patch, tuple) else (patch, patch)
+        valid_patch = (
+            len(patch_values) == 2
+            and all(type(value) is int and value > 0 for value in patch_values)
+        )
+        if not valid_patch:
+            raise ValueError(
+                f"Encoder '{encoder_name}' must declare patch_size as a positive int "
+                f"or pair of positive ints; got {patch!r}."
+            )
+    if _supports_attention(encoder_cls) and not (
+        all(dense_members) and has_static_patch_size
+    ):
+        raise ValueError(
+            f"Encoder '{encoder_name}' overrides encode_tiles_attention without a "
+            "complete dense contract. Attention maps require encode_tiles_dense, "
+            "patch_size, get_normalization_transform, and static patch_size metadata."
+        )
 
 
 def register_encoder(
@@ -66,9 +242,9 @@ def register_encoder(
             cache key can be resolved via :func:`resolve_patch_size` WITHOUT
             instantiating the (multi-GB) encoder; the model-load path asserts this
             static value still equals the loaded model's runtime ``patch_size``.
-        level: Encoder output level ("tile" or "slide").
-        tile_encoder: Registered tile encoder dependency for slide-level models.
-        tile_encoder_output_variant: Fixed tile-encoder output variant for slide models.
+        level: Encoder output level ("tile", "slide", or "patient").
+        tile_encoder: Registered tile encoder dependency for slide/patient models.
+        tile_encoder_output_variant: Fixed tile output variant for slide/patient models.
         supported_spacing_um: The spacing(s) in µm/px the model was trained/validated
             for; :func:`validate_encoder_config` rejects requests outside this set
             unless ``allow_non_recommended_settings=True``. ``None`` marks a
@@ -111,7 +287,13 @@ def register_encoder(
         "precision": precision,
         "source": source,
     }
-    return encoder_registry.register_decorator(name, metadata=metadata)
+
+    def decorator(encoder_cls: type) -> type:
+        _validate_encoder_capability_contract(name, encoder_cls, metadata)
+        encoder_registry.register(name, encoder_cls, metadata=metadata)
+        return encoder_cls
+
+    return decorator
 
 
 def resolve_variable_input_capability(
@@ -372,16 +554,8 @@ def resolve_tile_dependency_output(
         resolved["encoder_name"] = encoder_name
         return resolved
 
-    # Both "slide" and "patient" declare tile_encoder / tile_encoder_output_variant.
-    tile_encoder_name = str(
-        require_encoder_metadata_field(encoder_name, info, "tile_encoder")
-    )
-    tile_encoder_output_variant = str(
-        require_encoder_metadata_field(
-            encoder_name,
-            info,
-            "tile_encoder_output_variant",
-        )
+    tile_encoder_name, tile_encoder_output_variant = (
+        _resolve_hierarchical_tile_dependency(encoder_name, info)
     )
     tile_info = encoder_registry.info(tile_encoder_name)
     resolved = resolve_encoder_output(
@@ -391,3 +565,21 @@ def resolve_tile_dependency_output(
     )
     resolved["encoder_name"] = tile_encoder_name
     return resolved
+
+
+def _resolve_hierarchical_tile_dependency(
+    encoder_name: str,
+    metadata: dict[str, Any],
+) -> tuple[str, str]:
+    """Read the fixed tile preset and output variant for a hierarchical encoder."""
+    tile_encoder_name = str(
+        require_encoder_metadata_field(encoder_name, metadata, "tile_encoder")
+    )
+    tile_encoder_output_variant = str(
+        require_encoder_metadata_field(
+            encoder_name,
+            metadata,
+            "tile_encoder_output_variant",
+        )
+    )
+    return tile_encoder_name, tile_encoder_output_variant

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -735,6 +735,7 @@ def test_omitted_spacing_readable_scale_requires_one_resolvable_model_default(
     tmp_path, monkeypatch, encoder_name, supported_spacing_um
 ):
     import slide2vec.encoders.registry as encoder_registry_module
+    from slide2vec.encoders import TileEncoder
     from slide2vec.encoders.registry import register_encoder
     from slide2vec.runtime.registry import Registry
 
@@ -749,11 +750,25 @@ def test_omitted_spacing_readable_scale_requires_one_resolvable_model_default(
         default_output_variant="default",
         input_size=224,
         supports_variable_input_size=True,
-        patch_size=16,
         supported_spacing_um=supported_spacing_um,
     )
-    class _RegisteredForSpacingTest:
-        pass
+    class _RegisteredForSpacingTest(TileEncoder):
+        @property
+        def encode_dim(self):
+            return 192
+
+        @property
+        def device(self):
+            return torch.device("cpu")
+
+        def to(self, device):
+            return self
+
+        def get_transform(self):
+            return lambda image: image
+
+        def encode_tiles(self, batch):
+            return batch
 
     model = _FakeModel(_encoder(), name=encoder_name)
     monkeypatch.setattr(

--- a/tests/test_encoder_capabilities.py
+++ b/tests/test_encoder_capabilities.py
@@ -1,0 +1,481 @@
+"""Preflight capability reports for registered Encoder presets."""
+
+import pytest
+import torch
+
+from slide2vec.encoders import (
+    EncoderCapabilities,
+    PatientEncoder,
+    SlideEncoder,
+    TileEncoder,
+    encoder_registry,
+    register_encoder,
+    resolve_encoder_capabilities,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_encoder_registry(monkeypatch):
+    """Keep synthetic registrations local to each test."""
+    monkeypatch.setattr(encoder_registry, "_entries", dict(encoder_registry._entries))
+
+
+class _PooledOnlyEncoder(TileEncoder):
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("capability resolution must not construct encoders")
+
+    def get_transform(self):
+        return lambda image: image
+
+    def encode_tiles(self, batch):
+        return batch
+
+    @property
+    def encode_dim(self):
+        return 8
+
+    @property
+    def device(self):
+        return torch.device("cpu")
+
+    def to(self, device):
+        return self
+
+
+class _AbstractTileEncoder(TileEncoder):
+    pass
+
+
+class _DenseEncoder(_PooledOnlyEncoder):
+    def encode_tiles_dense(self, batch):
+        return batch
+
+    @property
+    def patch_size(self):
+        return (16, 16)
+
+    def get_normalization_transform(self):
+        return lambda image: image
+
+
+class _PartialDenseEncoder(_PooledOnlyEncoder):
+    def encode_tiles_dense(self, batch):
+        return batch
+
+
+class _AttentionEncoder(_DenseEncoder):
+    def encode_tiles_attention(
+        self,
+        batch,
+        *,
+        blocks=(-1,),
+        include_registers=False,
+    ):
+        return batch
+
+
+class _AttentionWithoutDenseEncoder(_PooledOnlyEncoder):
+    def encode_tiles_attention(
+        self,
+        batch,
+        *,
+        blocks=(-1,),
+        include_registers=False,
+    ):
+        return batch
+
+
+class _SlideEncoder(SlideEncoder):
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("capability resolution must not construct encoders")
+
+    @property
+    def encode_dim(self):
+        return 4
+
+    @property
+    def device(self):
+        return torch.device("cpu")
+
+    def to(self, device):
+        return self
+
+    def encode_slide(self, tile_features, coordinates=None, *, tile_size_lv0=None):
+        return tile_features
+
+
+class _PatientEncoder(PatientEncoder):
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("capability resolution must not construct encoders")
+
+    @property
+    def encode_dim(self):
+        return 4
+
+    @property
+    def device(self):
+        return torch.device("cpu")
+
+    def to(self, device):
+        return self
+
+    def encode_slide(self, tile_features, coordinates=None, *, tile_size_lv0=None):
+        return tile_features
+
+    def encode_patient(self, slide_embeddings):
+        return slide_embeddings
+
+
+def _register_pooled_dependency():
+    register_encoder(
+        "synthetic-dependency",
+        output_variants={"features": {"encode_dim": 8}},
+        default_output_variant="features",
+        input_size=224,
+        supports_variable_input_size=False,
+        supported_spacing_um=0.5,
+    )(_PooledOnlyEncoder)
+
+
+def test_pooled_only_preset_resolves_without_dense_or_attention_support():
+    register_encoder(
+        "synthetic-pooled",
+        output_variants={"default": {"encode_dim": 8}},
+        default_output_variant="default",
+        input_size=224,
+        supports_variable_input_size=False,
+        supported_spacing_um=0.5,
+    )(_PooledOnlyEncoder)
+
+    assert resolve_encoder_capabilities("synthetic-pooled") == EncoderCapabilities(
+        name="synthetic-pooled",
+        level="tile",
+        pooled=True,
+        dense=False,
+        attention=False,
+        slide=False,
+        patient=False,
+        patch_size=None,
+        tile_encoder=None,
+        tile_encoder_output_variant=None,
+    )
+
+
+def test_dense_preset_resolves_complete_class_and_static_metadata_contract():
+    register_encoder(
+        "synthetic-dense",
+        output_variants={"default": {"encode_dim": 8}},
+        default_output_variant="default",
+        input_size=224,
+        supports_variable_input_size=True,
+        patch_size=16,
+        supported_spacing_um=0.5,
+    )(_DenseEncoder)
+
+    assert resolve_encoder_capabilities("synthetic-dense") == EncoderCapabilities(
+        name="synthetic-dense",
+        level="tile",
+        pooled=True,
+        dense=True,
+        attention=False,
+        slide=False,
+        patient=False,
+        patch_size=(16, 16),
+        tile_encoder=None,
+        tile_encoder_output_variant=None,
+    )
+
+
+def test_attention_preset_resolves_attention_from_class_behavior():
+    register_encoder(
+        "synthetic-attention",
+        output_variants={"default": {"encode_dim": 8}},
+        default_output_variant="default",
+        input_size=224,
+        supports_variable_input_size=True,
+        patch_size=(14, 16),
+        supported_spacing_um=0.5,
+    )(_AttentionEncoder)
+
+    assert resolve_encoder_capabilities("synthetic-attention") == EncoderCapabilities(
+        name="synthetic-attention",
+        level="tile",
+        pooled=True,
+        dense=True,
+        attention=True,
+        slide=False,
+        patient=False,
+        patch_size=(14, 16),
+        tile_encoder=None,
+        tile_encoder_output_variant=None,
+    )
+
+
+def test_registration_rejects_static_patch_metadata_without_dense_class_contract():
+    with pytest.raises(ValueError) as exc_info:
+        register_encoder(
+            "synthetic-contradictory-dense",
+            output_variants={"default": {"encode_dim": 8}},
+            default_output_variant="default",
+            input_size=224,
+            supports_variable_input_size=False,
+            patch_size=16,
+            supported_spacing_um=0.5,
+        )(_PooledOnlyEncoder)
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-contradictory-dense' has an inconsistent dense contract: "
+        "patch_size metadata is declared, but the class must also override "
+        "encode_tiles_dense, patch_size, and get_normalization_transform."
+    )
+
+
+def test_registration_rejects_partial_dense_class_contract():
+    with pytest.raises(ValueError) as exc_info:
+        register_encoder(
+            "synthetic-incomplete-dense",
+            output_variants={"default": {"encode_dim": 8}},
+            default_output_variant="default",
+            input_size=224,
+            supports_variable_input_size=False,
+            supported_spacing_um=0.5,
+        )(_PartialDenseEncoder)
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-incomplete-dense' has an incomplete dense class contract: "
+        "encode_tiles_dense is overridden, but patch_size and "
+        "get_normalization_transform are inherited as unsupported. Override all three "
+        "dense members together and declare patch_size metadata."
+    )
+
+
+def test_registration_rejects_dense_class_contract_without_static_patch_metadata():
+    with pytest.raises(ValueError) as exc_info:
+        register_encoder(
+            "synthetic-dense-without-metadata",
+            output_variants={"default": {"encode_dim": 8}},
+            default_output_variant="default",
+            input_size=224,
+            supports_variable_input_size=True,
+            supported_spacing_um=0.5,
+        )(_DenseEncoder)
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-dense-without-metadata' implements the dense class "
+        "contract but does not declare patch_size metadata. Add the encoder's static "
+        "patch size to @register_encoder."
+    )
+
+
+def test_registration_rejects_attention_without_dense_contract():
+    with pytest.raises(ValueError) as exc_info:
+        register_encoder(
+            "synthetic-attention-without-dense",
+            output_variants={"default": {"encode_dim": 8}},
+            default_output_variant="default",
+            input_size=224,
+            supports_variable_input_size=False,
+            supported_spacing_um=0.5,
+        )(_AttentionWithoutDenseEncoder)
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-attention-without-dense' overrides "
+        "encode_tiles_attention without a complete dense contract. Attention maps "
+        "require encode_tiles_dense, patch_size, get_normalization_transform, and "
+        "static patch_size metadata."
+    )
+
+
+def test_slide_preset_resolves_level_and_tile_dependency():
+    _register_pooled_dependency()
+    register_encoder(
+        "synthetic-slide",
+        level="slide",
+        tile_encoder="synthetic-dependency",
+        tile_encoder_output_variant="features",
+        output_variants={"default": {"encode_dim": 4}},
+        default_output_variant="default",
+        supported_spacing_um=0.5,
+    )(_SlideEncoder)
+
+    assert resolve_encoder_capabilities("synthetic-slide") == EncoderCapabilities(
+        name="synthetic-slide",
+        level="slide",
+        pooled=False,
+        dense=False,
+        attention=False,
+        slide=True,
+        patient=False,
+        patch_size=None,
+        tile_encoder="synthetic-dependency",
+        tile_encoder_output_variant="features",
+    )
+
+
+def test_patient_preset_resolves_slide_patient_and_tile_dependency_contracts():
+    _register_pooled_dependency()
+    register_encoder(
+        "synthetic-patient",
+        level="patient",
+        tile_encoder="synthetic-dependency",
+        tile_encoder_output_variant="features",
+        output_variants={"default": {"encode_dim": 4}},
+        default_output_variant="default",
+        supported_spacing_um=0.5,
+    )(_PatientEncoder)
+
+    assert resolve_encoder_capabilities("synthetic-patient") == EncoderCapabilities(
+        name="synthetic-patient",
+        level="patient",
+        pooled=False,
+        dense=False,
+        attention=False,
+        slide=True,
+        patient=True,
+        patch_size=None,
+        tile_encoder="synthetic-dependency",
+        tile_encoder_output_variant="features",
+    )
+
+
+def test_registration_rejects_level_that_contradicts_registered_class():
+    with pytest.raises(ValueError) as exc_info:
+        register_encoder(
+            "synthetic-wrong-level",
+            level="slide",
+            tile_encoder="synthetic-dependency",
+            tile_encoder_output_variant="features",
+            output_variants={"default": {"encode_dim": 8}},
+            default_output_variant="default",
+            supported_spacing_um=0.5,
+        )(_PooledOnlyEncoder)
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-wrong-level' declares level='slide', but class "
+        "_PooledOnlyEncoder must subclass SlideEncoder."
+    )
+
+
+def test_registration_rejects_incomplete_abstract_encoder_class():
+    with pytest.raises(ValueError) as exc_info:
+        register_encoder(
+            "synthetic-abstract",
+            output_variants={"default": {"encode_dim": 8}},
+            default_output_variant="default",
+            input_size=224,
+            supports_variable_input_size=False,
+            supported_spacing_um=0.5,
+        )(_AbstractTileEncoder)
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-abstract' class _AbstractTileEncoder is abstract; implement "
+        "device, encode_dim, encode_tiles, get_transform, and to before registration."
+    )
+
+
+def test_registration_rejects_hierarchical_encoder_without_tile_dependency():
+    with pytest.raises(ValueError) as exc_info:
+        register_encoder(
+            "synthetic-slide-without-dependency",
+            level="slide",
+            output_variants={"default": {"encode_dim": 4}},
+            default_output_variant="default",
+            supported_spacing_um=0.5,
+        )(_SlideEncoder)
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-slide-without-dependency' must declare tile_encoder metadata"
+    )
+
+
+def test_resolution_rejects_non_tile_dependency_without_recursing():
+    register_encoder(
+        "synthetic-self-dependent-slide",
+        level="slide",
+        tile_encoder="synthetic-self-dependent-slide",
+        tile_encoder_output_variant="default",
+        output_variants={"default": {"encode_dim": 4}},
+        default_output_variant="default",
+        supported_spacing_um=0.5,
+    )(_SlideEncoder)
+
+    with pytest.raises(ValueError) as exc_info:
+        resolve_encoder_capabilities("synthetic-self-dependent-slide")
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-self-dependent-slide' tile_encoder dependency "
+        "'synthetic-self-dependent-slide' must have level='tile', got level='slide'."
+    )
+
+
+def test_registration_rejects_non_positive_dense_patch_size():
+    with pytest.raises(ValueError) as exc_info:
+        register_encoder(
+            "synthetic-invalid-patch",
+            output_variants={"default": {"encode_dim": 8}},
+            default_output_variant="default",
+            input_size=224,
+            supports_variable_input_size=True,
+            patch_size=0,
+            supported_spacing_um=0.5,
+        )(_DenseEncoder)
+
+    assert str(exc_info.value) == (
+        "Encoder 'synthetic-invalid-patch' must declare patch_size as a positive int "
+        "or pair of positive ints; got 0."
+    )
+
+
+def test_existing_built_in_presets_resolve_their_current_contracts():
+    assert resolve_encoder_capabilities("uni2") == EncoderCapabilities(
+        name="uni2",
+        level="tile",
+        pooled=True,
+        dense=True,
+        attention=True,
+        slide=False,
+        patient=False,
+        patch_size=(14, 14),
+        tile_encoder=None,
+        tile_encoder_output_variant=None,
+    )
+    assert resolve_encoder_capabilities("genbio-pathfm") == EncoderCapabilities(
+        name="genbio-pathfm",
+        level="tile",
+        pooled=True,
+        dense=True,
+        attention=False,
+        slide=False,
+        patient=False,
+        patch_size=(16, 16),
+        tile_encoder=None,
+        tile_encoder_output_variant=None,
+    )
+    assert resolve_encoder_capabilities("prism") == EncoderCapabilities(
+        name="prism",
+        level="slide",
+        pooled=False,
+        dense=False,
+        attention=False,
+        slide=True,
+        patient=False,
+        patch_size=None,
+        tile_encoder="virchow",
+        tile_encoder_output_variant="cls_patch_mean",
+    )
+    assert resolve_encoder_capabilities("moozy") == EncoderCapabilities(
+        name="moozy",
+        level="patient",
+        pooled=False,
+        dense=False,
+        attention=False,
+        slide=True,
+        patient=True,
+        patch_size=None,
+        tile_encoder="lunit",
+        tile_encoder_output_variant="default",
+    )
+
+    assert {
+        report.name for report in map(resolve_encoder_capabilities, encoder_registry.names())
+    } == set(encoder_registry.names())


### PR DESCRIPTION
## Summary

- expose a frozen public `EncoderCapabilities` preflight report resolved from the registered encoder class and existing static metadata
- validate level, abstract class, dense, attention, patch-size, and hierarchical dependency contradictions without constructing an encoder
- cover exact pooled, dense, attention, slide, patient, contradiction, and built-in reports with synthetic constructors that fail if called
- document capabilities as a derived view of the existing Encoder contract, not a second declaration

## Validation

- `49 passed` — focused capability, registry, and affected spacing tests after review fixes
- `1004 passed, 63 deselected` — post-review broad PR suite; heavy/GPU tests and the three worker-shard name matches excluded (two demonstrated a fresh-process hang in this environment)
- flake8 clean on changed Python files
- scoped mypy clean on the public encoder modules
- two-axis `main...HEAD` review: Spec 0 findings; Standards duplication finding fixed

## Acceptance criteria

- [x] A caller can resolve a registered preset's level and supported extraction capabilities through a stable public slide2vec API without constructing the encoder.
- [x] Minimal pooled-only presets resolve successfully without claiming dense or attention support.
- [x] Dense-capable presets resolve only when their class behavior and required static metadata form a complete, consistent dense contract.
- [x] Slide and patient presets resolve their level and tile-encoder dependency through the same report.
- [x] Contradictory or incomplete class/metadata declarations fail with an actionable registration or resolution error.
- [x] Existing built-in presets continue to register and resolve with their current behavior.
- [x] Tests use explicit synthetic pooled, dense, slide, and patient presets and assert exact resolved reports; no model construction, GPU, weight download, or network access is allowed.
- [x] Public encoder documentation explains the capability report as the preflight view of the existing Encoder contract, not as a second capability declaration.

Closes #291
