### PR TITLE
Remove redundant code and low-value tests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(ROOT))
 project = "slide2vec"
 author = "Clément Grisi"
 copyright = "2026, Clément Grisi"
-release = "4.2.0"
+release = "5.8.2"
 
 extensions = [
     "myst_parser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ testpaths = [
     "tests",
 ]
 markers = [
-    "heavy: real-weight foundation-model inference on CPU; minutes per test. Excluded from the PR suite via `-m 'not heavy'`; run on the scheduled/manual heavy workflow (.github/workflows/nightly-heavy.yaml).",
+    "heavy: real-weight foundation-model inference on CPU; minutes per test. Included in the PR suite and available separately through the manual heavy workflow (.github/workflows/nightly-heavy.yaml).",
     "gpu_integration: real one-GPU versus multi-GPU parity; requires at least two visible CUDA devices. Run explicitly with `CUDA_VISIBLE_DEVICES=0,1 python -m pytest -m gpu_integration --no-cov`.",
 ]
 
@@ -182,12 +182,13 @@ max-line-length = 160
 [tool.bumpver]
 current_version = "5.8.2"
 version_pattern = "MAJOR.MINOR.PATCH"
-commit = false       # We do version bumping in CI, not as a commit
-tag = false          # Git tag already exists — we don't auto-tag
-push = false         # Don't push anything in CI
+commit = false
+tag = false
+push = false
 files = [
     "pyproject.toml",
-    "slide2vec/__init__.py"
+    "slide2vec/__init__.py",
+    "docs/conf.py",
 ]
 
 [tool.bumpver.file_patterns]
@@ -197,4 +198,7 @@ files = [
 ]
 "slide2vec/__init__.py" = [
     '^__version__ = "{version}"$',
+]
+"docs/conf.py" = [
+    '^release = "{version}"$',
 ]

--- a/release.py
+++ b/release.py
@@ -11,10 +11,6 @@ def release_branch(version: str) -> str:
     return f"release-{version}"
 
 
-def release_tag(version: str) -> str:
-    return version
-
-
 def get_current_version() -> str:
     out = run("bumpver show")
     for line in out.splitlines():
@@ -43,31 +39,9 @@ def commit_bump(version: str) -> None:
 def push_branch_and_tag(branch: str, version: str) -> None:
     run(f"git push origin {branch}")
 
-    tag = release_tag(version)
-    print(f"🏷️ Creating and pushing tag {tag}...")
-    run(f"git tag {tag}")
-    run(f"git push origin {tag}")
-
-
-def push_tag_and_branch(version: str) -> str:
-    branch = release_branch(version)
-    tag = release_tag(version)
-
-    print(f"🌿 Creating branch {branch}...")
-    run(f"git checkout -b {branch}")
-    run(f"git push origin {branch}")
-
-    print(f"🏷️ Creating tag {tag}...")
-    # Check if tag already exists
-    existing_tags = run("git tag")
-    if tag not in existing_tags.split():
-        run(f"git tag {tag}")
-    else:
-        print(f"✅ Tag {tag} already exists.")
-
-    run(f"git push origin {tag}")
-
-    return branch
+    print(f"🏷️ Creating and pushing tag {version}...")
+    run(f"git tag {version}")
+    run(f"git push origin {version}")
 
 
 def create_pull_request(branch: str, version: str) -> None:
@@ -99,9 +73,8 @@ if __name__ == "__main__":
     parser.add_argument("--no-draft", action="store_true", help="Don't open GitHub release page")
     args = parser.parse_args()
 
-    # always start from main branch
     run("git checkout main")
-    run("git pull origin main")  # make sure it's up-to-date
+    run("git pull origin main")
 
     version = bump_version(args.level)
     branch = release_branch(version)
@@ -114,6 +87,6 @@ if __name__ == "__main__":
         create_pull_request(branch, version)
 
     if not args.no_draft:
-        open_release_draft(release_tag(version))
+        open_release_draft(version)
 
     print(f"\n✅ Release flow completed for version {version}!")

--- a/scripts/generate_gt.py
+++ b/scripts/generate_gt.py
@@ -98,19 +98,15 @@ def main():
             check=True,
         )
 
-        # Copy slide embedding
         slide_emb_src = tmp_path / "slide_embeddings" / "test-wsi.pt"
         shutil.copyfile(slide_emb_src, output_dir / "test-wsi.pt")
         print(f"Saved slide embedding: {output_dir / 'test-wsi.pt'}")
 
-        # Copy tile embeddings
         tile_emb_src = tmp_path / "tile_embeddings" / "test-wsi.pt"
         tile_emb = torch.load(tile_emb_src, map_location="cpu", weights_only=True)
         torch.save(tile_emb, output_dir / "test-wsi.tiles.pt")
         print(f"Saved tile embeddings: {output_dir / 'test-wsi.tiles.pt'} — shape {tuple(tile_emb.shape)}")
 
-        # Copy coordinates
-        import numpy as np
         coords_src = tmp_path / "tiles" / "test-wsi.coordinates.npz"
         shutil.copyfile(coords_src, output_dir / "test-wsi.coordinates.npz")
         print(f"Saved coordinates: {output_dir / 'test-wsi.coordinates.npz'}")

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -128,15 +128,12 @@ def resolve_masks(masks: Mapping[str, Any] | None) -> dict[str, Any]:
 
 def _masks_to_plain_dict(node: Any) -> dict[str, Any]:
     """Normalize a masks config node (OmegaConf, mapping, or namespace) to a plain dict."""
+    from omegaconf import OmegaConf
+
     if node is None:
         return {}
-    try:
-        from omegaconf import OmegaConf
-
-        if OmegaConf.is_config(node):
-            return copy.deepcopy(OmegaConf.to_container(node, resolve=True))  # type: ignore[return-value]
-    except ImportError:
-        pass
+    if OmegaConf.is_config(node):
+        return copy.deepcopy(OmegaConf.to_container(node, resolve=True))  # type: ignore[return-value]
     if isinstance(node, Mapping):
         return copy.deepcopy(dict(node))
     return copy.deepcopy(dict(vars(node)))
@@ -243,7 +240,6 @@ class PreprocessingConfig:
             "preview",
             _deep_merge_dicts(DEFAULT_PREPROCESSING["preview"], self.preview),
         )
-        # Complete a (possibly partial) masks mapping against the shipped default.
         object.__setattr__(self, "masks", resolve_masks(self.masks))
 
     @classmethod

--- a/slide2vec/data/tile_reader.py
+++ b/slide2vec/data/tile_reader.py
@@ -52,7 +52,6 @@ def _open_wsi_backend(image_path: str, backend: str, gpu_decode: bool):
         return VIPSReader(image_path)
     elif backend == "asap":
         from hs2p.wsi.backends.asap import ASAPReader
-        from slide2vec.utils.log_utils import suppress_c_stderr
         with suppress_c_stderr():
             return ASAPReader(image_path)
     else:

--- a/slide2vec/distributed/__init__.py
+++ b/slide2vec/distributed/__init__.py
@@ -133,7 +133,6 @@ class _TorchDistributedEnvironment:
 
     # Single node job with preset environment (i.e. torchrun)
     def _set_from_preset_env(self):
-        # logger.info("Initialization from preset environment")
         self.rank = int(os.environ["RANK"])
         self.world_size = int(os.environ["WORLD_SIZE"])
         assert self.rank < self.world_size
@@ -143,7 +142,6 @@ class _TorchDistributedEnvironment:
 
     # Single node and GPU job (i.e. local script run)
     def _set_from_local(self):
-        # logger.info("Initialization from local")
         self.rank = 0
         self.world_size = 1
         self.local_rank = 0
@@ -196,7 +194,6 @@ def enable(
     if set_cuda_current_device:
         torch.cuda.set_device(torch_env.local_rank)
 
-    # Finalize setup
     _RANK = torch_env.rank
     _WORLD_SIZE = torch_env.world_size
     _LOCAL_RANK = torch_env.local_rank

--- a/slide2vec/encoders/models/gigapath.py
+++ b/slide2vec/encoders/models/gigapath.py
@@ -48,13 +48,8 @@ class GigaPath(TimmTileEncoder):
         )
 
     def get_transform(self) -> Callable:
-        # POOLED transform only: center-crops the 256px tile to the model's 224px
-        # native input (paper recipe, center 224 @ native 0.5 mpp). Dense extraction
-        # must NOT route through this — it needs the full uncropped tile so the grid
-        # covers the whole source tile. The dense path supplies its own no-crop
-        # transform (Resize(256), no CenterCrop) → a 16x16 grid over the full tile;
-        # encode_tiles_dense itself is transform-agnostic (inherited from
-        # TimmTileEncoder) and operates on whatever batch the dense pipeline feeds.
+        # Pooled recipe: center 224px at native spacing. Dense extraction uses
+        # get_normalization_transform() to preserve the caller's tile geometry.
         return v2.Compose([
             v2.ToImage(),
             v2.Resize(256, interpolation=v2.InterpolationMode.BICUBIC, antialias=True),

--- a/slide2vec/encoders/models/moozy/slide.py
+++ b/slide2vec/encoders/models/moozy/slide.py
@@ -50,7 +50,7 @@ class MOOZYSlideEncoder(nn.Module):
                     dropout=dropout,
                     attn_dropout=attn_dropout,
                     alibi=self.pos_bias,
-                    drop_path_rate=dpr[i] if i < len(dpr) else 0.0,
+                    drop_path_rate=dpr[i],
                     qk_norm=qk_norm,
                     layerscale_init=layerscale_init,
                 )
@@ -109,26 +109,18 @@ class MOOZYSlideEncoder(nn.Module):
         x = torch.cat(tokens, dim=1)
 
         coords_xy = coords_xy.to(device=x.device, dtype=torch.float32).reshape(bsz, n_tokens, 2)
-        zeros_cls = torch.zeros(bsz, 1, 2, dtype=coords_xy.dtype, device=coords_xy.device)
-        if self.num_registers > 0:
-            zeros_reg = torch.zeros(bsz, self.num_registers, 2, dtype=coords_xy.dtype, device=coords_xy.device)
-            positions = torch.cat([zeros_cls, zeros_reg, coords_xy], dim=1)
-        else:
-            positions = torch.cat([zeros_cls, coords_xy], dim=1)
-
-        valid_flat = ~invalid_flat
-        reg_valid = (
-            torch.ones(bsz, self.num_registers, dtype=torch.bool, device=x.device)
-            if self.num_registers > 0
-            else torch.zeros(bsz, 0, dtype=torch.bool, device=x.device)
+        num_prefix = 1 + self.num_registers
+        prefix_positions = torch.zeros(
+            bsz, num_prefix, 2, dtype=coords_xy.dtype, device=coords_xy.device
         )
-        valid_with_cls = torch.cat([torch.ones(bsz, 1, dtype=torch.bool, device=x.device), reg_valid, valid_flat], dim=1)
+        positions = torch.cat([prefix_positions, coords_xy], dim=1)
+        prefix_valid = torch.ones(bsz, num_prefix, dtype=torch.bool, device=x.device)
+        valid_with_cls = torch.cat([prefix_valid, ~invalid_flat], dim=1)
 
         if mask is None and bsz == 1:
             keep = valid_with_cls[0]
-            if keep.sum() > 0:
-                x = x[:, keep, :]
-                positions = positions[:, keep, :]
+            x = x[:, keep, :]
+            positions = positions[:, keep, :]
             attn_mask = None
         else:
             pair_valid = valid_with_cls.unsqueeze(2) & valid_with_cls.unsqueeze(1)

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -1,26 +1,14 @@
-import json
-import importlib
 import os
-import tempfile
-import threading
-import time
-from contextlib import contextmanager, nullcontext
-from dataclasses import replace
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, Callable, Sequence
 
-import logging
-import pandas as pd
 import torch
-from hs2p import SlideSpec, tile_slides
-from hs2p.utils.stderr import run_with_filtered_stderr
+from hs2p import SlideSpec
 
 from slide2vec.runtime import (
     artifacts_collect,
     batching,
     cpu_budget,
-    distributed,
     distributed_stage,
     embedding,
     embedding_persist,
@@ -31,11 +19,9 @@ from slide2vec.runtime import (
     persist_callbacks,
     persistence,
     process_list,
-    serialization,
     slide_encode,
     tiling,
     tiling_pipeline,
-    worker_io,
 )
 from slide2vec.api import (
     EmbeddedPatient,
@@ -43,43 +29,21 @@ from slide2vec.api import (
     ExecutionOptions,
     PreprocessingConfig,
     RunResult,
-    _resolve_hierarchical_preprocessing,
 )
 from slide2vec.artifacts import (
     HierarchicalEmbeddingArtifact,
-    PatientEmbeddingArtifact,
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
-    write_hierarchical_embeddings,
     load_array,
-    write_patient_embeddings,
-    write_tile_embedding_metadata,
 )
 from slide2vec.encoders.registry import (
     encoder_registry,
-    resolve_encoder_output,
     resolve_patch_size,
-    resolve_preprocessing_defaults,
 )
 from slide2vec.runtime.model_settings import canonicalize_model_name
 from slide2vec.runtime.types import LoadedModel
 from slide2vec.runtime.encoder_input_contract import EncoderInputContract
-from slide2vec.progress import (
-    emit_progress,
-    read_tiling_progress_snapshot,
-)
-from slide2vec.utils.log_utils import suppress_c_stderr
-from slide2vec.data.dataset import BatchTileCollator, TileIndexDataset
-from slide2vec.data.tile_reader import OnTheFlyBatchTileCollator, OnTheFlyHierarchicalBatchCollator
-from slide2vec.utils.tiling_io import (
-    load_embedding_process_df,
-    load_patient_id_mapping,
-    load_slide_manifest,
-    load_tiling_process_df,
-    load_tiling_result_from_row,
-    _optional_float,
-)
-from slide2vec.utils.utils import cpu_worker_limit, slurm_cpu_limit
+from slide2vec.progress import emit_progress
 
 from slide2vec.runtime.hierarchical import num_embedding_items
 
@@ -716,11 +680,7 @@ def aggregate_tiles(
     outputs: list[SlideEmbeddingArtifact] = []
     for artifact in tile_artifacts:
         metadata = artifact.metadata
-        if "coordinates_npz_path" not in metadata or "coordinates_meta_path" not in metadata:
-            raise ValueError(
-                f"Tile artifact for {artifact.sample_id} is missing tiling metadata paths required for slide aggregation"
-            )
-        if not metadata["coordinates_npz_path"] or not metadata["coordinates_meta_path"]:
+        if not metadata.get("coordinates_npz_path") or not metadata.get("coordinates_meta_path"):
             raise ValueError(
                 f"Tile artifact for {artifact.sample_id} is missing tiling metadata paths required for slide aggregation"
             )
@@ -737,13 +697,12 @@ def aggregate_tiles(
             tiling_result,
             execution=execution,
         )
-        latents = None
         slide_artifact = embedding.write_slide_embedding_artifact(
             artifact.sample_id,
             slide_embedding,
             execution=execution,
             metadata=embedding.build_slide_embedding_metadata(model, image_path=metadata["image_path"]),
-            latents=latents,
+            latents=None,
         )
         outputs.append(slide_artifact)
     return outputs
@@ -923,9 +882,8 @@ def run_pipeline(
             execution=execution,
             process_list_path=process_list_path,
         )
-        embedded_slides: list[EmbeddedSlide] = []
         if pending_slides:
-            embedded_slides = embedding_pipeline.compute_embedded_slides(
+            embedding_pipeline.compute_embedded_slides(
                 model,
                 pending_slides,
                 pending_tiling_results,

--- a/slide2vec/runtime/artifacts_collect.py
+++ b/slide2vec/runtime/artifacts_collect.py
@@ -170,12 +170,10 @@ def collect_distributed_pipeline_artifacts(
         or include_slide_embeddings
         or persist_hierarchical_embeddings
     )
-    annotation_groups = (
-        _embeddable_annotation_groups(process_list_path) if annotation_aware else {}
-    )
     # The embedding stage must fan out per (sample_id, annotation) for every level so each class's
     # tiles are embedded independently.
     stage_annotation_groups = _embeddable_annotation_groups(process_list_path)
+    annotation_groups = stage_annotation_groups if annotation_aware else {}
     # One annotation per ``successful_slides`` entry (the tiling spine fans out per class). Carry each
     # on a lightweight placeholder so the resume gate keys by (sample_id, annotation) and the surviving
     # pending entries hand the stage the right per-class work units.
@@ -269,9 +267,6 @@ def collect_distributed_pipeline_artifacts(
         annotations=pending_annotations,
         on_progress_event=_update_process_list_for_finished_slide,
     )
-    # ``successful_slides`` is already one entry per (sample_id, annotation) row, so resolve a
-    # parallel annotations list (not an expansion) to re-read each entry's namespaced artifact.
-    annotations_for_collect = _annotations_parallel_to_slides(successful_slides, annotation_groups)
     tile_artifacts, hierarchical_artifacts, slide_artifacts = collect_pipeline_artifacts(
         successful_slides,
         output_dir=output_dir,
@@ -279,7 +274,7 @@ def collect_distributed_pipeline_artifacts(
         include_tile_embeddings=include_tile_embeddings,
         include_hierarchical_embeddings=persist_hierarchical_embeddings,
         include_slide_embeddings=include_slide_embeddings,
-        annotations=annotations_for_collect if annotation_aware else None,
+        annotations=stage_annotations if annotation_aware else None,
     )
     update_process_list_after_embedding(
         process_list_path,

--- a/slide2vec/runtime/batching.py
+++ b/slide2vec/runtime/batching.py
@@ -17,6 +17,7 @@ import torch
 
 from slide2vec.progress import emit_progress
 from slide2vec.runtime.types import LoadedModel
+from slide2vec.runtime.worker_io import uses_cuda_runtime
 from slide2vec.utils.log_utils import suppress_c_stderr
 
 from .preprocessing import (
@@ -29,17 +30,8 @@ from .preprocessing import (
 from .types import PreparedBatch
 
 
-def uses_cuda_runtime(device) -> bool:
-    return str(device).startswith("cuda") and torch.cuda.is_available()
-
-
-
 def should_suppress_cucim_dataloader_stderr(dataloader) -> bool:
-    if dataloader is None:
-        return False
     collate_fn = getattr(dataloader, "collate_fn", None)
-    if collate_fn is None:
-        return False
     return bool(getattr(collate_fn, "_suppress_cucim_stderr", False))
 
 

--- a/slide2vec/runtime/dense_sliding.py
+++ b/slide2vec/runtime/dense_sliding.py
@@ -73,11 +73,6 @@ def cover_origins(extent: int, size: int, stride: int) -> list[int]:
     return starts
 
 
-def _window_starts(extent: int, win: int, stride: int) -> list[int]:
-    """Patch-aligned encoder-window starts — the token-space use of :func:`cover_origins`."""
-    return cover_origins(extent, win, stride)
-
-
 def resolve_window_geometry(
     geometry: DenseGridGeometry, *, window_size: int | None, overlap: float
 ) -> tuple[tuple[int, int], tuple[int, int], list[int], list[int]]:
@@ -99,8 +94,8 @@ def resolve_window_geometry(
     keep = 1.0 - float(overlap)
     stride_h = min(win_h, _round_to(win_h * keep, ph))
     stride_w = min(win_w, _round_to(win_w * keep, pw))
-    starts_h = _window_starts(enc_h, win_h, stride_h)
-    starts_w = _window_starts(enc_w, win_w, stride_w)
+    starts_h = cover_origins(enc_h, win_h, stride_h)
+    starts_w = cover_origins(enc_w, win_w, stride_w)
     return (win_h, win_w), (stride_h, stride_w), starts_h, starts_w
 
 

--- a/slide2vec/runtime/model_settings.py
+++ b/slide2vec/runtime/model_settings.py
@@ -1,7 +1,4 @@
-import logging
 from typing import Any
-
-logger = logging.getLogger("slide2vec")
 
 
 PRECISION_ALIASES = {
@@ -66,8 +63,8 @@ def resolve_output_precision(output_dtype: Any, compute_precision: Any) -> str:
     """Resolve the concrete on-disk feature precision (``"fp16"`` or ``"fp32"``).
 
     ``output_dtype is None`` follows ``compute_precision``: an fp16 forward keeps fp16
-    features, while bf16 / fp32 (and an unset or unknown compute precision) widen to fp32 —
-    fp32 is bf16's lossless container and the only float dtype a numpy artifact can hold.
+    features, while bf16 / fp32 (and an unset compute precision) widen to fp32.
+    NumPy has no bfloat16 dtype, so fp32 is its lossless storage container.
     A non-null ``output_dtype`` is honored verbatim (after :func:`normalize_output_dtype`).
     This is the single source of truth shared by the pooled write path and the dense
     ``iter_regions_dense`` path.
@@ -98,4 +95,3 @@ def output_torch_dtype(precision: str):
 def canonicalize_model_name(name: str) -> str:
     normalized = name.strip().lower()
     return MODEL_NAME_ALIASES.get(normalized, normalized)
-

--- a/slide2vec/utils/log_utils.py
+++ b/slide2vec/utils/log_utils.py
@@ -7,12 +7,6 @@ import sys
 from slide2vec.progress import emit_progress_log
 
 
-def _distributed_module():
-    import slide2vec.distributed as distributed
-
-    return distributed
-
-
 @contextlib.contextmanager
 def suppress_c_stderr():
     """Temporarily redirect C-level stderr to /dev/null.
@@ -62,16 +56,17 @@ def _configure_logger(
         level: The logging level to use.
         output: A file name or a directory to save log. If None, will not save log file.
             If ends with ".txt" or ".log", assumed to be a file name.
-            Otherwise, logs will be saved to `output/log.txt`.
+            Otherwise, logs will be saved to `output/logs/log.txt`.
 
     Returns:
         The configured logger.
     """
 
+    import slide2vec.distributed as distributed
+
     logger = logging.getLogger(name)
     logger.setLevel(level)
     logger.propagate = False
-    distributed = _distributed_module()
 
     # Loosely match Google glog format:
     #   [IWEF]yyyymmdd hh:mm:ss.uuuuuu threadid file:line] msg
@@ -127,7 +122,7 @@ def setup_logging(
         output: A file name or a directory to save log files. If None, log
             files will not be saved. If output ends with ".txt" or ".log", it
             is assumed to be a file name.
-            Otherwise, logs will be saved to `output/log.txt`.
+            Otherwise, logs will be saved to `output/logs/log.txt`.
         name: The name of the logger to configure, by default the root logger.
         level: The logging level to use.
         capture_warnings: Whether warnings should be captured as logs.

--- a/slide2vec/utils/tiling_io.py
+++ b/slide2vec/utils/tiling_io.py
@@ -211,8 +211,6 @@ def _load_base_process_df(process_list_path: str | Path) -> pd.DataFrame:
         df["requested_mask_backend"] = [None] * len(df)
     if "mask_backend" not in df.columns:
         df["mask_backend"] = [None] * len(df)
-    if "annotation" not in df.columns:
-        df["annotation"] = ["tissue"] * len(df)
     reconstructed_output_mode = df["annotation"].map(
         lambda annotation: "merged" if str(annotation) == "merged" else None
     )

--- a/tests/test_architecture_runtime_split.py
+++ b/tests/test_architecture_runtime_split.py
@@ -3,20 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_root_package_python_modules_are_curated():
-    package_root = Path(__file__).resolve().parents[1] / "slide2vec"
-    root_modules = {path.name for path in package_root.glob("*.py")}
-    assert root_modules == {
-        "__init__.py",
-        "__main__.py",
-        "api.py",
-        "artifacts.py",
-        "cli.py",
-        "inference.py",
-        "progress.py",
-    }
-
-
 def test_runtime_modules_do_not_depend_on_cli_or_package_facade():
     package_root = Path(__file__).resolve().parents[1] / "slide2vec" / "runtime"
     runtime_modules = sorted(package_root.glob("*.py"))
@@ -31,30 +17,3 @@ def test_runtime_modules_do_not_depend_on_cli_or_package_facade():
         source = module_path.read_text(encoding="utf-8")
         for fragment in forbidden_fragments:
             assert fragment not in source, f"{module_path.name} should not import public CLI/facade modules"
-
-
-def test_internal_runtime_modules_stay_small():
-    package_root = Path(__file__).resolve().parents[1] / "slide2vec" / "runtime"
-    module_paths = [
-        package_root / "batching.py",
-        package_root / "distributed.py",
-        package_root / "embedding.py",
-        package_root / "hierarchical.py",
-        package_root / "model_settings.py",
-        package_root / "persistence.py",
-        package_root / "preprocessing.py",
-        package_root / "progress_bridge.py",
-        package_root / "registry.py",
-        package_root / "serialization.py",
-        package_root / "tiling.py",
-        package_root / "types.py",
-    ]
-    for module_path in module_paths:
-        line_count = len(module_path.read_text(encoding="utf-8").splitlines())
-        assert line_count <= 500, f"{module_path.name} grew beyond the workflow-module size target ({line_count} > 500)"
-
-
-def test_inference_module_is_orchestration_sized():
-    inference_path = Path(__file__).resolve().parents[1] / "slide2vec" / "inference.py"
-    line_count = len(inference_path.read_text(encoding="utf-8").splitlines())
-    assert line_count <= 3200, f"inference.py should stay below the legacy monolith size (current lines: {line_count})"

--- a/tests/test_dense_sliding.py
+++ b/tests/test_dense_sliding.py
@@ -17,7 +17,7 @@ pytest.importorskip("timm")
 from slide2vec.encoders.base import TimmTileEncoder  # noqa: E402
 from slide2vec.runtime.dense_regions import compute_dense_geometry  # noqa: E402
 from slide2vec.runtime.dense_sliding import (  # noqa: E402
-    _window_starts,
+    cover_origins,
     encode_dense_sliding,
     resolve_window_geometry,
 )
@@ -35,16 +35,13 @@ def _encoder() -> TimmTileEncoder:
 
 
 def test_window_starts_cover_and_patch_aligned():
-    starts = _window_starts(extent=64, win=32, stride=16)
+    starts = cover_origins(extent=64, size=32, stride=16)
     assert starts == [0, 16, 32]
-    assert all(s % PATCH == 0 for s in starts)
-    assert starts[-1] + 32 == 64  # last window flush to the edge
 
 
 def test_window_starts_appends_edge_window_when_stride_misses():
-    # stride 24 from 0 -> [0, 24] then last (24+32=56 < 64) appends edge 32.
-    starts = _window_starts(extent=64, win=32, stride=24)
-    assert starts[0] == 0 and starts[-1] == 32 and starts[-1] + 32 == 64
+    starts = cover_origins(extent=64, size=32, stride=24)
+    assert starts == [0, 24, 32]
 
 
 def test_resolve_window_geometry_whole_is_single_window():

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -3246,11 +3246,6 @@ def test_distributed_module_has_no_torch_distributed_dependency():
     assert "socket" not in imported
 
 
-def test_setup_distributed_helper_has_been_removed():
-    source = (ROOT / "slide2vec" / "utils" / "config.py").read_text(encoding="utf-8")
-
-    assert "def setup_distributed" not in source
-
 def test_direct_embed_slides_allows_no_output_dir_and_optional_persistence(monkeypatch, tmp_path: Path):
     import slide2vec.inference as inference
 

--- a/tests/test_soma_migration.py
+++ b/tests/test_soma_migration.py
@@ -43,7 +43,6 @@ from slide2vec.runtime.types import LoadedModel  # noqa: E402
 
 
 _FIXTURES = Path(__file__).parent / "fixtures"
-_REPOSITORY = Path(__file__).resolve().parents[1]
 _LITERAL_ENCODER_NAME = "issue260-literal-identity"
 
 
@@ -353,45 +352,6 @@ def _metadata(artifact: DenseImageArtifact) -> dict[str, Any]:
         dict[str, Any],
         json.loads(artifact.metadata_path.read_text(encoding="utf-8")),
     )
-
-
-def test_dense_image_glossary_names_the_release_contract_terms():
-    glossary = (_REPOSITORY / "docs" / "glossary.rst").read_text(
-        encoding="utf-8"
-    ).lower()
-
-    for term in (
-        "raster image",
-        "spacing-readable image",
-        "source-spacing declaration",
-        "source spacing",
-        "declared spacing",
-        "effective spacing",
-        "target size",
-        "compatible artifact",
-    ):
-        assert term in glossary
-
-
-def test_migration_guidance_lives_only_in_5_6_0_release_notes():
-    release_notes_path = _REPOSITORY / "docs" / "release-notes" / "5.6.0.rst"
-    release_notes = release_notes_path.read_text(encoding="utf-8")
-    for required in (
-        "soma",
-        "Model.embed_images_dense",
-        "compatible artifact",
-        "resume",
-        "provenance",
-    ):
-        assert required in release_notes
-
-    evergreen = "\n".join(
-        path.read_text(encoding="utf-8")
-        for path in (_REPOSITORY / "docs").rglob("*.rst")
-        if "release-notes" not in path.parts
-    )
-    assert "replace its private dense image reader" not in evergreen
-    assert "Artifacts written with hs2p 4.3 remain loadable" not in evergreen
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Remove maintenance noise left by earlier refactors while preserving inference, artifact, and configuration behavior. The cleanup removes 208 net lines across 20 files.

- Remove unused inference imports, unreachable fallbacks, redundant CUDA detection and window helpers, repeated process-list reads/alignment, and unnecessary MOOZY tensor branches.
- Delete six tests tied to filenames, line counts, documentation keywords, or a historically deleted helper. Retain behavioral tests and dependency-boundary checks, and make sliding-window expectations exact.
- Remove the unused duplicate release workflow and identity tag wrapper. Correct stale comments and the Sphinx release version, adding docs to the existing version-bump configuration.

Validation: 427 focused regression tests passed (34 deselected), covering API/config/artifacts, inference, batching, dense sliding, progress, registry/capabilities, authentication, patch metadata, migration, and tile storage. Temporary explicit-output MOOZY checks passed before and after the refactor; a mocked release CLI matched the original commands and output. Diff/unused-code checks passed, and a dry-run bump verified that project, package, and docs versions advance together.

Full-suite verification remains incomplete: the first broad attempt showed a failure before interruption without a completed traceback; a restart was interrupted during prolonged spawned-worker waiting. The focused run completed successfully, including its slow subprocess test. Heavy real-weight and multi-GPU tests were excluded.

The committed diff was reviewed locally. External structured review could not run because automatic approval review rejected transmitting repository source to the review service.
