### PR TITLE
Cast tile features to fp32 for slide encoders

### DIFF
--- a/slide2vec/encoders/models/gigapath.py
+++ b/slide2vec/encoders/models/gigapath.py
@@ -123,6 +123,9 @@ class GigaPathSlideEncoder(SlideEncoder):
             tile_features = tile_features.unsqueeze(0)
         if coordinates.ndim == 2:
             coordinates = coordinates.unsqueeze(0)
+        # prov-gigapath's reference usage feeds fp32 tile embeddings under autocast;
+        # fp16 input risks dtype mismatches in ops autocast does not cover.
+        tile_features = tile_features.float()
         # gigapath_slide_enc12l768d.forward always returns a list of per-layer
         # embeddings (a single element when all_layer_embed is False); the final
         # slide embedding is the last layer, matching prov-gigapath's own usage.

--- a/slide2vec/encoders/models/titan.py
+++ b/slide2vec/encoders/models/titan.py
@@ -51,6 +51,9 @@ class TitanSlideEncoder(SlideEncoder):
             tile_features = tile_features.unsqueeze(0)
         if coordinates.ndim == 2:
             coordinates = coordinates.unsqueeze(0)
+        # TITAN's remote code index_add_s features into an fp32 grid and crashes on
+        # fp16 input; its reference usage is fp32 features under autocast.
+        tile_features = tile_features.float()
         return self._model.encode_slide_from_patch_features(
             tile_features,
             coordinates.long(),

--- a/tests/test_titan.py
+++ b/tests/test_titan.py
@@ -1,0 +1,38 @@
+"""Regression tests for the TITAN slide encoder input contract."""
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+class _FakeTitan:
+    """Mirrors TITAN's preprocess_features: index_add_ of the input into an fp32
+    grid, which raises on fp16 features."""
+
+    def eval(self):
+        return self
+
+    def encode_slide_from_patch_features(self, patch_features, patch_coords, patch_size_lv0):
+        grid = torch.zeros(4, patch_features.size(-1))
+        indices = torch.zeros(patch_features.size(1), dtype=torch.long)
+        grid.index_add_(0, indices, patch_features.squeeze(0))
+        return torch.zeros(1, 768)
+
+
+def test_titan_encode_slide_accepts_fp16_features(monkeypatch):
+    import slide2vec.encoders.models.titan as titan_mod
+
+    monkeypatch.setattr(
+        titan_mod,
+        "AutoModel",
+        SimpleNamespace(from_pretrained=lambda *args, **kwargs: _FakeTitan()),
+    )
+    encoder = titan_mod.TitanSlideEncoder()
+
+    features = torch.randn(5, 768, dtype=torch.float16)
+    coordinates = torch.zeros(5, 2, dtype=torch.int64)
+    embedding = encoder.encode_slide(features, coordinates, tile_size_lv0=512)
+
+    assert embedding.shape[-1] == 768


### PR DESCRIPTION
## Problem

TITAN slide encoding crashes on every input:

```
RuntimeError: index_add_(): self (Float) and source (Half) must have the same scalar type
```

The titan preset sets `precision="fp16"`, so cached conchv15 tile features are `torch.float16`. `TitanSlideEncoder.encode_slide` passes them uncast to TITAN's remote code, whose `preprocess_features` does `index_add_` into an fp32 feature grid — an op autocast does not cover. This took down the fewnicorn task 3 extraction run (fp16 tile features from the cache → all four aggregation workers dead on their first slide).

## Fix

Cast `tile_features` to fp32 in `encode_slide` before handing them to the model, for both TITAN and GigaPath. This matches both models' reference usage — fp32 features under fp16 autocast — so embeddings are unchanged from intended behavior. GigaPath doesn't crash today but has the same input-dtype exposure (fp16 preset, ops outside autocast coverage), so it gets the same cast.

## Test

`tests/test_titan.py` uses a fake TITAN model that mirrors the remote code's fp32-grid `index_add_` (raises on Half input) and feeds fp16 features through `encode_slide`. Fails without the cast, passes with it.