### PR TITLE
Require hs2p 4.4.3

### DIFF
--- a/docs/release-notes/5.9.0.rst
+++ b/docs/release-notes/5.9.0.rst
@@ -17,6 +17,13 @@ Zero-tile slides, slides skipped by ``resume``, and failed slides do not fire
 the callback. An exception raised inside it propagates out of the entry point.
 Omitting the argument leaves every return value unchanged.
 
+hs2p 4.4.3 requirement
+----------------------
+
+slide2vec now requires ``hs2p>=4.4.3``. The hs2p public API is unchanged from
+4.4.2; the release lowers tiling and mask-decoding memory use. Existing
+coordinate and embedding artifacts stay valid.
+
 Scope
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.3",
     "omegaconf",
     "matplotlib",
     "numpy<2",
@@ -100,7 +100,7 @@ fm = [
     "pandas",
     "pillow",
     "rich",
-    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2",
+    "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.3",
     "wandb",
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",

--- a/tests/test_hs2p_package_cutover.py
+++ b/tests/test_hs2p_package_cutover.py
@@ -23,7 +23,7 @@ def test_package_root_exports_api():
     assert hasattr(package, "DenseRegionArtifact")
 
 
-def test_dependency_declarations_require_hs2p_4_4_2_with_consistent_extras():
+def test_dependency_declarations_require_hs2p_4_4_3_with_consistent_extras():
     project = tomllib.loads(
         (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
             encoding="utf-8"
@@ -39,8 +39,8 @@ def test_dependency_declarations_require_hs2p_4_4_2_with_consistent_extras():
     ]
 
     assert hs2p_dependencies == [
-        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2",
-        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2",
+        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.3",
+        "hs2p[asap,cucim,openslide,sam2,vips]>=4.4.3",
     ]
 
 


### PR DESCRIPTION
Aligns slide2vec with the latest hs2p release (4.4.3).

## Changes

- `pyproject.toml` — `hs2p[asap,cucim,openslide,sam2,vips]>=4.4.2` → `>=4.4.3`, in both the core `dependencies` and the `fm` extra.
- `tests/test_hs2p_package_cutover.py` — the pinned-dependency assertion and its test name.
- `docs/release-notes/5.9.0.rst` — a short entry recording the new floor.

Both Dockerfiles resolve hs2p from `pyproject.toml` (`/opt/deps[prism]`, `/opt/app[fm]`), so no image-side pin needed updating.

## Why this is only a floor bump

`hs2p/__init__.py` exports are identical between the 4.4.2 and 4.4.3 tags. 4.4.3 is `Simplify preprocessing internals (#204)` plus `Reduce preprocessing memory (#205)`: contour and coverage cropping, a `cv2.calcHist` fast path for mask label validation, and `dataclasses.replace` in place of hand-copied constructors.

Checked every symbol slide2vec imports:

- `build_supertile_index` — untouched.
- `wsi.resize_array`, `geometry.plan_spacing_read` — comment-only changes.
- `resolve_step_px_lv0`, `iter_grouped_read_plans` — lost a redundant `np.sort` before `np.unique` and a dead guard.

No behaviour slide2vec depends on moved, so no source changes were needed.

## Testing

Installed hs2p 4.4.3 locally and ran the full suite. Everything relevant passes.

24 pre-existing environment failures remain, none touching hs2p:

- 21 errors in `test_rudolfv2.py` and 1 in `test_patch_size_metadata.py[musk]` — `GatedRepoError: 401 ... access to model xiangjx/musk is restricted`. These pull real checkpoints from HuggingFace and need an `HF_TOKEN`; since #308 there is no implicit login.
- 2 in `test_prism2.py` — the tests assert `device_moves == [torch.device("cpu")]`, but `preferred_default_device()` (`slide2vec/encoders/base.py:15`) returns `cuda` on the test box. CI is CPU-only, so these pass there.