### PR TITLE
Skip huggingface_hub.login() in load_model

### DIFF
--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -126,13 +126,15 @@ def load_model(
     info = encoder_registry.info(name)
     resolved_level = info["level"]
 
-    if token is None and "HF_TOKEN" in os.environ:
-        token = os.environ["HF_TOKEN"]
-
+    # Never call ``huggingface_hub.login()`` here. Every encoder resolves its auth
+    # through the process-global ``huggingface_hub.get_token()``, which reads
+    # ``HF_TOKEN`` from the environment ahead of any stored token file, so an
+    # exported ``HF_TOKEN`` is all the hub needs. ``login()`` additionally rewrites a
+    # shared ``stored_tokens`` file without a lock; under distributed extraction every
+    # rank re-runs load_model per chunk and the concurrent truncate/re-read races,
+    # crashing runs with ``ValueError: Token ... not found``.
     if token is not None:
-        from huggingface_hub import login as hf_login
-
-        hf_login(token=token, add_to_git_credential=False)
+        os.environ["HF_TOKEN"] = token
 
     encoder_cls = encoder_registry.require(name)
     # Pass allow_non_recommended_settings ONLY to encoders whose constructor accepts it

--- a/tests/test_load_model_hf_auth.py
+++ b/tests/test_load_model_hf_auth.py
@@ -1,0 +1,113 @@
+"""``load_model`` must never call ``huggingface_hub.login()``.
+
+Under distributed extraction every rank re-runs ``load_model`` per chunk. ``login()``
+truncates and re-reads a shared ``stored_tokens`` file with no lock, so concurrent
+ranks race and crash with ``ValueError: Token ... not found``. The login was also
+redundant: ``huggingface_hub.get_token()`` resolves ``HF_TOKEN`` from the environment
+ahead of any stored file, which is the only thing the encoders rely on.
+"""
+
+from __future__ import annotations
+
+import os
+
+import huggingface_hub
+import pytest
+import torch
+from huggingface_hub import constants as hf_constants
+from torchvision.transforms import v2
+
+import slide2vec.inference as inference
+from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+
+class _StandInTileEncoder:
+    """A patch-14 tile encoder that loads no weights and touches no network."""
+
+    def __init__(self, *, output_variant=None):
+        self.device = torch.device("cpu")
+        self.encode_dim = 8
+
+    @property
+    def patch_size(self):
+        return (14, 14)
+
+    def get_transform(self):
+        return v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])
+
+    def to(self, device):
+        self.device = torch.device(device)
+        return self
+
+
+@pytest.fixture
+def hf_auth_sandbox(monkeypatch, tmp_path):
+    """Stub the encoder registry and point the hub's token files at a tmp dir.
+
+    Returns the sandboxed ``stored_tokens`` path. ``HF_TOKEN`` starts unset.
+    """
+    monkeypatch.setattr(inference.encoder_registry, "require", lambda name: _StandInTileEncoder)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+
+    token_path = tmp_path / "token"
+    stored_tokens_path = tmp_path / "stored_tokens"
+    monkeypatch.setenv("HF_TOKEN_PATH", str(token_path))
+    monkeypatch.setenv("HF_STORED_TOKENS_PATH", str(stored_tokens_path))
+    # ``huggingface_hub.constants`` reads those env vars at import time, so repoint the
+    # already-imported module constants too.
+    monkeypatch.setattr(hf_constants, "HF_TOKEN_PATH", str(token_path))
+    monkeypatch.setattr(hf_constants, "HF_STORED_TOKENS_PATH", str(stored_tokens_path))
+    return stored_tokens_path
+
+
+@pytest.fixture
+def login_calls(hf_auth_sandbox, monkeypatch):
+    """Replace ``huggingface_hub.login`` with a recorder; returns the call list."""
+    calls: list[dict] = []
+
+    def _record_login(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(huggingface_hub, "login", _record_login)
+    return calls
+
+
+def _load_stand_in(**kwargs):
+    return inference.load_model(
+        name="virchow2", encoder_input=EncoderInputContract.given(), device="cpu", **kwargs
+    )
+
+
+def test_load_model_with_hf_token_env_never_logs_in(login_calls, monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "hf_from_env")
+
+    _load_stand_in()
+
+    assert login_calls == []
+    assert huggingface_hub.get_token() == "hf_from_env"
+
+
+def test_load_model_with_explicit_token_exports_it_without_logging_in(login_calls):
+    _load_stand_in(token="hf_explicit")
+
+    assert login_calls == []
+    assert os.environ["HF_TOKEN"] == "hf_explicit"
+    assert huggingface_hub.get_token() == "hf_explicit"
+
+
+def test_repeated_load_model_calls_leave_no_stored_tokens_file(hf_auth_sandbox, monkeypatch):
+    """Nothing touches disk: neither ``HF_TOKEN`` nor ``token=`` writes a token file.
+
+    Uses the real ``huggingface_hub.login`` so a regression that reintroduces the call
+    would actually write the sandboxed ``stored_tokens``.
+    """
+    stored_tokens_path = hf_auth_sandbox
+    monkeypatch.setenv("HF_TOKEN", "hf_from_env")
+
+    for _ in range(3):
+        _load_stand_in()
+    for _ in range(3):
+        _load_stand_in(token="hf_explicit")
+
+    assert not stored_tokens_path.exists()
+    assert not (stored_tokens_path.parent / "token").exists()


### PR DESCRIPTION
## Summary

`load_model` called `huggingface_hub.login()` on every model load. Under distributed extraction every rank re-runs it per chunk, and `login()` truncates and re-reads the shared `stored_tokens` file without a lock, so concurrent ranks race and die with `ValueError: Token ... not found`. The call was redundant: `huggingface_hub.get_token()` resolves `HF_TOKEN` from the environment ahead of any stored file, and no encoder takes a token argument.

`load_model` now exports an explicit `token=` as `HF_TOKEN` for the process and otherwise leaves the environment alone. Nothing touches disk.

## Acceptance criteria

- [x] `load_model` never calls `huggingface_hub.login()`, whether the token came from `HF_TOKEN` or from the `token=` argument.
- [x] An explicitly passed `token=` argument is exported as `HF_TOKEN` for the process before the encoder is constructed, so `huggingface_hub.get_token()` returns it and gated weights still authenticate.
- [x] A unit test stubs the encoder registry and `huggingface_hub.login`, calls `load_model` with `HF_TOKEN` set and again with `token=` set, and asserts `login` is never called and `get_token()` resolves the expected value. No network, no real weights.
- [x] Repeated `load_model` calls in one process leave no `stored_tokens` file behind (asserted against `HF_TOKEN_PATH` / `HF_STORED_TOKENS_PATH` pointed at a tmp dir).

## Tests

`tests/test_load_model_hf_auth.py` (3 new tests) plus the full `-m "not heavy and not gpu_integration"` suite.

Closes #307
