### PR TITLE
Trim docs to usage essentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ embedded = model.embed_slide("/path/to/slide.svs", preprocessing=preprocessing)
 
 Hierarchical outputs have shape `(num_regions, tiles_per_region, feature_dim)` and are written to `hierarchical_embeddings/` when persisted.
 
-See [`docs/python-api.md`](docs/python-api.md) for details.
+See the [hierarchical features guide](https://clemsgrs.github.io/slide2vec/hierarchical.html) for details.
 
 ### Input Manifest
 
@@ -125,7 +125,7 @@ The package writes explicit artifact directories:
 
 `slide2vec` currently ships presets for 28 tile-level models, 4 slide-level models,
 and 1 patient-level model.
-For the full catalog and preset names, see [`docs/models.md`](docs/models.md).
+For the full catalog and preset names, see the [model zoo](https://clemsgrs.github.io/slide2vec/models.html).
 
 ## CLI
 
@@ -138,7 +138,7 @@ slide2vec /path/to/config.yaml
 
 By default, manifest-driven CLI runs use all available GPUs. Set `speed.num_gpus=4` when you want to cap the sharding explicitly.
 
-New to the CLI or doing batch runs to disk? Start with [`docs/cli.md`](docs/cli.md) for the config-driven workflow, overrides, and common run patterns.
+New to the CLI or doing batch runs to disk? Start with the [CLI guide](https://clemsgrs.github.io/slide2vec/cli.html) for the config-driven workflow and common run patterns.
 
 ## Docker
 
@@ -156,8 +156,8 @@ docker run --rm -it \
 
 ## Documentation
 
-- [Documentation website](https://clemsgrs.github.io/slide2vec/) for the polished docs site
-- [`docs/python-api.md`](docs/python-api.md) for the detailed API reference
-- [`docs/cli.md`](docs/cli.md) for the config-driven CLI guide
-- [`docs/models.md`](docs/models.md) for the full supported-model catalog
+- [Documentation website](https://clemsgrs.github.io/slide2vec/)
+- [API guide](https://clemsgrs.github.io/slide2vec/api.html)
+- [CLI guide](https://clemsgrs.github.io/slide2vec/cli.html)
+- [Model zoo](https://clemsgrs.github.io/slide2vec/models.html)
 - [`tutorials/api_walkthrough.ipynb`](tutorials/api_walkthrough.ipynb) for a notebook walkthrough of the API

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -101,10 +101,10 @@ ordered by first appearance.
 Images to Embeddings
 --------------------
 
-When the images already exist as files — a public patch benchmark (BACH, CRC,
-Gleason, BreakHis, MHIST, PCam), an exported ROI set — there is no slide to tile
-and no geometry to request. :meth:`Model.embed_images` takes those images
-directly and writes one embedding artifact per image:
+When your images already exist as files — a patch benchmark (BACH, CRC,
+PCam, …) or an exported ROI set — there is no slide to tile.
+:meth:`Model.embed_images` encodes those images directly and writes one
+embedding artifact per image:
 
 .. code-block:: python
 
@@ -122,24 +122,11 @@ directly and writes one embedding artifact per image:
    print(artifacts[0].path)         # outputs/bach/image_embeddings/bach-001.pt
    print(artifacts[0].feature_dim)  # 2560
 
-The run splits its images across all visible GPUs (``num_gpus=1`` encodes
-in-process) and is resume-aware: an image whose ``.meta.json`` sidecar already
-exists is skipped, so an interrupted run is restarted by re-issuing the same
-call. ``sample_id`` is the artifact's whole identity and must be unique within a
-run — slide2vec never derives it from the filename, because two directories can
-hold the same one.
-
-**Given geometry.** This is the one path where the caller supplies pixels it
-never requested, so the encoder's *shipped* transform is the contract (Resize,
-CenterCrop, Normalize — exactly what the model card prescribes), and slide2vec
-records the resulting encoder input size in each sidecar as provenance instead of
-validating it against a request. That also fixes how preprocessing runs: given
-images are heterogeneously sized (2048x1536 beside 96x96) and cannot be stacked
-into one uint8 batch before being resized, so the transform is applied **itemwise
-before stacking**. Auto worker selection stays in-process because the model
-runtime is already initialized; an explicit positive ``num_workers_per_gpu`` uses
-spawned dataloader workers. The batched transform spec used by the pooled path
-stays exclusive to it.
+The run splits images across all visible GPUs and resumes automatically:
+re-issue the same call to restart an interrupted run. ``sample_id`` is the
+artifact's identity and must be unique within a run; slide2vec never derives
+it from the filename. Mixed-size inputs are fine — each image goes through the
+encoder's shipped transform before batching.
 
 .. autoclass:: slide2vec.ImageSpec
    :members:
@@ -169,12 +156,10 @@ See :doc:`hierarchical` for the full explanation.
 Live Dense Encoding after Augmentation
 --------------------------------------
 
-Use :meth:`Model.prepare_dense_encoder` when a training or inference loop
-already owns image/mask reading and joint augmentation. The handoff is one CPU
-RGB ``uint8`` tensor in ``(3, H, W)`` layout. slide2vec then owns the shipped
-normalization, geometry check, bottom/right padding, device transfer, frozen
-evaluation-mode encoder, autocast, whole/sliding encode, attention selection,
-and output dtype.
+Use :meth:`Model.prepare_dense_encoder` when your training or inference loop
+already owns image/mask reading and joint augmentation. You hand slide2vec one
+CPU RGB ``uint8`` tensor in ``(3, H, W)`` layout; slide2vec owns normalization,
+padding, device transfer, and the frozen no-grad encode.
 
 .. code-block:: python
 
@@ -201,19 +186,16 @@ and output dtype.
    print(cpu_batch.shape)            # (B, 3, Henc, Wenc), on CPU
    print(grids.shape)                # (B, D, Gh, Gw), on the model device
 
-``preprocessor()`` accepts exactly one unbatched CPU ``uint8`` RGB tensor. It
-does not resize or crop: the post-augmentation ``(H, W)`` must equal
-``kit.geometry.target_size``. It applies the encoder's normalization-only
-recipe and bottom/right padding, returning one CPU floating-point tensor with
-shape ``(3, Henc, Wenc)`` for normal DataLoader collation.
+``preprocessor()`` accepts one unbatched CPU ``uint8`` RGB tensor whose
+``(H, W)`` equals ``kit.geometry.target_size`` — it never resizes or crops. It
+applies the encoder's normalization and bottom/right padding and returns a CPU
+floating-point tensor ready for normal DataLoader collation.
 
-``encode(batch)`` accepts the resulting collated CPU tensor, transfers it to
-the model device, and returns an on-device grid with no gradient history.
-``D`` is the patch-feature dimension for ``feature_kind="patch_features"``;
-for ``"cls_attention"`` it is the selected block/head/prefix-query channel
-count, including register-token queries when requested. The result uses
-``ExecutionOptions.output_dtype``, or the same precision-derived default as
-persisted dense extraction.
+``encode(batch)`` moves the collated batch to the model device and returns an
+on-device grid with no gradient history, in ``ExecutionOptions.output_dtype``
+(or the same precision-derived default as persisted dense extraction). ``D`` is
+the patch-feature dimension for ``feature_kind="patch_features"``; for
+``"cls_attention"`` it is the selected block/head/prefix-query channel count.
 
 The immutable ``kit.geometry`` is authoritative:
 
@@ -222,17 +204,14 @@ The immutable ``kit.geometry`` is authoritative:
 - ``encoded_size`` — padded encoder input ``(Henc, Wenc)``;
 - ``grid_shape`` — output ``(Gh, Gw)``;
 - ``pad`` — ``(bottom, right)`` padding;
-- ``crop_box`` — top-left ``(left, top, right, bottom)`` box for mapping the
-  padded extent back to the target.
+- ``crop_box`` — ``(left, top, right, bottom)`` box for mapping the padded
+  extent back to the target.
 
-Both :class:`DenseImageOptions` and :class:`DenseOptions` are accepted. Only
-their shared encoding fields apply: ``target_size``, padding, window/overlap,
-feature kind, and attention selection. Source-reading fields such as spacing,
-backend, and tolerance are outside this augmented-pixel interface and are
-ignored. This path never reads a source or creates caches, sidecars, artifacts,
-or output directories; corresponding persistence/execution fields have no
-effect. Reuse one prepared kit across loops or folds with the same resolved
-geometry and encoding recipe.
+The kit uses only the encoding fields of :class:`DenseImageOptions` /
+:class:`DenseOptions` (``target_size``, padding, window/overlap, feature kind,
+attention selection); source-reading fields are ignored, and this path never
+reads files or writes artifacts. Reuse one prepared kit across loops or folds
+with the same geometry.
 
 .. autoclass:: slide2vec.DenseEncodeKit
    :members:
@@ -245,8 +224,8 @@ geometry and encoding recipe.
 Persisted Region Grids
 ----------------------
 
-The public region entry point accepts level-0 point coordinates and the same
-optional source-spacing declaration as dense images:
+:meth:`Model.embed_regions_dense` accepts level-0 point coordinates and the
+same optional source-spacing declaration as dense images:
 
 .. code-block:: python
 
@@ -263,44 +242,19 @@ optional source-spacing declaration as dense images:
        execution=ExecutionOptions(output_dir="outputs"),
    )
 
-The coordinates remain in the source level-0 pixel frame. hs2p resolves the
-source declaration, backend, level, native read spacing, and effective encoded
-spacing once per source; every fact is persisted and checked by resume.
-
-Variable encoder input for dense runs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A dense run states a *supervision* geometry — the ``target_size`` the token grid
-registers to, plus an optional ``window_size`` — not an encoder input.
-``Model.embed_regions_dense`` and ``Model.embed_images_dense`` derive the
-**effective encoder input** from it, i.e. the geometry of the tensor handed to
-``encode_tiles_dense``:
-
-- whole-tile (``window_size=None``): the ROI or image padded up to the patch
-  multiple;
-- sliding: the ``window_size`` rounded to the patch multiple and clamped to that
-  padded extent.
-
-That size then goes through the same check as a pooled
-``requested_tile_size_px``: when it differs from the encoder's registered input
-size (in either dimension — a non-square image geometry is checked per axis, not
-rejected for not being square), the encoder must declare ``supports_variable_input_size=True``, and its
-``variable_input_model_kwargs`` (e.g. ``dynamic_img_size=True``) are applied at
-construction. Whole-tile dense at a non-native size on a fixed-input encoder
-(e.g. ``phikon``) therefore fails before any region is read, instead of feeding
-the backbone a size it cannot accept; sliding at the native window passes the
-check trivially. Callers never pass ``dynamic_img_size`` — it is derived from the
-declared geometry plus the registry metadata.
+Coordinates stay in the source level-0 pixel frame. Encoder inputs that differ
+from the encoder's registered size require an encoder that supports variable
+input; slide2vec derives the necessary model settings from the declared
+geometry, and fixed-input encoders fail before any region is read.
 
 Dense Grids from Images
 -----------------------
 
-When the supervision arrives as image/mask pairs rather than as slides —
+When the supervision arrives as image/mask pairs rather than slides —
 segmentation and detection datasets, exported ROI sets —
 :meth:`Model.embed_images_dense` is the image-sourced counterpart of
 ``embed_regions_dense``: the image *is* the region, so there is no ROI
-coordinate plan. Raster inputs need no spacing→level plan; spacing-readable
-inputs use the parent-resolved hs2p plan described below.
+coordinate plan.
 
 .. code-block:: python
 
@@ -326,55 +280,14 @@ inputs use the parent-resolved hs2p plan described below.
    print(artifacts[0].grid_shape)  # (74, 74) for a 1024px image on a 14px patch encoder
 
 Everything after the pixels arrive is shared with the ROI path: the same
-geometry resolution, the same bottom/right padding up to the patch multiple, the
-same whole-image-vs-sliding encode and raised-cosine blending, and the same
-``feature_kind`` choice between the patch-token grid and the CLS-attention grid.
-The run splits its images across all visible GPUs (``num_gpus=1`` encodes
-in-process) and is recipe-aware on resume. It skips an image only when both the
-payload and sidecar exist and the sidecar's image identity, encoder/output,
-geometry, dense settings, inference precision, and stored dtype exactly match
-the current call. Missing, legacy, or incompatible pairs are recomputed, so an
-interrupted run is restarted by re-issuing the call.
+geometry resolution, padding, whole-image-vs-sliding encode, and
+``feature_kind`` choice. The run splits images across all visible GPUs and
+resumes automatically: re-issue the same call to restart an interrupted run.
 
-**Source spacing and physical scale.** Every dense source uses a public hs2p
-reader. PNG/JPEG inputs use hs2p 4.4.1's one-level PIL reader; because those
-files have no reliable embedded physical spacing, their
-``ImageSpec.spacing_at_level_0`` declaration is required. Exact-spacing reads
-preserve the same RGB bytes as an unchanged Pillow read. Coarser requests use
-hs2p area downsampling; finer image requests raise under hs2p's content-aware
-no-upsampling policy. Flat and pyramidal sources may share a run.
-
-Numeric ``spacing_um`` is the :term:`declared spacing`; ``None`` resolves the
-encoder's single registry default. Encoders with ambiguous or missing defaults,
-including unregistered/custom encoders, require an explicit value. The parent asks hs2p
-to resolve each source's level-0 spacing, concrete backend, native read level
-and spacing, and tolerance result before resume filtering. Ranks consume that
-immutable plan: hs2p reads the complete selected level and area-downsamples only
-when needed. A native level within tolerance is accepted without resize, so its
-native spacing is the :term:`effective spacing`; an area-downsampled image has
-the declared spacing as its effective spacing. Reads never upsample and an
-explicit backend never silently falls back.
-
-``ImageSpec.spacing_at_level_0`` is an optional finite positive caller
-declaration passed to hs2p. Without it, hs2p metadata is authoritative and
-missing spacing is an error. The declaration, resolved ``source_spacing_um``,
-requested ``declared_spacing_um``, and encoded-grid ``effective_spacing_um``
-remain separate values in every dense sidecar. :meth:`Model.embed_images`
-(the pooled API) retains its existing raster policy.
-
-**target_size is a declaration, not a resize.** The :term:`target size` is
-checked after the selected
-reader finishes, including any hs2p spacing downsample. Every final image must
-be exactly ``target_size`` (a non-square ``(height, width)`` pair is accepted);
-a mismatch raises with the sample, observed and declared dimensions, and the
-resolved or unknown spacing. It never triggers fit-to-size resizing. Declaring
-the geometry up front is what lets the *effective* encoder input — the padded
-image, or one patch-aligned window of it — be validated, and the encoder's
-variable-input constructor settings resolved, before a single image is decoded (see
-`Variable encoder input for dense runs`_). A dataset whose images differ in size
-is therefore several runs, one per geometry — which is also the only way their
-grids could be batched downstream. See :term:`compatible artifact` for the
-resume boundary.
+PNG/JPEG inputs require ``ImageSpec.spacing_at_level_0``, because they carry
+no embedded physical spacing. ``target_size`` is a declaration, not a resize:
+every image must arrive at exactly ``target_size`` after reading, so a dataset
+whose images differ in size is several runs, one per geometry.
 
 .. autoclass:: slide2vec.DenseImageOptions
    :members:
@@ -387,26 +300,21 @@ resume boundary.
 Dense Attention Map Extraction
 ------------------------------
 
-Most ViT tile encoders can also return their frozen per-head **prefix-token
-self-attention** as a dense spatial grid. A frozen ViT's CLS-token attention
-doubles as a per-pixel feature (Ramchandani et al.,
-`arXiv:2602.18747 <https://arxiv.org/abs/2602.18747>`_); this is the attention
-analog of ``encode_tiles_dense`` and reuses the same ``get_dense_transform()``
-(normalization only, geometry preserved).
+Most ViT tile encoders can also return their per-head **prefix-token
+self-attention** as a dense spatial grid. This is the attention analog of
+``encode_tiles_dense`` and reuses the same ``get_dense_transform()``.
 
 - ``encode_tiles_attention(batch, *, blocks=(-1,), include_registers=False)``
   accepts a normalized ``(B, C, H, W)`` tensor and returns ``(B, K, h, w)``.
-- ``K = len(blocks) * (1 + M·include_registers) * nh``, where ``nh`` is the head
-  count and ``M`` the model's register-token count (``0`` for models without
-  registers). Each channel is one prefix-token query row's attention over the
-  patch grid for one head — heads are **never** reduced.
-- Channels are stacked in the deterministic order ``[block][cls, reg…][head]``
-  (block outer, in the order requested; then CLS, then any register tokens; head
-  innermost). The CLS block (the first ``nh`` channels of each block) does not
-  depend on ``include_registers`` — registers only *append* channels.
+- ``K = len(blocks) * (1 + M·include_registers) * nh``, where ``nh`` is the
+  head count and ``M`` the model's register-token count. Heads are never
+  reduced.
+- Channels are stacked in the deterministic order ``[block][cls, reg…][head]``.
+  The CLS channels do not depend on ``include_registers`` — registers only
+  append channels.
 - ``blocks`` selects transformer blocks (negative indices count from the end);
-  ``include_registers`` adds the register-token query rows (Darcet et al.) as
-  extra channels for models that carry them (e.g. Hibou).
+  ``include_registers`` adds the register-token query rows for models that
+  carry them (e.g. Hibou).
 
 Example:
 
@@ -428,20 +336,10 @@ Example:
 
    print(attn.shape)  # (1, nh, 28, 28) for a 224 px Lunit tile
 
-Each value is a softmax weight: a slice of one query row over the patch keys, so
-values are non-negative and a channel's spatial sum is ``<= 1`` (the prefix-token
-key columns carry the remaining mass). As with dense extraction, the input must
-be divisible by the encoder patch size, and unsupported encoders raise
-``NotImplementedError``.
-
-Implementation note: timm ViTs run a fused SDPA kernel that never materializes
-the attention matrix, so it is recomputed from each block's own projection
-(bit-equivalent to the weights the fused kernel applies). HuggingFace encoders
-read the weights via ``output_attentions=True``, but modern ``transformers``
-default to an SDPA implementation that silently ignores that flag (it warns and
-returns no attentions); extraction therefore temporarily switches the model to
-the ``eager`` attention implementation for the forward pass and restores the
-previous setting afterwards.
+Each value is a softmax weight: one query row's attention over the patch keys,
+so values are non-negative and a channel's spatial sum is ``<= 1`` (the
+prefix-token key columns carry the remaining mass). The input must be divisible
+by the encoder patch size.
 
 Pipeline
 ---------

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -22,299 +22,118 @@ Tile-level encoders
      - Model
      - Output dim
      - Spacing (um)
-     - Notes
    * - ``lunit``
      - `Lunit ViT-S/8 <https://huggingface.co/1aurent/vit_small_patch8_224.lunit_dino>`_
      - 384
      - ``0.5``
-     - Kang et al. (2023)
    * - ``prost40m``
      - `Prost40M <https://huggingface.co/waticlems/Prost40M>`_
      - 384
      - ``0.5``
-     - Grisi et al. (2026)
    * - ``conch``
      - `CONCH <https://huggingface.co/MahmoodLab/conch>`_
      - 512
      - ``0.5``
-     - Lu et al. (2024)
-   * - ``phikon``
-     - `Phikon <https://huggingface.co/owkin/phikon>`_
-     - 768
-     - ``0.5``
-     - Filiot et al. (2023)
-   * - ``conchv15``
-     - `CONCHv1.5 <https://huggingface.co/MahmoodLab/TITAN>`_
-     - 768
-     - ``0.5``
-     - Lu et al. (2024)
-   * - ``hibou-b``
-     - `Hibou-B <https://huggingface.co/histai/hibou-b>`_
-     - 768
-     - ``0.5``
-     - Nechaev et al. (2024)
-   * - ``h0-mini``
-     - `H0-mini <https://huggingface.co/bioptimus/H0-mini>`_
-     - 768 / 1536
-     - ``0.5``
-     - Filiot et al. (2024)
-   * - ``phikonv2``
-     - `Phikon-v2 <https://huggingface.co/owkin/phikon-v2>`_
-     - 1024
-     - ``0.5``
-     - Filiot et al. (2024)
-   * - ``phaet``
-     - `Phaet <https://huggingface.co/wearewaiv/phaet>`_
-     - 1024
-     - ``0.5`` (inferred)
-     - Waiv (2026); spacing inferred from the Phikon-v2 base model
-   * - ``hibou-l``
-     - `Hibou-L <https://huggingface.co/histai/hibou-L>`_
-     - 1024
-     - ``0.5``
-     - Nechaev et al. (2024)
-   * - ``mstar``
-     - `mSTAR <https://huggingface.co/Wangyh/mSTAR>`_
-     - 1024
-     - ``0.5``
-     - Xu et al. (2024)
-   * - ``gpfm``
-     - `GPFM <https://huggingface.co/majiabo/GPFM>`_
-     - 1024
-     - ``0.5``
-     - Ma et al. (2024)
-   * - ``uni``
-     - `UNI <https://huggingface.co/MahmoodLab/UNI>`_
-     - 1024
-     - ``0.5``
-     - Chen et al. (2024)
-   * - ``isight``
-     - `iSight <https://huggingface.co/nirschl-lab/iSight>`_
-     - 1024
-     - ``0.5``
-     - Huang et al. (2026); IHC-specific, 336 px tiles — see note below
-   * - ``musk``
-     - `MUSK <https://huggingface.co/xiangjx/musk>`_
-     - 1024 / 2048
-     - ``0.25``, ``0.5``, ``1.0``
-     - Xiang et al. (2024)
-   * - ``virchow``
-     - `Virchow <https://huggingface.co/paige-ai/Virchow>`_
-     - 1280 / 2560
-     - ``0.5``
-     - Vorontsov et al. (2024)
-   * - ``virchow2``
-     - `Virchow2 <https://huggingface.co/paige-ai/Virchow2>`_
-     - 1280 / 2560
-     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
-     - Zimmermann et al. (2024)
-   * - ``uni2``
-     - `UNI2 <https://huggingface.co/MahmoodLab/UNI2-h>`_
-     - 1536
-     - ``0.5``
-     - Chen et al. (2024)
-   * - ``gigapath``
-     - `GigaPath <https://huggingface.co/prov-gigapath/prov-gigapath>`_
-     - 1536
-     - ``0.5``
-     - Xu et al. (2024)
-   * - ``h-optimus-0``
-     - `H-Optimus-0 <https://huggingface.co/histai/h-optimus-0>`_
-     - 1536
-     - ``0.5``
-     - Saillard et al. (2024)
-   * - ``h-optimus-1``
-     - `H-Optimus-1 <https://huggingface.co/histai/h-optimus-1>`_
-     - 1536
-     - ``0.5``
-     - Saillard et al. (2024)
-   * - ``rudolfv2``
-     - `RudolfV 2 <https://huggingface.co/Aignostics/RudolfV-2>`_
-     - 1536 / 3072
-     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
-     - Aignostics (2026); CLS or CLS+patch-mean outputs
-   * - ``rudolfv2-b``
-     - `RudolfV 2-B <https://huggingface.co/Aignostics/RudolfV-2-B>`_
-     - 768 / 1536
-     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
-     - Aignostics (2026); CLS or CLS+patch-mean outputs
-   * - ``rudolfv2-s``
-     - `RudolfV 2-S <https://huggingface.co/Aignostics/RudolfV-2-S>`_
-     - 384 / 768
-     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
-     - Aignostics (2026); CLS or CLS+patch-mean outputs
-   * - ``mascaret``
-     - `Mascaret <https://huggingface.co/wearewaiv/mascaret>`_
-     - 1536
-     - ``0.5`` (inferred)
-     - Waiv (2026); spacing inferred
-   * - ``midnight``
-     - `Midnight <https://huggingface.co/AtlasAnalyticsLab/Midnight>`_
-     - 3072
-     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
-     - Karasikov et al. (2025)
-   * - ``genbio-pathfm``
-     - `GenBio-PathFM <https://huggingface.co/genbio-ai/genbio-pathfm>`_
-     - 4608
-     - ``0.5``
-     - GenBio AI (2024)
-
-iSight (IHC)
-~~~~~~~~~~~~
-
-``isight`` differs from every other preset in the table and is worth reading
-about before use.
-
-**It is IHC-specific, not a general pathology encoder.** It is
-``openai/clip-vit-large-patch14-336`` fine-tuned on HPA10M — 10.5M Human Protein
-Atlas immunohistochemistry images, all DAB + haematoxylin TMA cores from a single
-source and protocol, stored as lossy 3000x3000 JPEGs. Expect it to be useful on
-IHC and unproven elsewhere.
-
-**Tiles are 336 px, not 224 or 256.** At the ``0.5`` µm/px default that is a
-168 µm field of view. The CLIP backbone can interpolate its positional
-embeddings for other patch-divisible geometries, but 336 remains the trained,
-registered default. A different pooled size is an explicit non-recommended
-override; dense extraction can select a different geometry automatically.
-
-**The spacing is inferred.** HPA acquires at 20x, giving ~0.5 µm/px for its
-3000x3000 px images of ~1.5 mm cores, but HPA10M's dataset card does not state
-µm/px directly.
-
-**Only the tile level is exposed.** iSight's gated-attention pooler operates on
-token sequences rather than pooled tile vectors — each runtime token position
-carries its own distribution over tiles (577 positions at 336 x 336) — so it
-cannot be expressed through
-:class:`~slide2vec.encoders.base.SlideEncoder`, whose ``encode_slide`` receives
-``(N, D)``. Its five classification heads are also specific to the HPA tasks.
-Use downstream MIL for slide-level pooling.
-
-**Output variants.** ``token_mean`` (default) is the mean over all runtime tokens
-including CLS (577 at 336 x 336), matching the reference implementation;
-``cls`` selects the CLS token alone. Both are 1024-d.
-
-**The download is a raw training checkpoint** (~4.8 GB), of which roughly 3.7 GB
-is optimizer state that is read and discarded. There is no smaller artifact
-published upstream.
-
-**Caveats when consuming attention maps.** In the final block, 4 of 16 heads
-place under 1% of their CLS-query mass on the patch grid (attention sinks),
-against 0/16 at block 0. Consider passing an earlier ``blocks`` index.
-
-**Licence.** The upstream weights are published as ``license: unknown`` and the
-reference repository carries no LICENSE file. Confirm terms with the authors
-before relying on this preset in published or redistributed work.
-
-Natural-image control
-~~~~~~~~~~~~~~~~~~~~~~~
-
-A non-pathology tile encoder, kept separate from the pathology-focused table
-above. It holds the ViT architecture and self-supervised objective fixed while
-varying only the pretraining domain, so it acts as a control for measuring the
-effect of pathology pretraining. Being spacing-agnostic, it has no intrinsic
-micron spacing and accepts any requested spacing, tiling at ``0.5`` µm/px by
-default so it lands on the same tile geometry as the pathology encoders.
-
-.. list-table::
-   :header-rows: 1
-
-   * - Preset
-     - Model
-     - Output dim
-     - Spacing (um)
-     - Notes
    * - ``dinov2-vitb14``
      - `DINOv2 ViT-B/14 <https://huggingface.co/timm/vit_base_patch14_dinov2.lvd142m>`_
      - 768
      - any (``0.5`` default)
-     - Oquab et al. (2024)
-
-Dense tile grids
-~~~~~~~~~~~~~~~~
-
-Dense tile feature extraction is available on tile encoders that implement
-``encode_tiles_dense``. It returns a spatial patch-token tensor ``(B, d, h, w)``
-instead of the pooled ``(B, D)`` tensor returned by ``encode_tiles``.
-
-The following built-in tile presets are covered by the dense encoder interface:
-``conch``, ``conchv15``, ``dinov2-vitb14``, ``genbio-pathfm``, ``gigapath``,
-``gpfm``, ``h0-mini``, ``h-optimus-0``, ``h-optimus-1``, ``hibou-b``,
-``hibou-l``, ``isight``, ``lunit``, ``mascaret``, ``midnight``, ``mstar``, ``musk``,
-``phaet``, ``phikon``, ``phikonv2``, ``prost40m``, ``rudolfv2``, ``rudolfv2-b``,
-``rudolfv2-s``, ``uni``, ``uni2``, ``virchow``, and ``virchow2``.
-
-Notes:
-
-- Dense grids use patch-token dimensions. For encoders whose pooled output
-  concatenates CLS and mean patch tokens, ``d`` can be smaller than the pooled
-  output dimension ``D``.
-- ``get_normalization_transform`` preserves geometry by applying normalization
-  only. At the **encoder level**
-  (``get_normalization_transform`` / ``encode_tiles_dense``),
-  resize, crop, padding, and sliding-window policy are therefore the caller's
-  responsibility. slide2vec also ships a **region-level** streaming primitive,
-  ``iter_regions_dense``, that layers spacing-aware region reads, padding to the
-  patch multiple, and optional sliding-window blending on top of this encoder
-  API — see the "Dense Tile Feature Extraction" section of :doc:`api`.
-- ``musk`` dense extraction currently requires its native 384 x 384 input size.
-- ``conch``, ``conchv15``, ``phikon``, ``phikonv2``, and ``isight`` accept
-  patch-divisible square or rectangular encoder inputs. Their positional
-  embeddings are interpolated by the checkpoint's timm/Hugging Face backbone;
-  no variable-input constructor setting is required.
-- ``phaet`` and ``mascaret`` keep their 224 x 224 pooled preset, while their pinned
-  DINOv2 checkpoints also accept patch-divisible variable inputs without additional model
-  settings. Exact non-preset pooled sizes require ``allow_non_recommended_settings=True``;
-  dense region and window sizes use the same verified capability automatically.
-- H-Optimus dense extraction at non-native input sizes requires
-  ``dynamic_img_size=True`` and ``allow_non_recommended_settings=True`` when
-  constructing the encoder directly. Through ``Model.embed_regions_dense`` the
-  ``dynamic_img_size`` half is derived from the declared geometry, so only
-  ``allow_non_recommended_settings=True`` (the H-Optimus model card advises
-  against variable input) has to be passed to ``Model.from_preset``.
-- ``genbio-pathfm`` is a single-channel ViT: its dense grid (via
-  ``forward_with_patches``) concatenates the three per-colour-channel patch grids
-  along the feature dim, so ``d`` = 4608 matches the pooled output dimension.
-- RudolfV 2, RudolfV 2-B, and RudolfV 2-S expose the 8px patch-token grid after
-  stripping CLS plus eight register tokens. Their native pooled input is 224px,
-  while dense and explicitly declared pooled inputs may be any patch-divisible
-  square or rectangle; the adapter preserves both grid dimensions for 2D rotary
-  position encoding. The default pooled output is ``cls_patch_mean`` and
-  ``output_variant="cls"`` selects CLS alone.
-
-Dense attention maps
-~~~~~~~~~~~~~~~~~~~~~
-
-Tile encoders that implement ``encode_tiles_attention`` return per-head
-prefix-token self-attention as a spatial grid ``(B, K, h, w)`` — see the
-"Dense Attention Map Extraction" section of :doc:`api` for the channel-order
-contract and knobs.
-
-The following built-in tile presets are covered: ``conch``, ``conchv15``,
-``dinov2-vitb14``, ``gigapath``, ``gpfm``, ``h0-mini``, ``h-optimus-0``,
-``h-optimus-1``, ``hibou-b``, ``hibou-l``, ``isight``, ``lunit``, ``midnight``,
-``mstar``, ``phikon``, ``phikonv2``, ``prost40m``, ``rudolfv2``, ``rudolfv2-b``,
-``rudolfv2-s``, ``uni``, ``uni2``, ``virchow``, and ``virchow2``.
-
-Notes:
-
-- ``musk`` is **not** covered: its BEiT3 backbone uses a non-timm attention
-  module, so attention extraction raises ``NotImplementedError`` (dense
-  patch-token extraction is still available).
-- ``genbio-pathfm`` is **not** covered: it computes attention with a fused
-  ``scaled_dot_product_attention`` (no materialized weights) and encodes the three
-  colour channels as independent single-channel images, so there is no single
-  coherent CLS-over-patches attention to extract; ``encode_tiles_attention`` raises
-  ``NotImplementedError`` (dense patch-token extraction is still available).
-- ``phaet`` / ``mascaret`` are **not** covered: their pinned Waiv wrappers accept
-  ``output_attentions=True`` through ``**kwargs`` but do not forward it to the
-  inner backbone, and return ``attentions=None``. Their
-  ``encode_tiles_attention`` methods therefore raise ``NotImplementedError``
-  (dense patch-token extraction is still available).
-- ``hibou-b`` / ``hibou-l`` carry register tokens; pass ``include_registers=True``
-  to add their query rows as extra channels.
-- ``conch`` / ``conchv15`` recover attention from their inner timm ViT trunk, the
-  same trunk their dense extraction uses.
-
+   * - ``phikon``
+     - `Phikon <https://huggingface.co/owkin/phikon>`_
+     - 768
+     - ``0.5``
+   * - ``conchv15``
+     - `CONCHv1.5 <https://huggingface.co/MahmoodLab/TITAN>`_
+     - 768
+     - ``0.5``
+   * - ``hibou-b``
+     - `Hibou-B <https://huggingface.co/histai/hibou-b>`_
+     - 768
+     - ``0.5``
+   * - ``h0-mini``
+     - `H0-mini <https://huggingface.co/bioptimus/H0-mini>`_
+     - 768 / 1536
+     - ``0.5``
+   * - ``phikonv2``
+     - `Phikon-v2 <https://huggingface.co/owkin/phikon-v2>`_
+     - 1024
+     - ``0.5``
+   * - ``phaet``
+     - `Phaet <https://huggingface.co/wearewaiv/phaet>`_
+     - 1024
+     - ``0.5``
+   * - ``hibou-l``
+     - `Hibou-L <https://huggingface.co/histai/hibou-L>`_
+     - 1024
+     - ``0.5``
+   * - ``mstar``
+     - `mSTAR <https://huggingface.co/Wangyh/mSTAR>`_
+     - 1024
+     - ``0.5``
+   * - ``gpfm``
+     - `GPFM <https://huggingface.co/majiabo/GPFM>`_
+     - 1024
+     - ``0.5``
+   * - ``uni``
+     - `UNI <https://huggingface.co/MahmoodLab/UNI>`_
+     - 1024
+     - ``0.5``
+   * - ``isight``
+     - `iSight <https://huggingface.co/nirschl-lab/iSight>`_
+     - 1024
+     - ``0.5``
+   * - ``musk``
+     - `MUSK <https://huggingface.co/xiangjx/musk>`_
+     - 1024 / 2048
+     - ``0.25``, ``0.5``, ``1.0``
+   * - ``virchow``
+     - `Virchow <https://huggingface.co/paige-ai/Virchow>`_
+     - 1280 / 2560
+     - ``0.5``
+   * - ``virchow2``
+     - `Virchow2 <https://huggingface.co/paige-ai/Virchow2>`_
+     - 1280 / 2560
+     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
+   * - ``uni2``
+     - `UNI2 <https://huggingface.co/MahmoodLab/UNI2-h>`_
+     - 1536
+     - ``0.5``
+   * - ``gigapath``
+     - `GigaPath <https://huggingface.co/prov-gigapath/prov-gigapath>`_
+     - 1536
+     - ``0.5``
+   * - ``h-optimus-0``
+     - `H-Optimus-0 <https://huggingface.co/histai/h-optimus-0>`_
+     - 1536
+     - ``0.5``
+   * - ``h-optimus-1``
+     - `H-Optimus-1 <https://huggingface.co/histai/h-optimus-1>`_
+     - 1536
+     - ``0.5``
+   * - ``rudolfv2``
+     - `RudolfV 2 <https://huggingface.co/Aignostics/RudolfV-2>`_
+     - 1536 / 3072
+     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
+   * - ``rudolfv2-b``
+     - `RudolfV 2-B <https://huggingface.co/Aignostics/RudolfV-2-B>`_
+     - 768 / 1536
+     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
+   * - ``rudolfv2-s``
+     - `RudolfV 2-S <https://huggingface.co/Aignostics/RudolfV-2-S>`_
+     - 384 / 768
+     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
+   * - ``mascaret``
+     - `Mascaret <https://huggingface.co/wearewaiv/mascaret>`_
+     - 1536
+     - ``0.5``
+   * - ``midnight``
+     - `Midnight <https://huggingface.co/AtlasAnalyticsLab/Midnight>`_
+     - 3072
+     - ``0.25``, ``0.5``, ``1.0``, ``2.0``
+   * - ``genbio-pathfm``
+     - `GenBio-PathFM <https://huggingface.co/genbio-ai/genbio-pathfm>`_
+     - 4608
+     - ``0.5``
 
 
 Slide-level encoders
@@ -328,112 +147,31 @@ Slide-level encoders
      - Tile encoder
      - Spacing (um)
      - Output dim
-     - Notes
    * - ``gigapath-slide``
      - `GigaPath <https://huggingface.co/prov-gigapath/prov-gigapath>`_
      - ``gigapath``
      - ``0.5``
      - 768
-     - Xu et al. (2024)
    * - ``titan``
      - `TITAN <https://huggingface.co/MahmoodLab/TITAN>`_
      - ``conchv15``
      - ``0.5``
      - 768
-     - Ding et al. (2024)
    * - ``prism``
      - `PRISM <https://huggingface.co/paige-ai/PRISM>`_
      - ``virchow``
      - ``0.5``
      - 1280
-     - Shaikovski et al. (2024)
    * - ``prism2``
      - `PRISM2 <https://huggingface.co/paige-ai/Prism2>`_
-     - ``virchow2`` (CLS only)
+     - ``virchow2``
      - ``0.5``
-     - 2560 (base); 3072 (diagnostic)
-     - Base is default; Shaikovski et al. (2026)
+     - 2560 (base, default); 3072 (``output_variant="diagnostic"``)
    * - ``moozy-slide``
      - `MOOZY <https://huggingface.co/AtlasAnalyticsLab/MOOZY>`_
      - ``lunit``
      - ``0.5``
      - 768
-     - Kotp et al. (2026)
-
-
-PRISM2 gated-use contract
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``prism2`` defaults to PRISM2's 2560-dimensional **base embedding**, the
-Perceiver-pool output used for general slide representation. Select
-``output_variant="diagnostic"`` for the documented 3072-dimensional
-**diagnostic embedding**. That representation is the Phi-3 final-layer hidden
-state at the ``<|assistant|>`` position after PRISM2's fixed image-only prompt;
-the official ``get_diagnostic_embedding`` method owns that prompt and hidden-state
-selection. Free-form text generation, yes/no scoring, and concatenating multiple
-slides into one specimen remain outside this preset.
-
-The upstream repository is gated. Request access individually, accept its terms,
-then authenticate the machine that runs slide2vec with ``hf auth login`` (or set
-up Hugging Face authentication by another supported method). Tokens must not be
-stored in a project configuration or committed to source control. Install the
-isolated runtime only where this preset is needed:
-
-.. code-block:: bash
-
-   python -m pip install "slide2vec[prism2]"
-
-The pinned PRISM2 revision declares Transformers 4.51.3, which the isolated
-``prism2`` extra installs exactly; newer Transformers releases can remove Phi-3
-internals used by the gated custom code. PRISM2 also requires a CUDA-capable GPU
-and ``flash-attn>=2.6.3``. Flash attention is mandatory because its Perceiver
-cross-attention uses the training-time ``flash_attn_varlen_func`` kernel. The
-recommended compute precision is bf16.
-Because numpy-backed slide artifacts cannot persist bf16, slide2vec's existing
-default output-dtype policy widens bf16 results to fp32 on disk; pass an explicit
-supported ``output_dtype`` only when a different persisted dtype is intended.
-
-Input tiles must be foreground H&E tissue (background/glass removed), exactly
-224×224 pixels at 0.5 µm/px. The tile dependency is ``virchow2`` with its
-1280-dimensional ``cls`` output, not Virchow2's usual CLS+patch-mean vector.
-Although Virchow2 itself supports other spacings, the ``prism2`` preset rejects
-them unless the caller deliberately enables slide2vec's non-recommended-settings
-override. The default slide2vec preprocessing path segments and samples tissue;
-review custom masks and filtering overrides carefully so background tiles do not
-enter the bag.
-
-Both output variants use this identical tile extraction and preprocessing path;
-changing ``output_variant`` changes only the slide representation. Coordinates
-are intentionally not supplied to PRISM2: at tested revision
-``450352d0ddc6b42b21ce20794ce0fbefe6b5a47a``, the official processor accepts
-only tile embeddings (plus an optional attention mask), and both official
-embedding methods consume that same processed batch. The same revision was used
-for the deterministic contract tests and CUDA diagnostic smoke:
-
-.. code-block:: bash
-
-   CUDA_VISIBLE_DEVICES=0 python - <<'PY'
-   import torch
-   from slide2vec.encoders.models.prism2 import PRISM2_REVISION, Prism2SlideEncoder
-
-   assert PRISM2_REVISION == "450352d0ddc6b42b21ce20794ce0fbefe6b5a47a"
-   encoder = Prism2SlideEncoder(output_variant="diagnostic").to("cuda")
-   with torch.autocast("cuda", torch.bfloat16):
-       output = encoder.encode_slide(torch.zeros(2, 1280))
-   assert output.shape == (3072,)
-   PY
-
-The diagnostic path moves only the modules used by the official method
-(``image_resampler``, ``img_projection``, and ``text_decoder``) to CUDA and casts
-them to bf16. This avoids materializing the pinned checkpoint's roughly 16.7 GiB
-fp32 diagnostic path on-device while preserving the upstream computation. The
-default base path remains unchanged and moves only ``image_resampler``.
-
-PRISM2 is released under CC-BY-NC-ND-4.0 and its additional gated terms. It is
-for non-commercial academic research/evaluation only and must not be used for
-clinical care, diagnosis, treatment, or other medical decision support. Do not
-redistribute its weights or gated custom code; consult the upstream model page
-for the complete current terms before use.
 
 
 Patient-level encoders
@@ -441,8 +179,8 @@ Patient-level encoders
 
 Patient-level encoders aggregate multiple slide embeddings for the same patient
 into a single patient-level embedding. They require a ``patient_id`` column in
-the `input manifest <manifest.rst>`_ csv (or ``patient_id`` keys in each slide dict when using
-the Python API).
+the :doc:`input manifest <manifest>` (or ``patient_id`` keys in each slide dict
+when using the Python API).
 
 .. list-table::
    :header-rows: 1
@@ -452,20 +190,32 @@ the Python API).
      - Tile encoder
      - Spacing (um)
      - Output dim
-     - Notes
    * - ``moozy``
      - `MOOZY <https://huggingface.co/AtlasAnalyticsLab/MOOZY>`_
      - ``lunit``
      - ``0.5``
      - 768
-     - Kotp et al. (2026)
 
 
-Preflight capability reports
-----------------------------
+Installation extras
+-------------------
 
-Use :func:`slide2vec.encoders.resolve_encoder_capabilities` to inspect a registered
-preset before constructing its encoder or loading weights:
+Some presets need extra dependencies. Install them with the matching extra,
+for example ``pip install "slide2vec[prism2]"``. Some extras (``prism2``,
+``waiv``) have dependency pins that are incompatible with the others; install
+those in their own environment. Gated upstream repositories additionally
+require Hugging Face access approval and ``hf auth login``.
+
+
+Dense grids and attention maps
+------------------------------
+
+Tile encoders can also return a spatial patch-token grid ``(B, d, h, w)``
+instead of the pooled ``(B, D)`` vector, and most can return per-head
+CLS-attention grids ``(B, K, h, w)``. See :doc:`api` for the dense and
+attention APIs.
+
+Support varies by preset. Check it without loading weights:
 
 .. code-block:: python
 
@@ -478,34 +228,18 @@ preset before constructing its encoder or loading weights:
    print(capabilities.attention)   # True
    print(capabilities.patch_size)  # (14, 14)
 
-The frozen :class:`slide2vec.encoders.EncoderCapabilities` report is the preflight
-view of the existing :class:`~slide2vec.encoders.base.Encoder` contract. It is
-*derived* from the registered class behavior and the preset's existing static
-registry metadata; it is not a second capability declaration. Resolution does not
-instantiate the encoder, load weights, select a GPU, download files, or access the
-network.
-
-``level`` identifies tile, slide, or patient presets. The ``pooled``, ``dense``,
-``attention``, ``slide``, and ``patient`` flags identify the corresponding public
-Encoder methods supported by that class. Dense reports include the normalized static
-``patch_size``. Slide and patient reports include ``tile_encoder`` and
-``tile_encoder_output_variant``, so callers can preflight the fixed tile dependency
-through the same report.
-
-Registration rejects mismatches between the class contract and static metadata. A
-dense tile class, for example, must override ``encode_tiles_dense``, ``patch_size``,
-and ``get_normalization_transform`` together and must declare the same kind of
-positive static ``patch_size`` accepted by ``register_encoder``. A pooled-only tile
-encoder needs none of those dense members and resolves with ``dense=False`` and
-``attention=False``.
+Resolution reads the registry only: it does not instantiate the encoder,
+download files, or access the network. Slide and patient reports include
+``tile_encoder`` and ``tile_encoder_output_variant`` so you can preflight the
+fixed tile dependency the same way.
 
 Custom encoder plugin package
 -----------------------------
 
-An encoder owned outside this repository can behave exactly like a built-in preset.
-Package it as a Python distribution with a zero-argument provider in the
-``slide2vec.encoders`` entry-point group. Installing the distribution is enough:
-the Python API and CLI discover it lazily, without a manual import or a module path.
+An encoder owned outside this repository can behave exactly like a built-in
+preset. Package it as a Python distribution with a zero-argument provider in
+the ``slide2vec.encoders`` entry-point group. Installing the distribution is
+enough: the Python API and CLI discover it lazily, without a manual import.
 
 Minimal package layout
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -539,8 +273,8 @@ Create these two files in a separate repository:
    [tool.setuptools.packages.find]
    where = ["src"]
 
-``src/my_slide2vec_encoders/__init__.py`` implements the existing public Encoder
-contract and registers its static preset metadata from the provider:
+``src/my_slide2vec_encoders/__init__.py`` implements the public Encoder
+contract and registers its static preset metadata:
 
 .. code-block:: python
 
@@ -604,10 +338,9 @@ contract and registers its static preset metadata from the provider:
            source="/models/my-tile-model.ts",
        )(MyTileModel)
 
-The provider may register more than one class. Keep it metadata-only: importing the
-module and calling ``register_encoders()`` must not construct an encoder, read a
-checkpoint, contact a model hub, or otherwise access the network. Those operations
-belong to the encoder constructor, which runs only when slide2vec loads that preset.
+The provider must stay metadata-only: ``register_encoders()`` must not
+construct an encoder, read a checkpoint, or access the network. That work
+belongs to the encoder constructor.
 
 Install and use it
 ~~~~~~~~~~~~~~~~~~
@@ -619,42 +352,25 @@ Install and use it
 .. code-block:: python
 
    from slide2vec import Model, list_models
-   from slide2vec.encoders import encoder_registry
 
    assert "my-tile-model" in list_models()
-   print(encoder_registry.info("my-tile-model"))  # static metadata; no weights loaded
    model = Model.from_preset("my-tile-model")
 
-The same preset name works as ``model.name`` in YAML and in the CLI. Every process
-discovers installed providers on its first encoder-registry read; no plugin import is
-needed in application code.
+The same preset name works as ``model.name`` in YAML and in the CLI. For
+distributed extraction, install the plugin distribution — and make its weights
+and credentials reachable — in the same way on every worker and node.
 
-For distributed extraction, install the plugin distribution in the same Python
-environment used by every worker on every node. Workers reconstruct the model from
-the serialized preset name; slide2vec does not transfer the plugin's Python package,
-encoder class, provider, or checkpoint location from the parent process. Any weights,
-credentials, environment variables, and local paths used by the plugin must therefore
-be reachable with the same meaning from every worker and node.
+Provider diagnostics
+~~~~~~~~~~~~~~~~~~~~
 
-Provider failures and diagnostics
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Each provider registers transactionally. If loading or calling a provider raises,
-its metadata is invalid, or any of its preset names already belongs to a built-in or
-an earlier provider, slide2vec discards every preset registered by that provider.
-Built-ins and healthy providers remain available. Provider order is deterministic,
-and an existing preset is never replaced.
-
-``list_models()`` emits a concise ``RuntimeWarning`` when it skips a provider. The
-warning includes the provider's entry-point key, exception type, and single-line
-message. Downstream tools can consume the same information without parsing warning
-text through the stable top-level API:
+A provider that fails to load is skipped as a whole; built-ins and healthy
+providers stay available, and ``list_models()`` emits a ``RuntimeWarning``.
+For structured access to those failures:
 
 .. code-block:: python
 
-   from slide2vec import list_encoder_provider_diagnostics, list_models
+   from slide2vec import list_encoder_provider_diagnostics
 
-   available = list_models()
    for diagnostic in list_encoder_provider_diagnostics():
        print(
            diagnostic.provider_key,
@@ -662,33 +378,3 @@ text through the stable top-level API:
            diagnostic.exception_type,
            diagnostic.message,
        )
-
-The accessor returns a tuple of frozen
-:class:`~slide2vec.EncoderProviderDiagnostic` values, so callers cannot mutate the
-process-global discovery result. Looking up an unavailable preset includes these
-provider failures after the ordinary available-preset list. Successful lookup and
-model construction are unchanged.
-
-Loading ownership and trust
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Installing an Encoder provider authorizes slide2vec to import and execute that
-provider as trusted Python code during lazy discovery. There is no sandbox,
-signature system, dependency isolation, or allowlist. Review and control installed
-provider distributions with the same care as any other Python dependency.
-
-The plugin owns its checkpoint loader and credentials. The example uses a fixed local
-TorchScript path. For a private Hugging Face repository, replace that constructor line
-with the appropriate ``from_pretrained("my-org/my-private-model", token=True)`` call
-and supply credentials through the Hugging Face login/token mechanisms. This remains
-construction-time work; the provider itself stays offline and metadata-only.
-
-``trust_remote_code=True`` executes Python supplied by the model repository. Enable it
-only after reviewing that code and pinning a trusted commit; leave it disabled for
-unreviewed or mutable repositories.
-
-A preset name is the sole model and artifact identity. Once published, never repoint a
-name to different weights, preprocessing, output semantics, or architecture. Publish a
-new preset name and register a separate class when any of those change; distribution
-versions, checkpoint paths, providers, and recipe revisions are not added to artifact
-identity by slide2vec.

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -41,9 +41,9 @@ Per-Annotation Namespacing
 --------------------------
 
 The layout above is the tissue-only (default) case. When
-:ref:`annotation-aware sampling <annotation-aware-sampling>` is
-enabled, each sampled class gets its own ``<class>/`` subdirectory under every
-embedding directory, and the tiling artifacts are namespaced the same way:
+:ref:`annotation-aware sampling <annotation-aware-sampling>` is enabled, each
+sampled class gets its own ``<class>/`` subdirectory under every embedding
+directory, and the tiling artifacts are namespaced the same way:
 
 .. code-block:: text
 
@@ -63,12 +63,10 @@ embedding directory, and the tiling artifacts are namespaced the same way:
            ├── tumor/<sample_id>.png
            └── stroma/<sample_id>.png
 
-The ``tissue`` class and structural ``merged`` output collapse to the flat root
-shown earlier — there is no ``tissue/`` or ``merged/`` subdirectory. hs2p 4.4
-stores merged artifacts as ``annotation=None`` plus ``output_mode="merged"``,
-while ``process_list.csv`` keeps the readable ``merged`` label. Per-class mode
-has one row per ``(sample_id, annotation)`` pair, each recording that class's
-own ``feature_path``.
+The ``tissue`` class and the structural ``merged`` output collapse to the flat
+root shown earlier — there is no ``tissue/`` or ``merged/`` subdirectory.
+Per-class mode has one ``process_list.csv`` row per ``(sample_id, annotation)``
+pair, each recording that class's own ``feature_path``.
 
 
 Embedding Files
@@ -102,20 +100,20 @@ Shapes by artifact type:
    * - ``patient_embeddings``
      - ``(D,)``
 
-Dense grids are not written by :class:`~slide2vec.Pipeline` or the CLI. They are
-produced by :meth:`~slide2vec.Model.embed_regions_dense` (slide ROIs) and
-:meth:`~slide2vec.Model.embed_images_dense` (pre-cropped images), and exposed at
-the encoder level as ``encode_tiles_dense(...)``; see :doc:`api` for usage.
+Dense grids are not written by :class:`~slide2vec.Pipeline` or the CLI. They
+are produced by :meth:`~slide2vec.Model.embed_regions_dense` (slide ROIs) and
+:meth:`~slide2vec.Model.embed_images_dense` (pre-cropped images); see
+:doc:`api` for usage.
 
 
 Embedding Meta Files
 --------------------
 
-Each ``.pt`` embedding file has a companion ``.meta.json`` with provenance
-and shape information. The exact fields depend on the artifact type.
+Each ``.pt`` embedding file has a companion ``.meta.json`` with provenance and
+shape information. The exact fields depend on the artifact type.
 ``feature_dtype`` records the dtype the features were written in (``"fp16"`` or
-``"fp32"``), as resolved from ``ExecutionOptions.output_dtype`` / ``speed.output_dtype``
-(see :ref:`execution-options`).
+``"fp32"``), as resolved from ``ExecutionOptions.output_dtype`` (see
+:ref:`execution-options`).
 
 **tile_embeddings**
 
@@ -142,14 +140,15 @@ and shape information. The exact fields depend on the artifact type.
       "tile_size_lv0": 224,
    }
 
-``encoder_input_size_px`` is always present and may be ``null`` for a zero-tile
-artifact because no tensor reached the encoder. The metadata does not infer an
-encoder spacing: ``requested_spacing_um`` describes the canonical tile request,
-while the encoder input size reports only the observed post-transform pixels.
+``encoder_input_size_px`` is always present and is ``null`` for a zero-tile
+artifact, because no tensor reached the encoder. ``requested_spacing_um``
+describes the canonical tile request; the encoder input size reports only the
+observed post-transform pixels.
 
 **hierarchical_embeddings**
 
-Same fields as ``tile_embeddings`` (except  ``"artifact_type": "hierarchical_embeddings"``), plus:
+Same fields as ``tile_embeddings`` (except
+``"artifact_type": "hierarchical_embeddings"``), plus:
 
 .. code-block:: text
 
@@ -157,10 +156,6 @@ Same fields as ``tile_embeddings`` (except  ``"artifact_type": "hierarchical_emb
      ...
      "num_regions": 512,
      "tiles_per_region": 36,
-     "read_tile_size_px": 224,
-     "requested_tile_size_px": 224,
-     "encoder_input_size_px": 224,
-     "requested_spacing_um": 0.5
    }
 
 **slide_embeddings**
@@ -195,8 +190,8 @@ Same fields as ``tile_embeddings`` (except  ``"artifact_type": "hierarchical_emb
 Image Embeddings
 ----------------
 
-:meth:`~slide2vec.Model.embed_images` (see :doc:`api`) writes one flat directory,
-one payload plus one sidecar per input image, named by the caller's
+:meth:`~slide2vec.Model.embed_images` (see :doc:`api`) writes one flat
+directory — one payload plus one sidecar per input image, named by the caller's
 ``sample_id``:
 
 .. code-block:: text
@@ -205,12 +200,6 @@ one payload plus one sidecar per input image, named by the caller's
    └── image_embeddings/
        ├── <sample_id>.pt          ← Tensor of shape (D,)
        └── <sample_id>.meta.json
-
-There is no per-annotation namespacing here: a given-geometry image has no slide,
-no coordinate and no sampled class. The sidecar is written **last**, after the
-payload has been published atomically, so a payload without its sidecar
-unambiguously means an interrupted image — which is exactly what makes the run
-resumable at image granularity across GPUs.
 
 **image_embeddings**
 
@@ -229,20 +218,13 @@ resumable at image granularity across GPUs.
      "image_path": "/data/bach/001.tif",
    }
 
-``encoder_input_size_px`` is the factual side length of the tensor the encoder
-saw, after its shipped transform ran on that image. In the Given regime it is
-recorded, never validated: the caller supplied pixels it never requested, so
-there is no request to check it against.
-
-
 Dense Region Grids
 ------------------
 
 :meth:`~slide2vec.Model.embed_regions_dense` writes one payload and sidecar per
 level-0 point coordinate under
-``dense_embeddings/[<annotation>/]<sample_id>/<x>_<y>``. Region resume compares
-the sidecar's ``compatibility`` object, rather than trusting sidecar presence.
-It contains the same source/read geometry vocabulary as dense images:
+``dense_embeddings/[<annotation>/]<sample_id>/<x>_<y>``. The sidecar's
+``compatibility`` object records the source and read geometry:
 
 .. code-block:: json
 
@@ -263,19 +245,16 @@ It contains the same source/read geometry vocabulary as dense images:
      "output_size": [224, 224]
    }
 
-``spacing_at_level_0`` is the optional caller declaration;
-``source_spacing_um`` is hs2p's resolved source level-0 spacing;
-``declared_spacing_um`` is the requested run spacing; and
-``effective_spacing_um`` is the spacing of the encoded grid. Changing the
-declaration or any resolved read-plan field invalidates region resume.
+``read_size`` and ``output_size`` use ``[height, width]``; see the
+:doc:`glossary` for the spacing vocabulary. Resume recomputes any artifact
+whose ``compatibility`` object does not match the current call.
 
 
 Dense Image Grids
 -----------------
 
-:meth:`~slide2vec.Model.embed_images_dense` (see :doc:`api`) writes the dense
-counterpart of that layout — one flat directory, one grid payload plus one
-geometry sidecar per input image:
+:meth:`~slide2vec.Model.embed_images_dense` (see :doc:`api`) writes one flat
+directory — one grid payload plus one geometry sidecar per input image:
 
 .. code-block:: text
 
@@ -283,19 +262,6 @@ geometry sidecar per input image:
    └── dense_image_embeddings/
        ├── <sample_id>.pt          ← Tensor of shape (d, grid_h, grid_w)
        └── <sample_id>.meta.json
-
-For dense images, a *compatible artifact* is a payload plus a readable sidecar
-whose ``compatibility`` object exactly matches the current image identity and
-canonical extraction recipe. Sidecar presence alone is not enough. Missing
-payloads or sidecars, legacy/incomplete compatibility records, and recipe
-differences are recomputed; unreadable or malformed sidecars are errors.
-
-Replacement follows a strict sidecar-last contract. Before recomputing an
-incompatible artifact, slide2vec removes its old sidecar done-marker. The new
-payload is written to a sibling temporary file and atomically moved into place,
-then the new sidecar is published last. If the process stops before or after
-payload replacement, no trusted sidecar remains paired with the changed
-payload.
 
 **dense_image_embeddings**
 
@@ -321,8 +287,6 @@ payload.
      "is_within_tolerance": false,
      "read_size": [2048, 2048],
      "output_size": [1024, 1024],
-     "read_tile_size_px": null,
-     "requested_tile_size_px": null,
      "image_path": "/data/ocelot/001.jpg",
      "format": "pt",
      "dtype": "float32",
@@ -333,96 +297,19 @@ payload.
      "encoded_size": [1036, 1036],
      "pad": [12, 12],
      "pad_mode": "reflect",
-     "image_pad_value": null,
      "window_size": 224,
      "overlap": 0.0,
      "feature_kind": "patch_features",
      "attention_blocks": [-1],
      "attention_include_registers": false,
-     "compatibility": {
-       "sample_id": "ocelot-001",
-       "image_path": "/data/ocelot/001.jpg",
-       "encoder_name": "virchow2",
-       "output_variant": "cls_patch_mean",
-       "reader_regime": "spacing-readable",
-       "spacing_source": "explicit",
-       "declared_spacing_um": 0.5,
-       "source_spacing_um": 0.25,
-       "spacing_at_level_0": 0.25,
-       "read_spacing_um": 0.25,
-       "effective_spacing_um": 0.5,
-       "requested_backend": "auto",
-       "backend": "pil",
-       "tolerance": 0.05,
-       "read_level": 0,
-       "is_within_tolerance": false,
-       "read_size": [2048, 2048],
-       "output_size": [1024, 1024],
-       "read_tile_size_px": null,
-       "requested_tile_size_px": null,
-       "target_size": [1024, 1024],
-       "patch_size": [14, 14],
-       "encoded_size": [1036, 1036],
-       "pad": [12, 12],
-       "grid_shape": [74, 74],
-       "pad_mode": "reflect",
-       "image_pad_value": null,
-       "window_size": 224,
-       "overlap": 0.0,
-       "feature_kind": "patch_features",
-       "attention_blocks": [-1],
-       "attention_include_registers": false,
-       "precision": "fp32",
-       "dtype": "float32"
-     }
+     "compatibility": { ... }
    }
 
-The compatibility identity covers the sample ID and normalized source path;
-resolved reader regime, requested/resolved backend, spacing source, and the
-declared/source/native-read/effective spacing chain;
-encoder name and resolved output variant; target, patch, encoded, padding, and
-grid geometry; padding/window/overlap and attention settings; inference
-precision; and stored dtype. GPU count, batch size, workers, prefetching, output
-directory, and other execution mechanics are deliberately excluded.
-``encoder_input_regime`` is ``"declared"`` — unlike a pooled image embedding,
-this run *stated* its geometry and it was validated before any image was read.
-For PNG/JPEG inputs, ``reader_regime="spacing-readable"`` and ``backend="pil"``
-record hs2p's one-level PIL path. ``spacing_at_level_0`` is required when the
-source has no embedded spacing. An exact-spacing read is byte-identical to the
-unchanged Pillow RGB read; a coarser request records level 0 as the read and the
-truthful downsampled ``output_size`` and ``effective_spacing_um``.
-
-For spacing-readable inputs, the compatibility object records the complete
-parent-resolved hs2p plan. For example, a source whose level-0 spacing is
-``0.252`` µm/px may accept level 1 natively at ``0.504`` within tolerance:
-
-.. code-block:: json
-
-   {
-     "reader_regime": "spacing-readable",
-     "spacing_source": "model_default",
-     "declared_spacing_um": 0.5,
-     "source_spacing_um": 0.252,
-     "spacing_at_level_0": null,
-     "read_spacing_um": 0.504,
-     "effective_spacing_um": 0.504,
-     "requested_backend": "auto",
-     "backend": "vips",
-     "tolerance": 0.05,
-     "read_level": 1,
-     "is_within_tolerance": true,
-     "read_size": [1024, 1024],
-     "output_size": [1024, 1024]
-   }
-
-``declared_spacing_um`` is the explicit or model-default run request.
-``source_spacing_um`` is the authoritative level-0 scale after applying the
-optional ``spacing_at_level_0`` caller override. ``read_spacing_um`` is the
-selected level's native scale. ``effective_spacing_um`` is that native scale
-when no resize occurs, or the declared request after hs2p area downsampling.
-``read_size`` and ``output_size`` use ``[height, width]``. Changes in source
-metadata, the resolved result of ``backend="auto"``, or any other plan field
-invalidate compatible-artifact resume.
+The nested ``compatibility`` object repeats the identity and recipe fields
+above, plus the inference ``precision`` and stored ``dtype``. Resume recomputes
+any artifact whose ``compatibility`` object does not match the current call;
+execution mechanics (GPU count, batch size, workers, output directory) are
+excluded.
 
 
 Coordinate Files
@@ -436,9 +323,8 @@ under ``tiles/``:
 
 **Coordinate arrays**
 
-The ``.npz`` contains four arrays with tile coordinate and metadata information.
-All four arrays have length ``N`` (the number of tiles) and share the same ordering as the rows of the corresponding embedding tensor.
-
+The ``.npz`` contains four arrays, each of length ``N`` (the number of tiles),
+in the same order as the rows of the corresponding embedding tensor:
 
 .. list-table::
    :header-rows: 1
@@ -470,8 +356,8 @@ All four arrays have length ``N`` (the number of tiles) and share the same order
 
 **Coordinate meta files**
 
-The sidecar ``coordinates.meta.json`` is a structured file produced by the
-tiling pipeline. It contains several sections:
+The sidecar ``coordinates.meta.json`` records tiling provenance in several
+sections:
 
 .. code-block:: text
 

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -1,7 +1,7 @@
 Preprocessing
 =============
 
-This page covers the full set of options available in :class:`~slide2vec.PreprocessingConfig`
+This page covers the options available in :class:`~slide2vec.PreprocessingConfig`
 and how to configure them.
 
 .. autoclass:: slide2vec.PreprocessingConfig
@@ -22,80 +22,37 @@ The ``backend`` field controls which slide-reading library is used:
 - ``"vips"`` — libvips, good for large TIFF files
 - ``"asap"`` — ASAP reader (requires separate installation)
 
-The ``mask_backend`` field (hs2p ≥ 4.3.0) controls the reader used for **source masks**
-— precomputed tissue masks and annotation masks — and accepts the same values. It is
-resolved independently from the *mask* path, so a mask can use a different decoder than its
-slide. Since hs2p no longer silently falls back to another reader, set ``mask_backend``
-explicitly (e.g. ``"openslide"``) when a mask cannot be decoded by the slide backend — for
-example a deflate-compressed label TIFF that cuCIM can open but not decode. It defaults to
-``"auto"`` and is ignored for slides with no source mask.
+The ``mask_backend`` field controls the reader used for **source masks** —
+precomputed tissue masks and annotation masks — and accepts the same values. It
+is resolved independently from the mask path, so a mask can use a different
+decoder than its slide. hs2p never silently falls back to another reader, so
+set ``mask_backend`` explicitly (e.g. ``"openslide"``) when the slide backend
+cannot decode a mask — for example a deflate-compressed label TIFF that cuCIM
+can open but not decode. It defaults to ``"auto"`` and is ignored for slides
+with no source mask.
 
-The ``auto`` priority can change which decoder is selected when hs2p or the
-installed backend set changes. Set ``backend`` and ``mask_backend`` explicitly
-when decoder selection must remain stable across upgrades.
-
-Tile TAR export uses the portable Pillow encoder (``jpeg_backend="pil"``) by
-default. ``jpeg_backend="turbojpeg"`` remains an explicit performance opt-in;
-when its optional upstream dependency is unavailable, hs2p reports the
-actionable dependency error rather than silently choosing another encoder.
-
+The ``auto`` priority can change when hs2p or the installed backend set
+changes. Set ``backend`` and ``mask_backend`` explicitly when decoder selection
+must stay stable across upgrades.
 
 Pooled Tile Geometry
 --------------------
 
-Pooled extraction uses three distinct pixel sizes:
+Pooled extraction uses three distinct pixel sizes, recorded in every artifact
+sidecar:
 
-- ``read_tile_size_px`` is the raw square read from the selected WSI pyramid
+- ``read_tile_size_px`` — the raw square read from the selected WSI pyramid
   level.
-- ``requested_tile_size_px`` is the canonical square tile after geometry
-  correction and before model preprocessing.
-- ``encoder_input_size_px`` is the factual square tensor side length immediately
-  before ``encode_tiles``.
+- ``requested_tile_size_px`` — the canonical tile after geometry correction,
+  before model preprocessing.
+- ``encoder_input_size_px`` — the tensor side length the encoder receives.
 
-Every pooled reader path — direct WSI reads, saved tar tiles, hierarchical
-subtiles, and the tile-encoder dependencies of slide- and patient-level models —
-first produces ``requested_tile_size_px``. When a WSI read size differs,
-slide2vec uses hs2p's
-``resize_array(..., interpolation="area")`` operation before model
-preprocessing.
-
-When the requested size equals the tile encoder's registered preset, slide2vec
-uses the shipped pooled transform unchanged. For example, GigaPath keeps a
-requested tile size of 256 pixels and its shipped center-crop produces an
-encoder input size of 224 pixels. A different requested size is instead an exact
-encoder-input request: it requires ``allow_non_recommended_settings=True``, an
-encoder registered as variable-input capable, and a positive size divisible by
-the model's patch geometry. The permitted path applies normalization only, so
-the exact requested square reaches ``encode_tiles``. Fixed-size or
-patch-incompatible requests fail before slide reading begins.
-
-Which of those two rules applies is stated explicitly at model load rather than
-inferred. Every entry point resolves an ``EncoderInputContract`` in one of two
-regimes and passes it to ``load_model``, which has no default for it:
-
-- **Declared geometry** — the caller states the encoder input it wants, and
-  slide2vec honors it exactly or raises (the rules above).
-- **Given geometry** — the caller supplies pixels it never requested. The
-  encoder's shipped transform is the contract, and slide2vec *records* the
-  resulting ``encoder_input_size_px`` rather than vetoing it.
-
-Omitting the contract is an error, not a silent fallback to the shipped recipe:
-"the caller never requested this geometry" and "the caller forgot" must not look
-alike at the seam where the transform is chosen.
-
-The declared regime covers dense extraction too. Pooled and dense derive the
-**effective encoder input** — the geometry of the tensor immediately before
-``encode_tiles`` / ``encode_tiles_dense`` — differently (``requested_tile_size_px``
-for pooled; the padded ROI or the patch-aligned window for dense, see
-:doc:`api`), but both then ask the same thing of it: whether the encoder is
-registered as variable-input capable, and which constructor settings activate
-that. There is no separate ``dynamic_img_size`` knob for dense; it is derived.
-
-This reader convergence intentionally changes pooled embeddings for runs where
-``read_tile_size_px != requested_tile_size_px``: older runs could pass the raw
-pyramid read directly to the model transform. There is no legacy compatibility
-mode; use artifact geometry metadata to distinguish outputs produced under the
-canonical contract.
+When ``requested_tile_size_px`` equals the encoder's registered preset,
+slide2vec applies the encoder's shipped transform unchanged. A different
+requested size requires ``allow_non_recommended_settings=True``, an encoder
+that supports variable input, and a size divisible by the model's patch
+geometry; the exact requested square then reaches the encoder with
+normalization only.
 
 
 Tissue Segmentation
@@ -140,36 +97,33 @@ Annotation-Aware Sampling
 -------------------------
 
 By default ``slide2vec`` tiles tissue: the ``masks`` vocabulary is the binary
-``{background: 0, tissue: 1}``, and embeddings cover every tissue tile. You can
-instead restrict tiling **and** feature extraction to specific annotated classes
-(tumor-only, stroma-only, …) by customizing the ``masks`` block. Any divergence
+``{background: 0, tissue: 1}``, and embeddings cover every tissue tile. To
+restrict tiling and feature extraction to specific annotated classes
+(tumor-only, stroma-only, …), customize the ``masks`` block. Any divergence
 from the default vocabulary opts the run into annotation-aware sampling; the
-plain tissue path is otherwise byte-for-byte unchanged.
+plain tissue path is otherwise unchanged.
 
-In annotation mode the per-slide ``mask_path`` is read as a **multi-label
-raster**: each class occupies a distinct integer pixel value. The ``masks`` block
-maps that vocabulary and is deep-merged over the default, so you only state what
-you add:
+In annotation mode the per-slide ``mask_path`` (argument or manifest column) is
+**required** and is read as a multi-label raster: each class occupies a
+distinct integer pixel value. The ``masks`` block maps that vocabulary and is
+deep-merged over the default, so you only state what you add:
 
-- ``pixel_mapping`` — ``{class_name: integer pixel value in the raster}``. Values
-  must be distinct integers in ``[0, 255]``; ``merged`` is reserved for structural
-  merged output and cannot be used as a class name.
+- ``pixel_mapping`` — ``{class_name: integer pixel value}``. Values must be
+  distinct integers in ``[0, 255]``; ``merged`` is a reserved name.
 - ``min_coverage`` — ``{class_name: float | null}``; the minimum fraction of a
-  tile that must be covered by that class to keep it. ``null`` means *don't
-  sample that class*. The ``tissue`` entry is the single source of truth for the
-  tissue threshold.
+  tile covered by that class to keep it. ``null`` means *don't sample that
+  class*. The ``tissue`` entry is the single source of truth for the tissue
+  threshold.
 - ``colors`` — ``{class_name: [r, g, b] | null}`` used when rendering previews.
 - ``output_mode`` — ``per_annotation`` (one artifact set per sampled class) or
   ``merged`` (one set per slide over the union of tiles passing any class).
-- ``independent_sampling`` (a top-level ``tiling`` flag, exposed on
-  :class:`~slide2vec.PreprocessingConfig`) — ``True`` samples each class against
-  its own mask; ``False`` samples once over the union, then post-filters per
-  class by coverage.
+- ``independent_sampling`` (a top-level flag on
+  :class:`~slide2vec.PreprocessingConfig`) — ``True`` samples each class
+  against its own mask; ``False`` samples once over the union, then
+  post-filters per class by coverage.
 
-**Tumor-only bag features.** Add a ``tumor`` class, set its ``min_coverage``, and
-disable tissue sampling with ``min_coverage.tissue: null``. Only ``tumor`` tiles
-are sampled, so the returned :class:`~slide2vec.EmbeddedSlide` carries the
-tumor-only bag directly:
+**Tumor-only bag features.** Add a ``tumor`` class, set its ``min_coverage``,
+and disable tissue sampling with ``min_coverage.tissue: null``:
 
 .. code-block:: python
 
@@ -195,21 +149,13 @@ tumor-only bag directly:
    assert embedded.annotation == "tumor"  # every bag is stamped with its label
    tumor_bag = embedded.tile_embeddings   # shape (N_tumor, D) — tumor tiles only
 
-Because this run produces exactly one bag, bare ``embed_slide(...)`` returns that
-single :class:`~slide2vec.EmbeddedSlide` directly. You can also name the class
-explicitly with the ``annotation`` selector — ``embed_slide(..., annotation="tumor")``
-returns the same single bag, and requesting a class the run did not produce
-raises a ``ValueError`` listing the available bags.
+Because this run produces exactly one bag, bare ``embed_slide(...)`` returns it
+directly. Requesting a class the run did not produce raises a ``ValueError``
+listing the available bags.
 
-The ``mask_path`` argument (or the ``mask_path`` column in a manifest) is
-**required** in annotation mode — it is the raster the class vocabulary indexes
-into.
-
-**Multiple classes per slide.** To extract several classes in one run, give each
-its own ``min_coverage`` and use a :class:`~slide2vec.Pipeline` so the per-class
-artifacts are persisted and namespaced on disk under a ``<class>/`` subdirectory
-(e.g. ``tile_embeddings/tumor/<sample_id>.pt`` and
-``tile_embeddings/stroma/<sample_id>.pt``):
+**Multiple classes per slide.** Give each class its own ``min_coverage`` and
+use a :class:`~slide2vec.Pipeline` so per-class artifacts are persisted under a
+``<class>/`` subdirectory (e.g. ``tile_embeddings/tumor/<sample_id>.pt``):
 
 .. code-block:: python
 
@@ -232,23 +178,15 @@ artifacts are persisted and namespaced on disk under a ``<class>/`` subdirectory
    result = pipeline.run(manifest_path="/path/to/slides.csv")
 
 This fans out per ``(sample_id, annotation)`` across tile, slide, and
-hierarchical embeddings — and across multiple GPUs — recording each class's own
+hierarchical embeddings — and across GPUs — recording each class's own
 ``feature_path`` in ``process_list.csv``. See :doc:`output-layout` for the
 namespaced directory structure.
 
-**The** ``merged`` **output mode.** With ``masks={"output_mode": "merged"}`` the
-run does not fan out per class: it samples the union of tiles passing any class
-and produces **one bag per slide**. That bag is labelled ``"merged"`` rather than
-a class name — its :attr:`~slide2vec.EmbeddedSlide.annotation` is ``"merged"``,
-the inner ``embed_slides`` key is ``"merged"``, and on disk it lands at the flat
-output root (``tile_embeddings/<sample_id>.pt``) with **no** ``<class>/``
-subdirectory, exactly like the default ``tissue`` case:
-
-In hs2p 4.4 artifacts this structural output is represented as
-``annotation=None`` plus ``output_mode="merged"``. The human-readable
-``process_list.csv`` row and in-memory bag label remain ``"merged"``; slide2vec
-keeps those process and artifact identities separate so resume and distributed
-coordination continue to use the flat structural path.
+**The** ``merged`` **output mode.** With ``masks={"output_mode": "merged"}``
+the run does not fan out per class: it samples the union of tiles passing any
+class and produces one bag per slide, labelled ``"merged"``. On disk it lands
+at the flat output root (``tile_embeddings/<sample_id>.pt``) with no
+``<class>/`` subdirectory, exactly like the default ``tissue`` case:
 
 .. code-block:: python
 
@@ -260,18 +198,12 @@ coordination continue to use the flat structural path.
    merged = model.embed_slide(slide, ...)      # output_mode "merged"
    assert merged.annotation == "merged"
 
-A named class (``"tumor"``) is keyed by its class name and namespaced under
-``<class>/`` on disk; the ``"merged"`` and ``"tissue"`` labels are keyed by that
-label and sit at the flat root.
-
-To work with several classes **in memory** instead of on disk, call
-``embed_slides`` (not ``embed_slide``). It returns a **nested mapping**,
-``{sample_id: {label: EmbeddedSlide}}`` — the outer key is the ``sample_id`` and
-the inner key is each bag's informative annotation label (a class name,
-``"tissue"``, or ``"merged"``; never ``None``). Every
+**Working with several classes in memory.** Call ``embed_slides`` (not
+``embed_slide``). It returns a nested mapping ``{sample_id: {label:
+EmbeddedSlide}}`` where the inner key is each bag's annotation label (a class
+name, ``"tissue"``, or ``"merged"``; never ``None``). Every
 :class:`~slide2vec.EmbeddedSlide` is also stamped with its
-:attr:`~slide2vec.EmbeddedSlide.annotation`, so you can tell the bags apart by
-inner key *or* by attribute:
+:attr:`~slide2vec.EmbeddedSlide.annotation`:
 
 .. code-block:: python
 
@@ -282,12 +214,8 @@ inner key *or* by attribute:
        preprocessing=preprocessing,   # masks with tumor + stroma, as above
    )
 
-   # Index straight in by slide, then by class.
    tumor_bag = results["slide-1"]["tumor"].tile_embeddings    # shape (N_tumor, D)
    stroma_bag = results["slide-1"]["stroma"].tile_embeddings  # shape (N_stroma, D)
-
-   assert results["slide-1"]["tumor"].annotation == "tumor"
-   assert results["slide-1"]["stroma"].annotation == "stroma"
 
 Pass ``annotations=[...]`` to restrict the inner keys to the classes you care
 about; omit it to receive every bag the run produced:
@@ -298,31 +226,29 @@ about; omit it to receive every bag the run produced:
    results["slide-1"].keys()  # dict_keys(['tumor']) — stroma is dropped
 
 **Selecting bags with** ``embed_slide``. ``embed_slide`` returns one bag (or a
-list of bags) for a single slide via the same ``annotation`` selector:
+list of bags) for a single slide via the ``annotation`` selector:
 
 .. code-block:: python
 
    # One class → one EmbeddedSlide.
    tumor = model.embed_slide(slide, annotation="tumor")
-   assert tumor.annotation == "tumor"
 
    # A list of classes → a list of EmbeddedSlide in the requested order.
    tumor, stroma = model.embed_slide(slide, annotation=["tumor", "stroma"])
-   assert [b.annotation for b in (tumor, stroma)] == ["tumor", "stroma"]
 
-Bare ``embed_slide(slide)`` (no ``annotation``) returns the single bag when the
-run produced exactly one; if the run fanned the slide out into several bags it
-raises a ``ValueError`` naming the available bags and directing you to
-``embed_slides``, so per-class results are never silently dropped.
+Bare ``embed_slide(slide)`` returns the single bag when the run produced
+exactly one; if the run fanned out into several bags it raises a ``ValueError``
+naming the available bags and directing you to ``embed_slides``, so per-class
+results are never silently dropped.
 
 
 Preview Images
 --------------
 
-``slide2vec`` can write a tissue mask preview and a tiling preview for each slide.
-These are particularly useful for quality control.
-Both are enabled by default. The ``preview`` dict is a partial override, so this
-disables only the tiling preview:
+``slide2vec`` can write a tissue mask preview and a tiling preview for each
+slide — useful for quality control. Both are enabled by default. The
+``preview`` dict is a partial override, so this disables only the tiling
+preview:
 
 .. code-block:: python
 
@@ -339,5 +265,4 @@ recorded in ``process_list.csv`` and on the returned
 ``tiling_preview_path``).
 
 When resuming a run, existing preview paths are preserved in
-``process_list.csv`` for unchanged successful tiling artifacts if the preview
-files still exist on disk.
+``process_list.csv`` if the preview files still exist on disk.


### PR DESCRIPTION
## Summary

Applies a strict inclusion bar across the documentation site: keep only information that changes what the user does — commands, required arguments, tensor shapes, file schemas. Everything else goes: licenses, citations, model provenance, design rationale, internal write mechanics, and per-model caveats whose violation already raises a clear error.

The four heaviest pages go from ~9.1k to ~4.8k words; `models.rst` alone drops from ~3.2k to ~1.1k.

## Changes

**models**
- Drop the citations ("Notes") column from all three preset tables; the model link carries authorship and terms.
- Delete the iSight and PRISM2 sections entirely — model-specific details live in the upstream model cards.
- Fold `dinov2-vitb14` into the main tile table and drop the "natural-image control" prose.
- Replace the dense/attention preset enumerations and quirk bullets with a pointer at `resolve_encoder_capabilities()`.
- Add a short generic "Installation extras" note (`slide2vec[<preset>]`, pin-isolated extras, gated repos need `hf auth login`).
- Keep the plugin how-to (layout, code, install, diagnostics); drop the trust essay.

**api**
- Compress given-geometry, source-spacing, target-size, and variable-input prose to one actionable line each.
- Drop the SDPA/eager implementation note; resume prose becomes "re-issue the same call".
- Keep all code examples, tensor shapes, the attention channel-order contract, and `kit.geometry`.

**preprocessing**
- Pooled Tile Geometry reduced to the three sidecar field names plus the `allow_non_recommended_settings` rule.
- Drop the declared/given regime explanation, the legacy-embeddings note, and the turbojpeg paragraph.

**output layout**
- Keep all directory trees, shape tables, and sidecar JSON examples.
- Drop atomicity/sidecar-last mechanics and the compatibility field enumeration; spacing glosses point at the glossary.

**README**
- Point documentation links at the published site; the previous links targeted nonexistent `docs/*.md` files.

## Notes

- Sphinx build passes with no new warnings.
- Follow-up (code, not docs): missing-extra error messages are inconsistent — `moozy` tells you to install `slide2vec[moozy]`, other presets don't. The docs now lean on those errors, so aligning them is worth a small issue.