### PR TITLE
Isolate failed Encoder providers and publish diagnostics

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,17 @@ examples.
   :meth:`Model.embed_slides`
 - artifact generation with :meth:`Pipeline.run`
 
+Encoder provider diagnostics
+----------------------------
+
+.. autoclass:: slide2vec.EncoderProviderDiagnostic
+   :members:
+
+.. autofunction:: slide2vec.list_encoder_provider_diagnostics
+
+See :doc:`models` for provider packaging, transactional discovery, and trust
+guidance.
+
 EmbeddedSlide
 -------------
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -636,8 +636,46 @@ encoder class, provider, or checkpoint location from the parent process. Any wei
 credentials, environment variables, and local paths used by the plugin must therefore
 be reachable with the same meaning from every worker and node.
 
+Provider failures and diagnostics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each provider registers transactionally. If loading or calling a provider raises,
+its metadata is invalid, or any of its preset names already belongs to a built-in or
+an earlier provider, slide2vec discards every preset registered by that provider.
+Built-ins and healthy providers remain available. Provider order is deterministic,
+and an existing preset is never replaced.
+
+``list_models()`` emits a concise ``RuntimeWarning`` when it skips a provider. The
+warning includes the provider's entry-point key, exception type, and single-line
+message. Downstream tools can consume the same information without parsing warning
+text through the stable top-level API:
+
+.. code-block:: python
+
+   from slide2vec import list_encoder_provider_diagnostics, list_models
+
+   available = list_models()
+   for diagnostic in list_encoder_provider_diagnostics():
+       print(
+           diagnostic.provider_key,
+           diagnostic.provider,
+           diagnostic.exception_type,
+           diagnostic.message,
+       )
+
+The accessor returns a tuple of frozen
+:class:`~slide2vec.EncoderProviderDiagnostic` values, so callers cannot mutate the
+process-global discovery result. Looking up an unavailable preset includes these
+provider failures after the ordinary available-preset list. Successful lookup and
+model construction are unchanged.
+
 Loading ownership and trust
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Installing an Encoder provider authorizes slide2vec to import and execute that
+provider as trusted Python code during lazy discovery. There is no sandbox,
+signature system, dependency isolation, or allowlist. Review and control installed
+provider distributions with the same care as any other Python dependency.
 
 The plugin owns its checkpoint loader and credentials. The example uses a fixed local
 TorchScript path. For a private Hugging Face repository, replace that constructor line

--- a/slide2vec/__init__.py
+++ b/slide2vec/__init__.py
@@ -21,6 +21,10 @@ from slide2vec.artifacts import (
     TileEmbeddingArtifact,
 )
 from slide2vec.runtime.dense_encode import DenseEncodeGeometry, DenseEncodeKit
+from slide2vec.encoders import (
+    EncoderProviderDiagnostic,
+    list_encoder_provider_diagnostics,
+)
 
 
 __version__ = "5.7.0"
@@ -28,6 +32,8 @@ __version__ = "5.7.0"
 __all__ = [
     "Model",
     "list_models",
+    "EncoderProviderDiagnostic",
+    "list_encoder_provider_diagnostics",
     "Pipeline",
     "PreprocessingConfig",
     "DenseOptions",

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import math
 import os
+import warnings
 from dataclasses import dataclass, field, replace
 from contextlib import contextmanager
 from pathlib import Path
@@ -23,6 +24,7 @@ from slide2vec.artifacts import (
 from slide2vec.configs.resources import load_config
 from slide2vec.encoders.registry import (
     encoder_registry,
+    list_encoder_provider_diagnostics,
     resolve_preprocessing_fields,
 )
 from slide2vec.encoders.validation import validate_encoder_config
@@ -1146,16 +1148,32 @@ def list_models(level: str | None = None) -> list[str]:
         level: Optional model level filter. Supported values are ``"tile"``,
             ``"slide"``, and ``"patient"``.
     """
-    if level is None:
-        return sorted(encoder_registry.names())
+    normalized_level = None
+    if level is not None:
+        normalized_level = str(level).strip().lower()
+        if normalized_level not in {"tile", "slide", "patient"}:
+            raise ValueError(
+                "list_models(level=...) must be one of: tile, slide, patient"
+            )
 
-    normalized_level = str(level).strip().lower()
-    if normalized_level not in {"tile", "slide", "patient"}:
-        raise ValueError("list_models(level=...) must be one of: tile, slide, patient")
+    names = encoder_registry.names()
+    diagnostics = list_encoder_provider_diagnostics()
+    if diagnostics:
+        detail = "; ".join(
+            f"'{item.provider_key}': {item.concise()}" for item in diagnostics
+        )
+        warnings.warn(
+            f"Skipped Encoder provider{'' if len(diagnostics) == 1 else 's'} {detail}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    if level is None:
+        return sorted(names)
 
     return sorted(
         name
-        for name in encoder_registry.names()
+        for name in names
         if encoder_registry.info(name)["level"] == normalized_level
     )
 

--- a/slide2vec/encoders/__init__.py
+++ b/slide2vec/encoders/__init__.py
@@ -16,7 +16,9 @@ from slide2vec.encoders.base import (
 )
 from slide2vec.encoders.registry import (
     EncoderCapabilities,
+    EncoderProviderDiagnostic,
     encoder_registry,
+    list_encoder_provider_diagnostics,
     normalize_patch_size,
     register_encoder,
     resolve_encoder_capabilities,
@@ -32,6 +34,7 @@ from slide2vec.encoders import models  # noqa: F401
 __all__ = [
     "Encoder",
     "EncoderCapabilities",
+    "EncoderProviderDiagnostic",
     "PatientEncoder",
     "TileEncoder",
     "SlideEncoder",
@@ -40,6 +43,7 @@ __all__ = [
     "resolve_recommended_dynamic_img_size",
     "resolve_requested_output_variant",
     "encoder_registry",
+    "list_encoder_provider_diagnostics",
     "normalize_patch_size",
     "register_encoder",
     "resolve_encoder_capabilities",

--- a/slide2vec/encoders/registry.py
+++ b/slide2vec/encoders/registry.py
@@ -21,6 +21,20 @@ class _DiscoveryState(Enum):
     FAILED = auto()
 
 
+@dataclass(frozen=True)
+class EncoderProviderDiagnostic:
+    """Public, immutable description of one skipped installed provider."""
+
+    provider_key: str
+    provider: str
+    exception_type: str
+    message: str
+
+    def concise(self) -> str:
+        """Format the diagnostic without traceback details."""
+        return f"{self.exception_type}: {self.message}"
+
+
 def _installed_encoder_providers() -> list[importlib_metadata.EntryPoint]:
     entry_points = importlib_metadata.entry_points()
     providers = entry_points.select(group=_ENCODER_ENTRY_POINT_GROUP)
@@ -36,6 +50,7 @@ class EncoderRegistry(Registry):
         self._discovery_state = _DiscoveryState.PENDING
         self._discovery_owner: int | None = None
         self._discovery_error: BaseException | None = None
+        self._provider_diagnostics: tuple[EncoderProviderDiagnostic, ...] = ()
 
     def _ensure_plugins_discovered(self) -> None:
         current_thread = get_ident()
@@ -52,9 +67,23 @@ class EncoderRegistry(Registry):
             self._discovery_state = _DiscoveryState.RUNNING
             self._discovery_owner = current_thread
 
+        diagnostics: list[EncoderProviderDiagnostic] = []
         try:
             for entry_point in _installed_encoder_providers():
-                entry_point.load()()
+                entries_before_provider = dict(self._entries)
+                try:
+                    entry_point.load()()
+                except BaseException as error:
+                    self._entries = entries_before_provider
+                    message = " ".join(str(error).split()) or "No error message"
+                    diagnostics.append(
+                        EncoderProviderDiagnostic(
+                            provider_key=entry_point.name,
+                            provider=entry_point.value,
+                            exception_type=type(error).__name__,
+                            message=message,
+                        )
+                    )
         except BaseException as error:
             with self._discovery_condition:
                 self._discovery_state = _DiscoveryState.FAILED
@@ -64,6 +93,7 @@ class EncoderRegistry(Registry):
             raise
         else:
             with self._discovery_condition:
+                self._provider_diagnostics = tuple(diagnostics)
                 self._discovery_state = _DiscoveryState.COMPLETE
                 self._discovery_owner = None
                 self._discovery_condition.notify_all()
@@ -71,8 +101,44 @@ class EncoderRegistry(Registry):
     def _before_read(self) -> None:
         self._ensure_plugins_discovered()
 
+    def provider_diagnostics(self) -> tuple[EncoderProviderDiagnostic, ...]:
+        """Return an immutable snapshot of skipped provider diagnostics."""
+        self._ensure_plugins_discovered()
+        return self._provider_diagnostics
+
+    def _missing_preset_error(self, name: str) -> KeyError:
+        available = ", ".join(sorted(self._entries)) or "(none)"
+        message = f"'{name}' not found in encoders registry. Available: {available}"
+        if self._provider_diagnostics:
+            failures = "; ".join(
+                f"'{item.provider_key}' ({item.concise()})"
+                for item in self._provider_diagnostics
+            )
+            message += f". Skipped Encoder providers: {failures}"
+        return KeyError(message)
+
+    def require(self, name: str) -> type:
+        """Retrieve an Encoder class, including provider context when it is missing."""
+        self._ensure_plugins_discovered()
+        if name not in self._entries:
+            raise self._missing_preset_error(name)
+        return self._entries[name].cls
+
+    def info(self, name: str) -> dict[str, Any]:
+        """Return Encoder metadata, including provider context when it is missing."""
+        self._ensure_plugins_discovered()
+        if name not in self._entries:
+            raise self._missing_preset_error(name)
+        entry = self._entries[name]
+        return {"name": name, **entry.metadata}
+
 
 encoder_registry = EncoderRegistry()
+
+
+def list_encoder_provider_diagnostics() -> tuple[EncoderProviderDiagnostic, ...]:
+    """List deterministic diagnostics for installed providers skipped at discovery."""
+    return encoder_registry.provider_diagnostics()
 
 
 @dataclass(frozen=True)

--- a/tests/test_encoder_provider_failures.py
+++ b/tests/test_encoder_provider_failures.py
@@ -175,6 +175,45 @@ def test_late_builtin_collision_rejects_the_whole_provider() -> None:
     )
 
 
+def test_later_provider_collision_preserves_the_earlier_plugin_owner() -> None:
+    _run_isolated(
+        _plugin_scenario("""
+        state = {}
+
+        def earlier_provider():
+            state["earlier_owner"] = register_test_encoder("shared-plugin-preset")
+
+        def colliding_provider():
+            register_test_encoder("discarded-before-plugin-collision")
+            register_test_encoder("shared-plugin-preset")
+
+        install_providers(
+            EntryPoint("a-earlier", "earlier_plugin:register", earlier_provider),
+            EntryPoint("z-collision", "collision_plugin:register", colliding_provider),
+        )
+
+        from slide2vec import list_encoder_provider_diagnostics, list_models
+        from slide2vec.encoders import encoder_registry
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            models = list_models()
+
+        assert "shared-plugin-preset" in models
+        assert "discarded-before-plugin-collision" not in models
+        assert encoder_registry.require("shared-plugin-preset") is state["earlier_owner"]
+        diagnostics = list_encoder_provider_diagnostics()
+        assert [(item.provider_key, item.exception_type, item.message) for item in diagnostics] == [
+            (
+                "z-collision",
+                "ValueError",
+                "'shared-plugin-preset' is already registered in the encoders registry",
+            )
+        ]
+        """)
+    )
+
+
 def test_invalid_metadata_rolls_back_an_earlier_valid_preset() -> None:
     _run_isolated(
         _plugin_scenario("""

--- a/tests/test_encoder_provider_failures.py
+++ b/tests/test_encoder_provider_failures.py
@@ -1,0 +1,352 @@
+"""Failed installed Encoder providers remain isolated at the public API seam."""
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_isolated(script: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+_PLUGIN_SCENARIO_PREAMBLE = """
+import importlib.metadata
+import warnings
+import torch
+
+class EntryPoint:
+    def __init__(self, name, value, provider):
+        self.name = name
+        self.value = value
+        self._provider = provider
+
+    def load(self):
+        return self._provider
+
+class EntryPoints(list):
+    def select(self, *, group):
+        assert group == "slide2vec.encoders"
+        return self
+
+def install_providers(*providers):
+    original_entry_points = importlib.metadata.entry_points
+    def entry_points(**kwargs):
+        if kwargs:
+            return original_entry_points(**kwargs)
+        return EntryPoints(providers)
+    importlib.metadata.entry_points = entry_points
+
+def test_encoder_class(encode_dim=3):
+    from slide2vec.encoders import TileEncoder
+
+    class TestEncoder(TileEncoder):
+        def __init__(self, *, output_variant=None):
+            self._device = torch.device("cpu")
+
+        @property
+        def encode_dim(self):
+            return encode_dim
+
+        @property
+        def device(self):
+            return self._device
+
+        def to(self, device):
+            self._device = torch.device(device)
+            return self
+
+        def get_transform(self):
+            return lambda image: image
+
+        def encode_tiles(self, batch):
+            return batch[:, :encode_dim]
+
+    return TestEncoder
+
+def register_test_encoder(name, encode_dim=3):
+    from slide2vec.encoders import register_encoder
+
+    encoder_cls = test_encoder_class(encode_dim)
+    register_encoder(
+        name,
+        output_variants={"default": {"encode_dim": encode_dim}},
+        default_output_variant="default",
+        input_size=224,
+        supports_variable_input_size=False,
+        supported_spacing_um=0.5,
+        precision="fp32",
+    )(encoder_cls)
+    return encoder_cls
+"""
+
+
+def _plugin_scenario(body: str) -> str:
+    return _PLUGIN_SCENARIO_PREAMBLE + textwrap.dedent(body)
+
+
+def test_provider_exception_rolls_back_every_preset() -> None:
+    _run_isolated(
+        _plugin_scenario("""
+        state = {}
+
+        def register_encoders():
+            from slide2vec import list_models
+            state["before"] = list_models()
+            register_test_encoder("rolled-back-preset")
+            raise RuntimeError("provider setup failed")
+
+        install_providers(
+            EntryPoint(
+                "raising-provider",
+                "raising_plugin:register_encoders",
+                register_encoders,
+            )
+        )
+
+        from slide2vec import list_encoder_provider_diagnostics, list_models
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            models = list_models()
+
+        assert models == state["before"]
+        assert "rolled-back-preset" not in models
+        assert [str(item.message) for item in caught] == [
+            "Skipped Encoder provider 'raising-provider': RuntimeError: provider setup failed"
+        ]
+
+        diagnostics = list_encoder_provider_diagnostics()
+        assert len(diagnostics) == 1
+        diagnostic = diagnostics[0]
+        assert diagnostic.provider_key == "raising-provider"
+        assert diagnostic.provider == "raising_plugin:register_encoders"
+        assert diagnostic.exception_type == "RuntimeError"
+        assert diagnostic.message == "provider setup failed"
+        """)
+    )
+
+
+def test_late_builtin_collision_rejects_the_whole_provider() -> None:
+    _run_isolated(
+        _plugin_scenario("""
+        state = {}
+
+        def register_encoders():
+            from slide2vec.encoders import encoder_registry, register_encoder
+            state["builtin_owner"] = encoder_registry.require("virchow2")
+            plugin_encoder = register_test_encoder("discarded-before-collision")
+
+            register_encoder(
+                "virchow2",
+                output_variants={"default": {"encode_dim": 3}},
+                default_output_variant="default",
+                input_size=224,
+                supports_variable_input_size=False,
+                supported_spacing_um=0.5,
+            )(plugin_encoder)
+
+        install_providers(
+            EntryPoint("collision", "collision_plugin:register_encoders", register_encoders)
+        )
+
+        from slide2vec import list_encoder_provider_diagnostics, list_models
+        from slide2vec.encoders import encoder_registry
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            models = list_models()
+
+        assert "discarded-before-collision" not in models
+        assert encoder_registry.require("virchow2") is state["builtin_owner"]
+        diagnostics = list_encoder_provider_diagnostics()
+        assert [(item.provider_key, item.exception_type, item.message) for item in diagnostics] == [
+            (
+                "collision",
+                "ValueError",
+                "'virchow2' is already registered in the encoders registry",
+            )
+        ]
+        """)
+    )
+
+
+def test_invalid_metadata_rolls_back_an_earlier_valid_preset() -> None:
+    _run_isolated(
+        _plugin_scenario("""
+        state = {}
+
+        def register_encoders():
+            from slide2vec import list_models
+            from slide2vec.encoders import register_encoder
+            state["before"] = list_models()
+            register_test_encoder("discarded-before-invalid-metadata")
+
+            register_encoder(
+                "invalid-metadata",
+                output_variants={"embedding": {"encode_dim": 3}},
+                default_output_variant="missing",
+                input_size=224,
+                supports_variable_input_size=False,
+                supported_spacing_um=0.5,
+            )
+
+        install_providers(
+            EntryPoint("invalid", "invalid_plugin:register_encoders", register_encoders)
+        )
+
+        from slide2vec import list_encoder_provider_diagnostics, list_models
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            models = list_models()
+
+        assert models == state["before"]
+        assert "discarded-before-invalid-metadata" not in models
+        diagnostics = list_encoder_provider_diagnostics()
+        assert diagnostics[0].provider_key == "invalid"
+        assert diagnostics[0].exception_type == "ValueError"
+        assert diagnostics[0].message == (
+            "default_output_variant 'missing' must be present in output_variants"
+        )
+        """)
+    )
+
+
+def test_healthy_and_broken_providers_coexist_through_public_lookup() -> None:
+    _run_isolated(
+        _plugin_scenario("""
+        calls = []
+
+        def broken_provider():
+            calls.append("a-broken")
+            register_test_encoder("broken-partial")
+            raise ModuleNotFoundError("missing_private_dependency")
+
+        def healthy_provider():
+            calls.append("z-healthy")
+            register_test_encoder("healthy-preset")
+
+        install_providers(
+            EntryPoint("z-healthy", "healthy_plugin:register_encoders", healthy_provider),
+            EntryPoint("a-broken", "broken_plugin:register_encoders", broken_provider),
+        )
+
+        from dataclasses import FrozenInstanceError
+        from slide2vec import Model, list_encoder_provider_diagnostics, list_models
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            models = list_models()
+
+        assert calls == ["a-broken", "z-healthy"]
+        assert "virchow2" in models
+        assert "healthy-preset" in models
+        assert "broken-partial" not in models
+        assert [str(item.message) for item in caught] == [
+            "Skipped Encoder provider 'a-broken': "
+            "ModuleNotFoundError: missing_private_dependency"
+        ]
+
+        assert Model.from_preset("virchow2", device="cpu").name == "virchow2"
+        healthy = Model.from_preset("healthy-preset", device="cpu")
+        assert healthy.feature_dim == 3
+
+        try:
+            Model.from_preset("expected-from-broken-provider", device="cpu")
+        except KeyError as error:
+            missing_message = str(error)
+        else:
+            raise AssertionError("missing plugin preset unexpectedly resolved")
+        assert "Available:" in missing_message
+        assert "'a-broken' (ModuleNotFoundError: missing_private_dependency)" in missing_message
+
+        diagnostics = list_encoder_provider_diagnostics()
+        assert diagnostics == list_encoder_provider_diagnostics()
+        assert isinstance(diagnostics, tuple)
+        try:
+            diagnostics[0].message = "changed"
+        except FrozenInstanceError:
+            pass
+        else:
+            raise AssertionError("provider diagnostic was mutable")
+        """)
+    )
+
+
+def test_provider_diagnostics_are_sorted_by_provider_key_and_value() -> None:
+    _run_isolated(
+        _plugin_scenario("""
+        calls = []
+
+        def provider(label, message):
+            def fail():
+                calls.append(label)
+                raise RuntimeError(message)
+            return fail
+
+        install_providers(
+            EntryPoint("zeta", "plugins:zeta", provider("zeta", "z failed")),
+            EntryPoint("alpha", "plugins:second", provider("alpha-second", "second failed")),
+            EntryPoint("alpha", "plugins:first", provider("alpha-first", "first failed")),
+        )
+
+        from slide2vec import list_encoder_provider_diagnostics, list_models
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            list_models()
+
+        assert calls == ["alpha-first", "alpha-second", "zeta"]
+        diagnostics = list_encoder_provider_diagnostics()
+        assert [(item.provider_key, item.provider) for item in diagnostics] == [
+            ("alpha", "plugins:first"),
+            ("alpha", "plugins:second"),
+            ("zeta", "plugins:zeta"),
+        ]
+        assert [item.message for item in diagnostics] == [
+            "first failed",
+            "second failed",
+            "z failed",
+        ]
+        assert [str(item.message) for item in caught] == [
+            "Skipped Encoder providers 'alpha': RuntimeError: first failed; "
+            "'alpha': RuntimeError: second failed; 'zeta': RuntimeError: z failed"
+        ]
+        """)
+    )
+
+
+def test_entry_point_load_failure_is_isolated_from_later_provider() -> None:
+    _run_isolated(
+        _plugin_scenario("""
+        class UnloadableEntryPoint(EntryPoint):
+            def load(self):
+                register_test_encoder("import-side-effect")
+                raise ModuleNotFoundError("optional_plugin_runtime")
+
+        def later_provider():
+            register_test_encoder("later-healthy", encode_dim=2)
+
+        install_providers(
+            UnloadableEntryPoint("unloadable", "unloadable_plugin:register", None),
+            EntryPoint("working", "working_plugin:register", later_provider),
+        )
+
+        from slide2vec import list_encoder_provider_diagnostics, list_models
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            models = list_models()
+
+        assert "import-side-effect" not in models
+        assert "later-healthy" in models
+        assert [item.provider_key for item in list_encoder_provider_diagnostics()] == [
+            "unloadable"
+        ]
+        """)
+    )


### PR DESCRIPTION
## Summary

- discover each installed Encoder provider transactionally and roll back all of its registrations on load, invocation, validation, or collision failure
- preserve built-ins and earlier healthy providers while recording deterministic immutable diagnostics
- surface skipped provider keys and concise failures from `list_models()`, missing-preset lookups, and a stable top-level diagnostics API
- document provider execution as trusted Python code and cover exception, metadata, built-in/earlier-plugin collision, coexistence, ordering, lookup, and load-failure paths

## Acceptance criteria

- [x] A provider that registers one preset and then raises leaves the registry exactly as it was before that provider started.
- [x] A provider whose later preset collides with a built-in or earlier plugin is rejected in full; the existing owner is never replaced.
- [x] Provider discovery order and diagnostics are deterministic.
- [x] A broken provider does not prevent built-ins or presets from healthy providers from being listed, resolved, or loaded.
- [x] Public model listing visibly reports skipped provider keys and concise diagnostics.
- [x] Public lookup of a missing preset includes discovery-failure context without changing successful lookup behavior.
- [x] A stable public read-only diagnostics interface is available to downstream consumers without importing slide2vec internals.
- [x] Loading and invoking providers is documented as trusted Python code; no sandbox, signature system, dependency isolation, or allowlist is implied.
- [x] Tests cover provider exceptions, invalid metadata, collision after partial registration, healthy/broken coexistence, and exact post-failure registry state without depending on traceback formatting.

## Verification

- `python -m pytest tests/test_encoder_provider_failures.py tests/test_encoder_plugins.py -q --no-cov`: **8 passed**
- `python -m pytest -m 'not heavy and not gpu_integration' --no-cov -q`: **940 passed, 75 failed, 60 deselected**. The same 75 unrelated failures reproduce on untouched `origin/main` (**933 passed, 75 failed, 60 deselected**) under local `hs2p 4.2.0`; the project declares `hs2p>=4.4.1` and CI supplies its pinned container.
- `python -m mypy slide2vec`: **308 errors in 60 files**, exactly reproduced on untouched `origin/main`.
- `python -m sphinx -W -b html docs .tasks/docs-build`: locally gated because the docs dependency `myst_parser` is not installed.
- `git diff --check origin/main...HEAD`: passed.

## Review

The Standards review found no hard violations and only two minor duplication heuristics retained for explicit test readability and minimal production impact. The Spec review found missing explicit coverage for collision with an earlier plugin; that regression test was added and passes. No findings remain unfixed.

Closes #294
