### PR TITLE
Require hs2p 4.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.1",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -100,7 +100,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.1",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/tests/test_hs2p_package_cutover.py
+++ b/tests/test_hs2p_package_cutover.py
@@ -23,7 +23,7 @@ def test_package_root_exports_api():
     assert hasattr(package, "DenseRegionArtifact")
 
 
-def test_dependency_declarations_require_hs2p_4_4_1_with_consistent_extras():
+def test_dependency_declarations_require_hs2p_4_4_2_with_consistent_extras():
     project = tomllib.loads(
         (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
             encoding="utf-8"
@@ -39,8 +39,8 @@ def test_dependency_declarations_require_hs2p_4_4_1_with_consistent_extras():
     ]
 
     assert hs2p_dependencies == [
-        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.1",
-        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.1",
+        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2",
+        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2",
     ]
 
 


### PR DESCRIPTION
Aligns slide2vec with the hs2p 4.4.2 release.

## What changed upstream

hs2p 4.4.2 is a single change on top of 4.4.1 (hs2p #202, "Speed up tiling previews"):

- `draw_grid_from_coordinates` draws the grid directly on the loaded slide canvas when no annotation overlay is requested, instead of cropping and re-pasting every tile. The overlay path is unchanged.
- The preview stage runs in up to `speed.num_workers` spawned processes rather than threads; a single worker renders inline to avoid spawn and backend re-import overhead.
- Grid lines are now complete: the previous per-tile paste erased the shared edge of already-drawn neighbours when tiles did not fall on whole preview pixels.

On dense prostatectomy slides (60k-190k tiles) this cuts the preview stage from ~19 s to ~2 s per slide with 16 workers.

## What changed here

Only the dependency floor. No public hs2p API changed, so slide2vec needs no code adaptation:

- `tile_slides` keeps its signature; only hs2p-internal executor selection was touched.
- The `preview.started` / `preview.progress` / `preview.finished` event contract consumed by `slide2vec/progress.py` is intact.
- slide2vec already forwards `num_preprocessing_workers`, so the process-parallel preview stage applies without further wiring.

The `hs2p 4.4.1` mentions in `slide2vec/runtime/image_specs.py` and `docs/release-notes/5.6.0.rst` are left as-is: they state which version introduced the flat-raster PIL reader and remain accurate. Docker and CI images resolve hs2p from `pyproject.toml`, so there is no second pin to update.

## Test plan

- [x] `pytest tests/test_hs2p_package_cutover.py` — 18 passed