### PR TITLE
Discover healthy installed Encoder plugins

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -499,60 +499,80 @@ positive static ``patch_size`` accepted by ``register_encoder``. A pooled-only t
 encoder needs none of those dense members and resolves with ``dense=False`` and
 ``attention=False``.
 
-Custom registry-backed encoders
---------------------------------
+Custom encoder plugin package
+-----------------------------
 
-If you want to use a model that is not shipped with ``slide2vec``, wrap it in
-an encoder class and register it under a new preset name.
+An encoder owned outside this repository can behave exactly like a built-in preset.
+Package it as a Python distribution with a zero-argument provider in the
+``slide2vec.encoders`` entry-point group. Installing the distribution is enough:
+the Python API and CLI discover it lazily, without a manual import or a module path.
 
-Where to put the file
-~~~~~~~~~~~~~~~~~~~~~
+Minimal package layout
+~~~~~~~~~~~~~~~~~~~~~~
 
-The registry only sees a preset once the module containing
-``@register_encoder`` is imported. ``slide2vec`` auto-imports everything under
-``slide2vec/encoders/models/``, so the simplest way to expose a custom encoder
-to **both the Python API and the CLI** is:
+Create these two files in a separate repository:
 
-1. Add your file as ``slide2vec/encoders/models/my_tile_model.py``.
-2. Add it to ``slide2vec/encoders/models/__init__.py`` (both the
-   ``from . import (...)`` block and ``__all__``).
-3. Reinstall in editable mode if needed (``pip install -e .``).
+.. code-block:: text
 
-The preset name can then be used in YAML configs (``model.name: my-tile-model``),
-``Model.from_preset(...)``, and ``slide2vec.list_models()``.
+   my-slide2vec-encoders/
+   ├── pyproject.toml
+   └── src/
+       └── my_slide2vec_encoders/
+           └── __init__.py
 
-Tile encoder example
-~~~~~~~~~~~~~~~~~~~~
+``pyproject.toml`` declares the installed provider:
+
+.. code-block:: toml
+
+   [build-system]
+   requires = ["setuptools>=61"]
+   build-backend = "setuptools.build_meta"
+
+   [project]
+   name = "my-slide2vec-encoders"
+   version = "0.1.0"
+   dependencies = ["slide2vec>=5.7", "torch", "torchvision"]
+
+   [project.entry-points."slide2vec.encoders"]
+   my_org = "my_slide2vec_encoders:register_encoders"
+
+   [tool.setuptools.packages.find]
+   where = ["src"]
+
+``src/my_slide2vec_encoders/__init__.py`` implements the existing public Encoder
+contract and registers its static preset metadata from the provider:
 
 .. code-block:: python
 
+   from pathlib import Path
+
    import torch
    from torch import Tensor
+   from torchvision.transforms import v2
 
-   from slide2vec.encoders import TileEncoder
-   from slide2vec.encoders import register_encoder, resolve_requested_output_variant
-
-
-   @register_encoder(
-       "my-tile-model",
-       output_variants={"default": {"encode_dim": 768}},
-       default_output_variant="default",
-       input_size=224,
-       supported_spacing_um=0.5,
-       precision="fp16",
-       source="my-org/my-tile-model",
+   from slide2vec.encoders import (
+       TileEncoder,
+       register_encoder,
+       resolve_requested_output_variant,
    )
+
+   CHECKPOINT = Path("/models/my-tile-model.ts")
+
+
    class MyTileModel(TileEncoder):
        def __init__(self, *, output_variant: str | None = None):
            self._output_variant = resolve_requested_output_variant(output_variant)
-           self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-           self._model = self._load_model().eval()
-
-       def _load_model(self):
-           ...
+           self._device = torch.device("cpu")
+           # Loading belongs in construction, never in register_encoders().
+           self._model = torch.jit.load(CHECKPOINT, map_location="cpu").eval()
 
        def get_transform(self):
-           ...
+           return v2.Compose([
+               v2.ToImage(),
+               v2.Resize((224, 224)),
+               v2.ToDtype(torch.float32, scale=True),
+               v2.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
+           ])
 
        def encode_tiles(self, batch: Tensor) -> Tensor:
            return self._model(batch)
@@ -570,101 +590,60 @@ Tile encoder example
            self._model = self._model.to(self._device)
            return self
 
-Once the module is imported, the preset is available through the existing API:
+
+   def register_encoders() -> None:
+       register_encoder(
+           "my-tile-model",
+           level="tile",
+           output_variants={"default": {"encode_dim": 768}},
+           default_output_variant="default",
+           input_size=224,
+           supports_variable_input_size=False,
+           supported_spacing_um=0.5,
+           precision="fp16",
+           source="/models/my-tile-model.ts",
+       )(MyTileModel)
+
+The provider may register more than one class. Keep it metadata-only: importing the
+module and calling ``register_encoders()`` must not construct an encoder, read a
+checkpoint, contact a model hub, or otherwise access the network. Those operations
+belong to the encoder constructor, which runs only when slide2vec loads that preset.
+
+Install and use it
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+   pip install ./my-slide2vec-encoders
 
 .. code-block:: python
 
-   from slide2vec import Model
+   from slide2vec import Model, list_models
+   from slide2vec.encoders import encoder_registry
 
+   assert "my-tile-model" in list_models()
+   print(encoder_registry.info("my-tile-model"))  # static metadata; no weights loaded
    model = Model.from_preset("my-tile-model")
 
+The same preset name works as ``model.name`` in YAML and in the CLI. Every process
+discovers installed providers on its first encoder-registry read; no plugin import is
+needed in application code.
 
-Slide encoder example
-~~~~~~~~~~~~~~~~~~~~~
+Loading ownership and trust
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: python
+The plugin owns its checkpoint loader and credentials. The example uses a fixed local
+TorchScript path. For a private Hugging Face repository, replace that constructor line
+with the appropriate ``from_pretrained("my-org/my-private-model", token=True)`` call
+and supply credentials through the Hugging Face login/token mechanisms. This remains
+construction-time work; the provider itself stays offline and metadata-only.
 
-   import torch
-   from torch import Tensor
+``trust_remote_code=True`` executes Python supplied by the model repository. Enable it
+only after reviewing that code and pinning a trusted commit; leave it disabled for
+unreviewed or mutable repositories.
 
-   from slide2vec.encoders import SlideEncoder
-   from slide2vec.encoders import register_encoder, resolve_requested_output_variant
-
-
-   @register_encoder(
-       "my-slide-model",
-       level="slide",
-       tile_encoder="my-tile-model",
-       tile_encoder_output_variant="default",
-       output_variants={"default": {"encode_dim": 512}},
-       default_output_variant="default",
-       supported_spacing_um=0.5,
-       precision="fp16",
-       source="my-org/my-slide-model",
-   )
-   class MySlideModel(SlideEncoder):
-       def __init__(self, *, output_variant: str | None = None):
-           self._output_variant = resolve_requested_output_variant(output_variant)
-           self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-           self._model = self._load_model().eval()
-
-       def _load_model(self):
-           ...
-
-       @property
-       def encode_dim(self) -> int:
-           return 512
-
-       @property
-       def device(self) -> torch.device:
-           return self._device
-
-       def to(self, device: torch.device | str):
-           self._device = torch.device(device)
-           self._model = self._model.to(self._device)
-           return self
-
-       def encode_slide(
-           self,
-           tile_features: Tensor,
-           coordinates: Tensor | None = None,
-           *,
-           tile_size_lv0: int | None = None,
-       ) -> Tensor:
-           return self._model(tile_features)
-
-
-Multiple weights for the same architecture
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Encoders are instantiated as ``encoder_cls(output_variant=...)``, so the
-weights are tied to the registered class. To expose several checkpoints of
-the same architecture (e.g. different pretraining stages), put the shared
-logic in a base class and register one thin subclass per checkpoint. This
-keeps "preset name → exact weights" as a stable invariant and avoids any
-runtime configuration of paths.
-
-The built-in ``phikon`` encoder
-(``slide2vec/encoders/models/phikon.py``) follows this pattern:
-
-.. code-block:: python
-
-   class _PhikonBase(TileEncoder):
-       def __init__(self, model_name: str, *, output_variant: str | None = None):
-           self._model = AutoModel.from_pretrained(model_name).eval()
-           ...
-
-   @register_encoder("phikon", ..., source="owkin/phikon")
-   class Phikon(_PhikonBase):
-       def __init__(self, *, output_variant: str | None = None):
-           super().__init__("owkin/phikon", output_variant=output_variant)
-
-   @register_encoder("phikonv2", ..., source="owkin/phikon-v2")
-   class PhikonV2(_PhikonBase):
-       def __init__(self, *, output_variant: str | None = None):
-           super().__init__("owkin/phikon-v2", output_variant=output_variant)
-
-For local checkpoints, swap the HuggingFace identifier for a path (or any
-loader you control) in each subclass. Each preset can then be selected
-through the usual ``model.name`` field in YAML configs or
-``Model.from_preset(...)``.
+A preset name is the sole model and artifact identity. Once published, never repoint a
+name to different weights, preprocessing, output semantics, or architecture. Publish a
+new preset name and register a separate class when any of those change; distribution
+versions, checkpoint paths, providers, and recipe revisions are not added to artifact
+identity by slide2vec.

--- a/slide2vec/encoders/registry.py
+++ b/slide2vec/encoders/registry.py
@@ -1,13 +1,78 @@
 """Encoder registry with enforced metadata schema."""
 
 from dataclasses import dataclass
+from enum import Enum, auto
+from importlib import metadata as importlib_metadata
 import inspect
+from threading import Condition, RLock, get_ident
 from typing import Any
 
 from slide2vec.encoders.base import PatientEncoder, SlideEncoder, TileEncoder
 from slide2vec.runtime.registry import Registry
 
-encoder_registry = Registry("encoders")
+
+_ENCODER_ENTRY_POINT_GROUP = "slide2vec.encoders"
+
+
+class _DiscoveryState(Enum):
+    PENDING = auto()
+    RUNNING = auto()
+    COMPLETE = auto()
+    FAILED = auto()
+
+
+def _installed_encoder_providers() -> list[importlib_metadata.EntryPoint]:
+    entry_points = importlib_metadata.entry_points()
+    providers = entry_points.select(group=_ENCODER_ENTRY_POINT_GROUP)
+    return sorted(providers, key=lambda provider: (provider.name, provider.value))
+
+
+class EncoderRegistry(Registry):
+    """Encoder registry with one lazy, process-global plugin discovery pass."""
+
+    def __init__(self) -> None:
+        super().__init__("encoders")
+        self._discovery_condition = Condition(RLock())
+        self._discovery_state = _DiscoveryState.PENDING
+        self._discovery_owner: int | None = None
+        self._discovery_error: BaseException | None = None
+
+    def _ensure_plugins_discovered(self) -> None:
+        current_thread = get_ident()
+        with self._discovery_condition:
+            while self._discovery_state is _DiscoveryState.RUNNING:
+                if self._discovery_owner == current_thread:
+                    return
+                self._discovery_condition.wait()
+            if self._discovery_state is _DiscoveryState.COMPLETE:
+                return
+            if self._discovery_state is _DiscoveryState.FAILED:
+                assert self._discovery_error is not None
+                raise self._discovery_error
+            self._discovery_state = _DiscoveryState.RUNNING
+            self._discovery_owner = current_thread
+
+        try:
+            for entry_point in _installed_encoder_providers():
+                entry_point.load()()
+        except BaseException as error:
+            with self._discovery_condition:
+                self._discovery_state = _DiscoveryState.FAILED
+                self._discovery_owner = None
+                self._discovery_error = error
+                self._discovery_condition.notify_all()
+            raise
+        else:
+            with self._discovery_condition:
+                self._discovery_state = _DiscoveryState.COMPLETE
+                self._discovery_owner = None
+                self._discovery_condition.notify_all()
+
+    def _before_read(self) -> None:
+        self._ensure_plugins_discovered()
+
+
+encoder_registry = EncoderRegistry()
 
 
 @dataclass(frozen=True)

--- a/slide2vec/runtime/registry.py
+++ b/slide2vec/runtime/registry.py
@@ -34,8 +34,12 @@ class Registry:
 
         return decorator
 
+    def _before_read(self) -> None:
+        """Run domain-specific setup before registry entries are observed."""
+
     def require(self, name: str) -> type:
         """Retrieve a registered class by name."""
+        self._before_read()
         if name not in self._entries:
             available = ", ".join(sorted(self._entries)) or "(none)"
             msg = f"'{name}' not found in {self._domain} registry. Available: {available}"
@@ -43,14 +47,17 @@ class Registry:
         return self._entries[name].cls
 
     def __contains__(self, name: str) -> bool:
+        self._before_read()
         return name in self._entries
 
     def names(self) -> list[str]:
         """List all registered component names."""
+        self._before_read()
         return list(self._entries.keys())
 
     def info(self, name: str) -> dict[str, Any]:
         """Get metadata for a registered component."""
+        self._before_read()
         if name not in self._entries:
             msg = f"'{name}' not found in {self._domain} registry"
             raise KeyError(msg)
@@ -59,6 +66,7 @@ class Registry:
 
     def list_with_metadata(self) -> list[dict[str, Any]]:
         """List all components with their metadata."""
+        self._before_read()
         return [self.info(name) for name in self._entries]
 
 
@@ -68,4 +76,3 @@ class _Entry:
     def __init__(self, cls: type, metadata: dict[str, Any]) -> None:
         self.cls = cls
         self.metadata = metadata
-

--- a/tests/test_encoder_plugins.py
+++ b/tests/test_encoder_plugins.py
@@ -1,0 +1,212 @@
+"""Installed encoder plugins are discovered through the public model API."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+PLUGIN_MODULE = """
+import os
+from pathlib import Path
+import time
+
+import torch
+
+from slide2vec.encoders import TileEncoder, register_encoder
+
+
+def register_presets():
+    discovered = Path(os.environ["PLUGIN_DISCOVERED_SENTINEL"])
+    with discovered.open("x") as sentinel:
+        sentinel.write("discovered")
+
+    # A provider may use public registry reads while it registers. Built-ins must
+    # already be visible, and the in-progress provider must not recursively run.
+    from slide2vec import list_models
+    assert "virchow2" in list_models()
+    assert "private-alpha" not in list_models()
+    time.sleep(0.1)
+
+    @register_encoder(
+        "private-alpha",
+        output_variants={"default": {"encode_dim": 3}},
+        default_output_variant="default",
+        input_size=224,
+        supports_variable_input_size=False,
+        supported_spacing_um=0.5,
+        precision="fp32",
+        source="/models/private-alpha.pt",
+    )
+    class PrivateAlpha(TileEncoder):
+        def __init__(self, *, output_variant=None):
+            Path(os.environ["PLUGIN_CONSTRUCTED_SENTINEL"]).write_text("constructed")
+            self._device = torch.device("cpu")
+
+        @property
+        def encode_dim(self):
+            return 3
+
+        @property
+        def device(self):
+            return self._device
+
+        def to(self, device):
+            self._device = torch.device(device)
+            return self
+
+        def get_transform(self):
+            return lambda image: image
+
+        def encode_tiles(self, batch):
+            return batch[:, :3]
+
+    @register_encoder(
+        "private-beta",
+        output_variants={"embedding": {"encode_dim": 5}},
+        default_output_variant="embedding",
+        input_size=256,
+        supports_variable_input_size=True,
+        variable_input_model_kwargs={"dynamic_img_size": True},
+        supported_spacing_um=[0.25, 0.5],
+        default_spacing_um=0.5,
+        precision="fp16",
+        source="private-org/private-beta",
+    )
+    class PrivateBeta(PrivateAlpha):
+        @property
+        def encode_dim(self):
+            return 5
+"""
+
+
+PLUGIN_PYPROJECT = """
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "slide2vec-private-encoders"
+version = "1.0.0"
+requires-python = ">=3.10"
+
+[project.entry-points."slide2vec.encoders"]
+private = "private_encoder_plugin:register_presets"
+
+[tool.setuptools]
+py-modules = ["private_encoder_plugin"]
+"""
+
+
+PLUGIN_CONSUMER_SCRIPT = """
+from concurrent.futures import ThreadPoolExecutor
+import os
+from pathlib import Path
+import socket
+from threading import Barrier
+
+import slide2vec
+from slide2vec import Model, list_models
+from slide2vec.encoders import encoder_registry
+
+discovered = Path(os.environ["PLUGIN_DISCOVERED_SENTINEL"])
+constructed = Path(os.environ["PLUGIN_CONSTRUCTED_SENTINEL"])
+assert not discovered.exists()
+assert not constructed.exists()
+
+def reject_network(*args, **kwargs):
+    raise AssertionError("encoder discovery attempted network access")
+
+socket.socket = reject_network
+
+expected_models = [
+    "conch", "conchv15", "dinov2-vitb14", "genbio-pathfm", "gigapath",
+    "gigapath-slide", "gpfm", "h-optimus-0", "h-optimus-1", "h0-mini",
+    "hibou-b", "hibou-l", "isight", "lunit", "mascaret", "midnight",
+    "moozy", "moozy-slide", "mstar", "musk", "phaet", "phikon", "phikonv2",
+    "prism", "prism2", "private-alpha", "private-beta", "prost40m", "rudolfv2",
+    "rudolfv2-b", "rudolfv2-s", "titan", "uni", "uni2", "virchow", "virchow2",
+]
+barrier = Barrier(8)
+def list_after_barrier():
+    barrier.wait()
+    return list_models()
+
+with ThreadPoolExecutor(max_workers=8) as executor:
+    listings = list(executor.map(lambda _: list_after_barrier(), range(8)))
+
+assert listings == [expected_models] * 8
+assert discovered.read_text() == "discovered"
+assert not constructed.exists()
+
+assert encoder_registry.info("private-beta") == {
+    "name": "private-beta",
+    "output_variants": {"embedding": {"encode_dim": 5}},
+    "default_output_variant": "embedding",
+    "level": "tile",
+    "input_size": 256,
+    "supports_variable_input_size": True,
+    "variable_input_model_kwargs": {"dynamic_img_size": True},
+    "patch_size": None,
+    "tile_encoder": None,
+    "tile_encoder_output_variant": None,
+    "supported_spacing_um": [0.25, 0.5],
+    "default_spacing_um": 0.5,
+    "precision": "fp16",
+    "source": "private-org/private-beta",
+}
+
+model = Model.from_preset("private-alpha", device="cpu")
+assert model.name == "private-alpha"
+assert model.level == "tile"
+assert not constructed.exists()
+assert model.feature_dim == 3
+assert str(model.device) == "cpu"
+assert constructed.read_text() == "constructed"
+
+# Repeated public access is process-global and idempotent: the provider would fail
+# on duplicate preset names if slide2vec invoked it a second time.
+assert list_models() == expected_models
+"""
+
+
+def test_installed_distribution_contributes_presets_to_public_model_api(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HF_TOKEN", "ci-token-must-not-reach-plugin-consumer")
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    (plugin / "pyproject.toml").write_text(textwrap.dedent(PLUGIN_PYPROJECT))
+    (plugin / "private_encoder_plugin.py").write_text(textwrap.dedent(PLUGIN_MODULE))
+
+    target = tmp_path / "site-packages"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--no-deps",
+            "--no-build-isolation",
+            "--target",
+            str(target),
+            str(plugin),
+        ],
+        check=True,
+    )
+
+    env = os.environ.copy()
+    env.pop("HF_TOKEN", None)
+    repository_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = os.pathsep.join((str(target), str(repository_root)))
+    env["PLUGIN_DISCOVERED_SENTINEL"] = str(tmp_path / "discovered")
+    env["PLUGIN_CONSTRUCTED_SENTINEL"] = str(tmp_path / "constructed")
+    subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(PLUGIN_CONSUMER_SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )


### PR DESCRIPTION
## Summary

- discover installed zero-argument Encoder providers from the `slide2vec.encoders` entry-point group on first registry read
- make discovery deterministic, process-global, idempotent, re-entrant, and safe for concurrent readers without constructing models
- prove the public listing, metadata, and `Model.from_preset(...)` journey with a real installed test distribution
- replace source-editing guidance with a copyable external plugin package guide

## Acceptance criteria

- [x] A separately packaged provider can contribute one or more presets through the existing public registration API.
- [x] Installing that package is sufficient for its presets to appear in public model listing and load through `Model.from_preset(...)`; no manual import or module-path option is required.
- [x] Built-in presets register before external providers and retain their existing names and behavior.
- [x] Discovery is lazy, process-global, idempotent, deterministic, and safe under repeated, re-entrant, or concurrent public registry access.
- [x] Listing and metadata lookup do not construct encoder classes, load checkpoints, download weights, or access the network.
- [x] Preset names remain the sole model/artifact identity; no checkpoint, provider, distribution-version, or recipe-revision field is introduced.
- [x] A high-level test uses real installed distribution metadata and verifies exact listing, metadata, and construction behavior without a GPU or network.
- [x] The custom-encoder documentation is replaced with a minimal copyable plugin package skeleton covering the entry point, provider, existing encoder contract, local and private-Hub loading ownership, trusted-code warning, and immutable-name rule.
- [x] The documented tile example includes every required registry field and no longer claims that adding a built-in source file alone triggers automatic import.

## Validation

- `1 passed` — installed-distribution plugin journey
- `151 passed` — focused registry, capability, and regression-core suite after review fixes
- `1006 passed, 62 deselected, 7 warnings` — post-review broad PR suite; heavy/GPU tests and exactly two known local fresh-worker shard hangs excluded
- flake8 and diff checks clean
- Sphinx content builds; `-W` is blocked only by four unavailable external intersphinx inventories under sandbox DNS
- two-axis `main...HEAD` review: Spec 0 findings; all 3 Standards findings fixed

Closes #292
