### PR TITLE
Reduce runtime overhead and add verified GPU/WSI benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,4 +160,5 @@ docker run --rm -it \
 - [API guide](https://clemsgrs.github.io/slide2vec/api.html)
 - [CLI guide](https://clemsgrs.github.io/slide2vec/cli.html)
 - [Model zoo](https://clemsgrs.github.io/slide2vec/models.html)
+- [Performance benchmarks and QA](docs/performance.md)
 - [`tutorials/api_walkthrough.ipynb`](tutorials/api_walkthrough.ipynb) for a notebook walkthrough of the API

--- a/docs/gpu-performance-audit-results.json
+++ b/docs/gpu-performance-audit-results.json
@@ -1,0 +1,4024 @@
+{
+  "baseline_commit": "e6efef8f9a728839dd330ffe4bb00635f33051f5",
+  "candidate_runtime_commit": "1b5af9a",
+  "workload": [
+    {
+      "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_1.tiff",
+      "coordinates": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/he-1.npz",
+      "count": 64,
+      "anchors": [
+        [
+          9216,
+          25600
+        ],
+        [
+          17408,
+          25600
+        ],
+        [
+          9216,
+          54272
+        ],
+        [
+          17408,
+          54272
+        ]
+      ],
+      "size_bytes": 84956350,
+      "source_block_size": [
+        4096,
+        4096
+      ],
+      "read_level": 0,
+      "tile_size": 224,
+      "selection": "four 4x4 tile grids across separated source TIFF blocks; no tissue filtering"
+    },
+    {
+      "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+      "coordinates": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/he-5.npz",
+      "count": 64,
+      "anchors": [
+        [
+          17408,
+          9216
+        ],
+        [
+          33792,
+          9216
+        ],
+        [
+          17408,
+          21504
+        ],
+        [
+          33792,
+          21504
+        ]
+      ],
+      "size_bytes": 287303418,
+      "source_block_size": [
+        4096,
+        4096
+      ],
+      "read_level": 0,
+      "tile_size": 224,
+      "selection": "four 4x4 tile grids across separated source TIFF blocks; no tissue filtering"
+    },
+    {
+      "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_3.tiff",
+      "coordinates": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/he-3.npz",
+      "count": 64,
+      "anchors": [
+        [
+          13312,
+          29696
+        ],
+        [
+          29696,
+          29696
+        ],
+        [
+          13312,
+          58368
+        ],
+        [
+          29696,
+          58368
+        ]
+      ],
+      "size_bytes": 644879226,
+      "source_block_size": [
+        4096,
+        4096
+      ],
+      "read_level": 0,
+      "tile_size": 224,
+      "selection": "four 4x4 tile grids across separated source TIFF blocks; no tissue filtering"
+    }
+  ],
+  "staging": {
+    "source": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+    "destination": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+    "bytes": 287303418,
+    "seconds": 2.1555639379657805,
+    "storage": "tmpfs RAM"
+  },
+  "correctness": {
+    "full_pipeline_shape": [
+      474,
+      384
+    ],
+    "storage_outputs_exact": true,
+    "rtol": 0.0001,
+    "atol": 0.0001,
+    "expanded_max_abs_errors": {
+      "expanded-before": 0.0,
+      "expanded-after": 0.00014495849609375,
+      "expanded-ram-after": 0.00014495849609375,
+      "expanded-no-overlap": 0.00014495849609375,
+      "expanded-baseline-recheck": 0.0
+    },
+    "prototype_full_pipeline_max_abs_error": 6.29425048828125e-05,
+    "retained_full_pipeline_max_abs_error": 0.0,
+    "retained_full_pipeline_exact": true,
+    "retained_storage_outputs_exact": true
+  },
+  "runs": {
+    "lunit-before": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "274ad5e354373fc29e1067c8c4cb0afcf23f1130469c29e4dd43b03cb1d6e59d",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.595658992882818,
+      "modes": {
+        "model-only": {
+          "samples_seconds": [
+            0.3353297980502248,
+            0.33865594188682735,
+            0.3407795208040625,
+            0.3408910990692675,
+            0.34249340603128076
+          ],
+          "median_seconds": 0.3407795208040625,
+          "tiles_per_second": 187.80471270395967,
+          "peak_allocated_bytes": [
+            366395392,
+            366395392,
+            366395392,
+            366395392,
+            366395392
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-before-model-only.pt",
+          "embeddings_sha256": "dd54cebd9337fc70dc713abf91081136aa5f2ecfa78a89d0a5bd4661a35bd63d",
+          "cache_advice": [],
+          "trace_path": "output/gpu-performance-audit/lunit-before-model-only-trace.json"
+        },
+        "cached": {
+          "samples_seconds": [
+            0.5018705090042204,
+            0.4848254898097366,
+            0.4776876431424171,
+            0.47169514116831124,
+            0.46691507706418633
+          ],
+          "median_seconds": 0.4776876431424171,
+          "tiles_per_second": 133.9787639868238,
+          "peak_allocated_bytes": [
+            385662976,
+            385662976,
+            385662976,
+            385662976,
+            385662976
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-before-cached.pt",
+          "embeddings_sha256": "2c57e468897914baf797b1e74ff0a90f9811ce57289944f6aff03e33b2bad551",
+          "cache_advice": [],
+          "trace_path": "output/gpu-performance-audit/lunit-before-cached-trace.json"
+        },
+        "wsi": {
+          "samples_seconds": [
+            1.0294036658015102,
+            1.016378456959501,
+            1.0092771919444203,
+            0.9871448820922524,
+            0.9901522900909185
+          ],
+          "median_seconds": 1.0092771919444203,
+          "tiles_per_second": 63.41171732683364,
+          "peak_allocated_bytes": [
+            385662976,
+            385662976,
+            385662976,
+            385662976,
+            385662976
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-before-wsi.pt",
+          "embeddings_sha256": "86c4557f82e39cd725f0eb28860edb34ffe83e51c3aa9a3b5f3aedf96d6a17a1",
+          "cache_advice": [],
+          "trace_path": "output/gpu-performance-audit/lunit-before-wsi-trace.json"
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "baseline"
+    },
+    "lunit-after": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "d02b70c737e84e1cf886b64e2d56358c681dfcd53d963f561424bc7e27048b46",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.2652621669694781,
+      "modes": {
+        "model-only": {
+          "samples_seconds": [
+            0.33902822504751384,
+            0.3403479198459536,
+            0.34470526478253305,
+            0.34435109701007605,
+            0.34356568404473364
+          ],
+          "median_seconds": 0.34356568404473364,
+          "tiles_per_second": 186.28170091535375,
+          "peak_allocated_bytes": [
+            366395392,
+            366395392,
+            366395392,
+            366395392,
+            366395392
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-after-model-only.pt",
+          "embeddings_sha256": "85c2678fcf5b3fc8812f9c488dca436455fe0b91671a0ca5d99ad632d3d18fe0",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 0.9918904495703116,
+          "trace_path": "output/gpu-performance-audit/lunit-after-model-only-trace.json"
+        },
+        "cached": {
+          "samples_seconds": [
+            0.34936067182570696,
+            0.3498760152142495,
+            0.35676952195353806,
+            0.351674861041829,
+            0.3521293490193784
+          ],
+          "median_seconds": 0.351674861041829,
+          "tiles_per_second": 181.98628076627773,
+          "peak_allocated_bytes": [
+            385662976,
+            385662976,
+            385662976,
+            385662976,
+            385662976
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-after-cached.pt",
+          "embeddings_sha256": "ed5441917635e7ef1d2914a904a6d5365e7aa90a33c5228c97f3127114ddd16f",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.3583218366171468,
+          "trace_path": "output/gpu-performance-audit/lunit-after-cached-trace.json"
+        },
+        "wsi": {
+          "samples_seconds": [
+            0.8681483869440854,
+            0.9525006690528244,
+            0.9705271739512682,
+            0.9034039420075715,
+            0.8968644109554589
+          ],
+          "median_seconds": 0.9034039420075715,
+          "tiles_per_second": 70.84317106008777,
+          "peak_allocated_bytes": [
+            385662976,
+            385662976,
+            385662976,
+            385662976,
+            385662976
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-after-wsi.pt",
+          "embeddings_sha256": "40d54d64385eea132d85aeaccedc123a757cd7198f3bede8a06d597155905d6f",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.1171936993119314,
+          "trace_path": "output/gpu-performance-audit/lunit-after-wsi-trace.json"
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "lunit-overlap": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.364802457159385,
+      "modes": {
+        "model-only": {
+          "samples_seconds": [
+            0.33647919981740415,
+            0.338087857933715,
+            0.3397877309471369,
+            0.3419679249636829,
+            0.34290031995624304
+          ],
+          "median_seconds": 0.3397877309471369,
+          "tiles_per_second": 188.35288673197243,
+          "peak_allocated_bytes": [
+            366395392,
+            366395392,
+            366395392,
+            366395392,
+            366395392
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-overlap-model-only.pt",
+          "embeddings_sha256": "d1079ad67860797e39dafee6f980d549f9a45f8f9e66f092e557837bb77c85ce",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.002918851290366,
+          "trace_path": "output/gpu-performance-audit/lunit-overlap-model-only-trace.json"
+        },
+        "cached": {
+          "samples_seconds": [
+            0.3465514681302011,
+            0.3474569588433951,
+            0.34760033898055553,
+            0.34652135404758155,
+            0.34922799398191273
+          ],
+          "median_seconds": 0.3474569588433951,
+          "tiles_per_second": 184.19547621967737,
+          "peak_allocated_bytes": [
+            376029184,
+            376029184,
+            376029184,
+            376029184,
+            376029184
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-overlap-cached.pt",
+          "embeddings_sha256": "8d263dc368d4c294e7c3966e61fa59a1525f4a44e8c1e117d4c185289887649b",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.3748109830136377,
+          "trace_path": "output/gpu-performance-audit/lunit-overlap-cached-trace.json"
+        },
+        "wsi": {
+          "samples_seconds": [
+            0.6847651458811015,
+            0.6560167910065502,
+            0.6868594351690263,
+            0.6462201199028641,
+            0.6821248598862439
+          ],
+          "median_seconds": 0.6821248598862439,
+          "tiles_per_second": 93.8244649383884,
+          "peak_allocated_bytes": [
+            376029184,
+            376029184,
+            376029184,
+            376029184,
+            376029184
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-overlap-wsi.pt",
+          "embeddings_sha256": "fb17545d7743ed81a9300a4e1cfb70b24ff4d15808ae2ffef8bf3d59ab1e6998",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.4796076954485058,
+          "trace_path": "output/gpu-performance-audit/lunit-overlap-wsi-trace.json"
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "lunit-final": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.7449610461480916,
+      "modes": {
+        "model-only": {
+          "samples_seconds": [
+            0.34151207003742456,
+            0.34382994496263564,
+            0.3459052359685302,
+            0.3463978301733732,
+            0.348128727870062
+          ],
+          "median_seconds": 0.3459052359685302,
+          "tiles_per_second": 185.02177285868723,
+          "peak_allocated_bytes": [
+            366395392,
+            366395392,
+            366395392,
+            366395392,
+            366395392
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/lunit-final-model-only.pt",
+          "embeddings_sha256": "187699d9e02f63f537cfd0434a3598a5b661468fed952304fef62fbb2b5a57b5",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 0.9851817358297114
+        },
+        "cached": {
+          "samples_seconds": [
+            0.35082580195739865,
+            0.34992507682181895,
+            0.3504042981658131,
+            0.35021627484820783,
+            0.3506337769795209
+          ],
+          "median_seconds": 0.3504042981658131,
+          "tiles_per_second": 182.64616140557408,
+          "peak_allocated_bytes": [
+            376029184,
+            376029184,
+            376029184,
+            376029184,
+            376029184
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/lunit-final-cached.pt",
+          "embeddings_sha256": "e370173f9cf667c5748df36b7c19c0ebe8f43f03fa0a38ffa88e21b7e0c45ce2",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.3632470995443464
+        },
+        "wsi": {
+          "samples_seconds": [
+            0.6756618320941925,
+            0.6527289301156998,
+            0.6396553399972618,
+            0.6440485899802297,
+            0.7091126709710807
+          ],
+          "median_seconds": 0.6527289301156998,
+          "tiles_per_second": 98.04989030998772,
+          "peak_allocated_bytes": [
+            376029184,
+            376029184,
+            376029184,
+            376029184,
+            376029184
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/lunit-final-wsi.pt",
+          "embeddings_sha256": "74fdc53b4ab62e5cf4008bb16eb206064bbe6cde67b71beea67e6e508300c51c",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.5462424681644193
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "phikon-before": {
+      "case": "inference",
+      "parameters": {
+        "model": "phikonv2",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": "2ae989a9c40cffaa27f0a6cb29cc94d1d6f9a5fd",
+        "weight_hub_id": "owkin/phikon-v2"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "274ad5e354373fc29e1067c8c4cb0afcf23f1130469c29e4dd43b03cb1d6e59d",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/phikon.py": "db13486f5ec77d635c3bb51e2f55601c6d41fcdb9e1b4d70da3614f981b95cda"
+      },
+      "model_load_seconds": 7.933326260885224,
+      "modes": {
+        "model-only": {
+          "samples_seconds": [
+            0.7648135269992054,
+            0.7672604240942746,
+            0.7712700399570167,
+            0.773348551010713,
+            0.774408747907728
+          ],
+          "median_seconds": 0.7712700399570167,
+          "tiles_per_second": 82.98001566813973,
+          "peak_allocated_bytes": [
+            1443831808,
+            1443831808,
+            1443831808,
+            1443831808,
+            1443831808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/phikon-before-model-only.pt",
+          "embeddings_sha256": "d814cabb091aa6333e44a83602aa78c939ae3317fa3e03328962c97ad3f9f543",
+          "cache_advice": [],
+          "trace_path": "output/gpu-performance-audit/phikon-before-model-only-trace.json"
+        },
+        "cached": {
+          "samples_seconds": [
+            0.816818559076637,
+            0.8204871260095388,
+            0.8179547169711441,
+            0.8189962450414896,
+            0.8195874991361052
+          ],
+          "median_seconds": 0.8189962450414896,
+          "tiles_per_second": 78.14443642138777,
+          "peak_allocated_bytes": [
+            1463885824,
+            1463885824,
+            1463885824,
+            1463885824,
+            1463885824
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/phikon-before-cached.pt",
+          "embeddings_sha256": "de2a7765e2dcc6f65b699309554895e687b7933976d26a2245383b1e5eb4f862",
+          "cache_advice": [],
+          "trace_path": "output/gpu-performance-audit/phikon-before-cached-trace.json"
+        },
+        "wsi": {
+          "samples_seconds": [
+            1.354677168885246,
+            1.3358711160253733,
+            1.3340446730144322,
+            1.3795317029580474,
+            1.3282938529737294
+          ],
+          "median_seconds": 1.3358711160253733,
+          "tiles_per_second": 47.90881338195233,
+          "peak_allocated_bytes": [
+            1463885824,
+            1463885824,
+            1463885824,
+            1463885824,
+            1463885824
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/phikon-before-wsi.pt",
+          "embeddings_sha256": "0ecb114837029619d2a161cc3ac6397922ae8ad486cd1fe7475a42d7964c59b4",
+          "cache_advice": [],
+          "trace_path": "output/gpu-performance-audit/phikon-before-wsi-trace.json"
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "baseline"
+    },
+    "phikon-after": {
+      "case": "inference",
+      "parameters": {
+        "model": "phikonv2",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": "2ae989a9c40cffaa27f0a6cb29cc94d1d6f9a5fd",
+        "weight_hub_id": "owkin/phikon-v2"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/phikon.py": "db13486f5ec77d635c3bb51e2f55601c6d41fcdb9e1b4d70da3614f981b95cda"
+      },
+      "model_load_seconds": 15.070211412152275,
+      "modes": {
+        "model-only": {
+          "samples_seconds": [
+            0.767687011975795,
+            0.7721179809886962,
+            0.7733295070938766,
+            0.7769689899869263,
+            0.7795731369405985
+          ],
+          "median_seconds": 0.7733295070938766,
+          "tiles_per_second": 82.75903015844818,
+          "peak_allocated_bytes": [
+            1443831808,
+            1443831808,
+            1443831808,
+            1443831808,
+            1443831808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/phikon-after-model-only.pt",
+          "embeddings_sha256": "42ac34249cb7aa52247ce3b15ff7c80092f60b40f1160e41d7723bf543b096fd",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 0.9973368827673481
+        },
+        "cached": {
+          "samples_seconds": [
+            0.8192117030266672,
+            0.8341798409819603,
+            0.8291205589193851,
+            0.822437590919435,
+            0.8220768230967224
+          ],
+          "median_seconds": 0.822437590919435,
+          "tiles_per_second": 77.81745473045791,
+          "peak_allocated_bytes": [
+            1463885824,
+            1463885824,
+            1463885824,
+            1463885824,
+            1463885824
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/phikon-after-cached.pt",
+          "embeddings_sha256": "a4509403718356c52ffe81c2498dd096badb06780f598cfc4cbfc8d537bec04f",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 0.995815675358299
+        },
+        "wsi": {
+          "samples_seconds": [
+            1.4101237158756703,
+            1.3448154160287231,
+            1.326561186928302,
+            1.3805247240234166,
+            1.3734536380507052
+          ],
+          "median_seconds": 1.3734536380507052,
+          "tiles_per_second": 46.59785975071788,
+          "peak_allocated_bytes": [
+            1463885824,
+            1463885824,
+            1463885824,
+            1463885824,
+            1463885824
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/phikon-after-wsi.pt",
+          "embeddings_sha256": "240c26d43569a6c46442353f05d48b9d8aea0fbfa2251a937a21a0ea1a4bb304",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 0.9726364829622707
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "storage-fresh": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "fresh-reader",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.2751454720273614,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.6586440629325807,
+            0.668549319030717,
+            0.643129751086235,
+            0.6589046958833933,
+            0.6506756490562111
+          ],
+          "median_seconds": 0.6586440629325807,
+          "tiles_per_second": 97.16932650245583,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/storage-fresh-wsi.pt",
+          "embeddings_sha256": "fd88607362c15aebea7a60e5dc66cdfe6af8b92c61a46579c3d642d2ba4e769f",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "storage-advised": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "advised-client-drop",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.8219775510951877,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.8080929168500006,
+            0.8744337521493435,
+            0.8494683799799532,
+            0.7902971028815955,
+            0.9439324128907174
+          ],
+          "median_seconds": 0.8494683799799532,
+          "tiles_per_second": 75.34123871863288,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/storage-advised-wsi.pt",
+          "embeddings_sha256": "d241e22927da1d835716ac3f54fefed4c9cacc7ab674f8e70b731bd06d225e0d",
+          "cache_advice": [
+            {
+              "before": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            }
+          ]
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "storage-ram": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.4546244009397924,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.641307728132233,
+            0.6735838330350816,
+            0.6291685928590596,
+            0.6255833809264004,
+            0.7162507819011807
+          ],
+          "median_seconds": 0.641307728132233,
+          "tiles_per_second": 99.79608414574362,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/storage-ram-wsi.pt",
+          "embeddings_sha256": "a3b874baa8701a904e4384eb6c1ef0e56632b1f2abaeb4f0c04b356b75ca9a5a",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "storage-workers2": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 2,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "62ca92828a09d6f743886366ee7a1558b4b5f502db13d731c0814cafe2b8ff25",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.4939677510410547,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.5123203240800649,
+            0.49919081199914217,
+            0.5019722369033843,
+            0.5038201950956136,
+            0.5026777680031955
+          ],
+          "median_seconds": 0.5026777680031955,
+          "tiles_per_second": 127.31814310035918,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/storage-workers2-wsi.pt",
+          "embeddings_sha256": "d5a5beb8eb6c989d275bd6a8f38adf94414547f54d097a03be19f7a78ee9a89f",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "expanded-before": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "65d45cabef9b1d1dcd8b6d5e76b333b05bde3cec96058532f5c91d4af86c0920",
+        "slide2vec/runtime/batching.py": "274ad5e354373fc29e1067c8c4cb0afcf23f1130469c29e4dd43b03cb1d6e59d",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.6239124222192913,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            5.534224086906761,
+            5.1117948167957366,
+            5.311193337896839,
+            5.127756619127467,
+            5.305780082941055
+          ],
+          "median_seconds": 5.305780082941055,
+          "tiles_per_second": 48.24926702542414,
+          "peak_allocated_bytes": [
+            347127808,
+            347127808,
+            347127808,
+            347127808,
+            347127808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/expanded-before-wsi.pt",
+          "embeddings_sha256": "5d219e4addabdacb8970d0d3ec879fbfdbb167496a8fd52606f3481025f948cf",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "baseline"
+    },
+    "expanded-after": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "65d45cabef9b1d1dcd8b6d5e76b333b05bde3cec96058532f5c91d4af86c0920",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.5058838890399784,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            25.37422814616002,
+            43.30292222183198,
+            9.621431984007359,
+            51.92229465814307,
+            5.609750916017219
+          ],
+          "median_seconds": 25.37422814616002,
+          "tiles_per_second": 10.088976836079306,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/expanded-after-wsi.pt",
+          "embeddings_sha256": "27fa28893a87fa48067a1165983996ff13239a5351411eda91be312e4b3dc9ff",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 0.2091011420082939
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "he3-before": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_3.tiff",
+        "slide_size_bytes": 644879226,
+        "slide_mtime_ns": 1773937680293422400,
+        "coordinates_sha256": "07a631339d1d9b58e05a24035fbc62003ef0ba9aba1389405da9e55113f89951",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "65d45cabef9b1d1dcd8b6d5e76b333b05bde3cec96058532f5c91d4af86c0920",
+        "slide2vec/runtime/batching.py": "274ad5e354373fc29e1067c8c4cb0afcf23f1130469c29e4dd43b03cb1d6e59d",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.3300762069411576,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.9717488191090524,
+            0.9919911841861904,
+            0.976258005015552,
+            1.0230356028769165,
+            0.876217412063852
+          ],
+          "median_seconds": 0.976258005015552,
+          "tiles_per_second": 65.55644068596443,
+          "peak_allocated_bytes": [
+            347127808,
+            347127808,
+            347127808,
+            347127808,
+            347127808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/he3-before-wsi.pt",
+          "embeddings_sha256": "36beb52f27ff88f07026b08812bd01e1d9bd425bddf8d78e33b943717cd9d037",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "baseline"
+    },
+    "he3-after": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_3.tiff",
+        "slide_size_bytes": 644879226,
+        "slide_mtime_ns": 1773937680293422400,
+        "coordinates_sha256": "07a631339d1d9b58e05a24035fbc62003ef0ba9aba1389405da9e55113f89951",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "65d45cabef9b1d1dcd8b6d5e76b333b05bde3cec96058532f5c91d4af86c0920",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.4105767558794469,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.6288426369428635,
+            0.6037307190708816,
+            0.598546130117029,
+            0.6261846059933305,
+            0.6462487529497594
+          ],
+          "median_seconds": 0.6261846059933305,
+          "tiles_per_second": 102.20628132254288,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/he3-after-wsi.pt",
+          "embeddings_sha256": "64e9896e6789077735174b4358e13fffbdea5d734415def6808b64d516f6ae8c",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00013887882232666016,
+          "speedup": 1.5590578172500622
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "expanded-ram-before": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "65d45cabef9b1d1dcd8b6d5e76b333b05bde3cec96058532f5c91d4af86c0920",
+        "slide2vec/runtime/batching.py": "274ad5e354373fc29e1067c8c4cb0afcf23f1130469c29e4dd43b03cb1d6e59d",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.348903700010851,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            5.157192579936236,
+            5.256007255986333,
+            5.114414331968874,
+            5.044589962810278,
+            5.0661195169668645
+          ],
+          "median_seconds": 5.114414331968874,
+          "tiles_per_second": 50.05460711303943,
+          "peak_allocated_bytes": [
+            347127808,
+            347127808,
+            347127808,
+            347127808,
+            347127808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/expanded-ram-before-wsi.pt",
+          "embeddings_sha256": "b90eae467b40bca22bd77f375cf6ace8970e0b3481b13858522a6edb60c6978c",
+          "cache_advice": [],
+          "trace_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/expanded-ram-before-wsi-trace.json"
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "baseline"
+    },
+    "expanded-ram-after": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "65d45cabef9b1d1dcd8b6d5e76b333b05bde3cec96058532f5c91d4af86c0920",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 2.2070600278675556,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            16.1516412650235,
+            9.594718493986875,
+            3.76928454102017,
+            4.537781602004543,
+            3.7665657070465386
+          ],
+          "median_seconds": 4.537781602004543,
+          "tiles_per_second": 56.415231593982675,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/expanded-ram-after-wsi.pt",
+          "embeddings_sha256": "87359eeeaab3aafb32006b5cbaa6dae22204b2cafab3cdb2b991fc94a6e049f2",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.127073707053157,
+          "trace_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/expanded-ram-after-wsi-trace.json"
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "expanded-no-overlap": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "65d45cabef9b1d1dcd8b6d5e76b333b05bde3cec96058532f5c91d4af86c0920",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.027553060092032,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            24.760793576948345,
+            4.917415538104251,
+            12.93821953702718,
+            7.968108821893111,
+            4.906989936949685
+          ],
+          "median_seconds": 7.968108821893111,
+          "tiles_per_second": 32.12807527133872,
+          "peak_allocated_bytes": [
+            347127808,
+            347127808,
+            347127808,
+            347127808,
+            347127808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/expanded-no-overlap-wsi.pt",
+          "embeddings_sha256": "b72ff7e417661997d3beb1befcd9a6d4f1be2b431bca16d01636be439733d1b2",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "diagnostic_override": "Temporary wrapper disabled deferred preload; source hashes do not represent this runtime monkeypatch.",
+      "audit_role": "experiment, not the final runtime"
+    },
+    "expanded-baseline-recheck": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "65d45cabef9b1d1dcd8b6d5e76b333b05bde3cec96058532f5c91d4af86c0920",
+        "slide2vec/runtime/batching.py": "274ad5e354373fc29e1067c8c4cb0afcf23f1130469c29e4dd43b03cb1d6e59d",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.6474265588913113,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            14.151145898038521,
+            11.809649668168277,
+            5.04485734202899,
+            5.105565252015367,
+            5.12232364108786
+          ],
+          "median_seconds": 5.12232364108786,
+          "tiles_per_second": 49.97731848619227,
+          "peak_allocated_bytes": [
+            347127808,
+            347127808,
+            347127808,
+            347127808,
+            347127808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/expanded-baseline-recheck-wsi.pt",
+          "embeddings_sha256": "84bff3ab97ddfe6b43f6f7936f61388ec1f7e374533b159f787ae394a27c1aee",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."
+      ],
+      "audit_role": "baseline"
+    },
+    "expanded-telemetry-before": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "274ad5e354373fc29e1067c8c4cb0afcf23f1130469c29e4dd43b03cb1d6e59d",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 2.53713831002824,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            5.212460215901956,
+            5.451267518103123,
+            5.279726332984865,
+            5.378661367110908,
+            5.18878430291079
+          ],
+          "median_seconds": 5.279726332984865,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 300578,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 2027244,
+                "full": 2027244
+              },
+              "host_memory_psi_us": {
+                "some": 1331541,
+                "full": 1331508
+              }
+            },
+            {
+              "parent_minor_faults": 319504,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 2649807,
+                "full": 2649807
+              },
+              "host_memory_psi_us": {
+                "some": 1559509,
+                "full": 1559460
+              }
+            },
+            {
+              "parent_minor_faults": 289047,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 1141334,
+                "full": 1141334
+              },
+              "host_memory_psi_us": {
+                "some": 1228050,
+                "full": 1227904
+              }
+            },
+            {
+              "parent_minor_faults": 275472,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 273082,
+                "full": 273077
+              }
+            },
+            {
+              "parent_minor_faults": 267812,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 517069,
+                "full": 517059
+              }
+            }
+          ],
+          "tiles_per_second": 48.48736162718339,
+          "peak_allocated_bytes": [
+            347127808,
+            347127808,
+            347127808,
+            347127808,
+            347127808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/expanded-telemetry-before-wsi.pt",
+          "embeddings_sha256": "435852b5ca769e60b0566386ded63546ae51078b331bd4d9d987185d3f222876",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "baseline"
+    },
+    "expanded-telemetry-after": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.1601676321588457,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            43.96727145696059,
+            3.7959598819725215,
+            3.6983962210360914,
+            3.785355884116143,
+            14.245272099040449
+          ],
+          "median_seconds": 3.7959598819725215,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 392854,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 36784132,
+                "full": 36784132
+              },
+              "host_memory_psi_us": {
+                "some": 9026470,
+                "full": 9025666
+              }
+            },
+            {
+              "parent_minor_faults": 393262,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 25006,
+                "full": 25005
+              },
+              "host_memory_psi_us": {
+                "some": 23743,
+                "full": 23736
+              }
+            },
+            {
+              "parent_minor_faults": 392367,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 257971,
+                "full": 257958
+              }
+            },
+            {
+              "parent_minor_faults": 395244,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 14341,
+                "full": 14342
+              },
+              "host_memory_psi_us": {
+                "some": 1352815,
+                "full": 1352742
+              }
+            },
+            {
+              "parent_minor_faults": 406978,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 9588818,
+                "full": 9588818
+              },
+              "host_memory_psi_us": {
+                "some": 5023193,
+                "full": 5022653
+              }
+            }
+          ],
+          "tiles_per_second": 67.44012264612579,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/expanded-telemetry-after-wsi.pt",
+          "embeddings_sha256": "3ffff20ce06cf4927841a1c4644304493c6a1942894af69117b86e4bce54656e",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.3908804352909343
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "advised-paired-before": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "advised-client-drop",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "274ad5e354373fc29e1067c8c4cb0afcf23f1130469c29e4dd43b03cb1d6e59d",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.1722737839445472,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            1.1450463149230927,
+            1.0826430420856923,
+            1.3438390309456736,
+            1.1440667330753058,
+            1.1179767979774624
+          ],
+          "median_seconds": 1.1440667330753058,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 72122,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 293047,
+                "full": 293037
+              }
+            },
+            {
+              "parent_minor_faults": 72982,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 179086,
+                "full": 179058
+              }
+            },
+            {
+              "parent_minor_faults": 70520,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 317463,
+                "full": 317438
+              }
+            },
+            {
+              "parent_minor_faults": 90633,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 265572,
+                "full": 265546
+              }
+            },
+            {
+              "parent_minor_faults": 89389,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 249658,
+                "full": 249636
+              }
+            }
+          ],
+          "tiles_per_second": 55.940792743763254,
+          "peak_allocated_bytes": [
+            347127808,
+            347127808,
+            347127808,
+            347127808,
+            347127808
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/advised-paired-before-wsi.pt",
+          "embeddings_sha256": "ff8925f52fe28e1b85e286234142bb92c3f5e505b0b27423105545e4eff6d5fe",
+          "cache_advice": [
+            {
+              "before": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            }
+          ]
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "baseline"
+    },
+    "advised-paired-after": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "advised-client-drop",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.6435851040296257,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.9146360869053751,
+            0.7893110068980604,
+            0.7947489488869905,
+            0.8140610950067639,
+            0.9866939659696072
+          ],
+          "median_seconds": 0.8140610950067639,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 82471,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 82194,
+                "full": 82192
+              }
+            },
+            {
+              "parent_minor_faults": 82436,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 153139,
+                "full": 153134
+              }
+            },
+            {
+              "parent_minor_faults": 83607,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 178017,
+                "full": 178012
+              }
+            },
+            {
+              "parent_minor_faults": 82507,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 182184,
+                "full": 182177
+              }
+            },
+            {
+              "parent_minor_faults": 86295,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 197840,
+                "full": 197824
+              }
+            }
+          ],
+          "tiles_per_second": 78.61817791386804,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/advised-paired-after-wsi.pt",
+          "embeddings_sha256": "12fbd2b27a520495fc6c32ee1fe546c87f836bb70b17693740fd97546acf845f",
+          "cache_advice": [
+            {
+              "before": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            }
+          ],
+          "baseline_max_abs_error": 0.00014495849609375,
+          "speedup": 1.4053819057226902
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "experiment, not the final runtime"
+    },
+    "expanded-cpu-transforms": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.6630681499373168,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            7.306218969868496,
+            3.9711724231019616,
+            9.989085536915809,
+            5.260265500051901,
+            4.1157209780067205
+          ],
+          "median_seconds": 5.260265500051901,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 281423,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 3339887,
+                "full": 3339887
+              },
+              "host_memory_psi_us": {
+                "some": 3793076,
+                "full": 3792895
+              }
+            },
+            {
+              "parent_minor_faults": 284674,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 291827,
+                "full": 291801
+              }
+            },
+            {
+              "parent_minor_faults": 375186,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 5106661,
+                "full": 5106661
+              },
+              "host_memory_psi_us": {
+                "some": 2054484,
+                "full": 2054309
+              }
+            },
+            {
+              "parent_minor_faults": 348996,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 797807,
+                "full": 797807
+              },
+              "host_memory_psi_us": {
+                "some": 658013,
+                "full": 657969
+              }
+            },
+            {
+              "parent_minor_faults": 316485,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 86591,
+                "full": 86591
+              },
+              "host_memory_psi_us": {
+                "some": 133225,
+                "full": 133218
+              }
+            }
+          ],
+          "tiles_per_second": 48.66674505259747,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/expanded-cpu-transforms-wsi.pt",
+          "embeddings_sha256": "dfef0fd0bcf56927144b9471b0642b4170a05e87c18e03af76c045bae45c4e9b",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 1.0036995913861708
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "diagnostic_override": "Temporary wrapper restored original CPU preprocessing; runtime scheduling remained candidate. Source hashes do not represent this override.",
+      "audit_role": "experiment, not the final runtime"
+    },
+    "retained-he5": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "3cd78084d2db4697612f7d0779fb70be17c877a2b2c26fad14fb62ecb4c10d50",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 2.506665961118415,
+      "modes": {
+        "model-only": {
+          "samples_seconds": [
+            0.3363200491294265,
+            0.3386502838693559,
+            0.3420291349757463,
+            0.34178124205209315,
+            0.3421166518237442
+          ],
+          "median_seconds": 0.34178124205209315,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 67,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 102023,
+                "full": 102018
+              }
+            },
+            {
+              "parent_minor_faults": 0,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 86829,
+                "full": 86817
+              }
+            },
+            {
+              "parent_minor_faults": 0,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 78185,
+                "full": 78167
+              }
+            },
+            {
+              "parent_minor_faults": 436,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 95667,
+                "full": 95659
+              }
+            },
+            {
+              "parent_minor_faults": 412,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 86896,
+                "full": 86892
+              }
+            }
+          ],
+          "tiles_per_second": 187.254278835599,
+          "peak_allocated_bytes": [
+            366395392,
+            366395392,
+            366395392,
+            366395392,
+            366395392
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-he5-model-only.pt",
+          "embeddings_sha256": "31e8a861bb8855a8e4b0e6f78bd9a83da63175998eb36af27f9cb1a3aec40b34",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 0.9970691157829019,
+          "trace_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-he5-model-only-trace.json"
+        },
+        "cached": {
+          "samples_seconds": [
+            0.3951533939689398,
+            0.4524159908760339,
+            0.3744018110446632,
+            0.3932650580536574,
+            0.38929152791388333
+          ],
+          "median_seconds": 0.3932650580536574,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 24490,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 31876,
+                "full": 31866
+              }
+            },
+            {
+              "parent_minor_faults": 32331,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 33524,
+                "full": 33519
+              }
+            },
+            {
+              "parent_minor_faults": 15364,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 30473,
+                "full": 30473
+              }
+            },
+            {
+              "parent_minor_faults": 17720,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 25558,
+                "full": 25557
+              }
+            },
+            {
+              "parent_minor_faults": 20070,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 33556,
+                "full": 33548
+              }
+            }
+          ],
+          "tiles_per_second": 162.74011303406414,
+          "peak_allocated_bytes": [
+            376029184,
+            376029184,
+            376029184,
+            376029184,
+            376029184
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-he5-cached.pt",
+          "embeddings_sha256": "ad61b326a58cd5c23177b95173aa316783a93a98d5b80431474d27a388ed828f",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 1.2146709537495726,
+          "trace_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-he5-cached-trace.json"
+        },
+        "wsi": {
+          "samples_seconds": [
+            0.7997066481038928,
+            0.8150293971411884,
+            0.7395877270027995,
+            0.7734350650571287,
+            0.7472825499717146
+          ],
+          "median_seconds": 0.7734350650571287,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 76254,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 283633,
+                "full": 283613
+              }
+            },
+            {
+              "parent_minor_faults": 83313,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 314906,
+                "full": 314869
+              }
+            },
+            {
+              "parent_minor_faults": 76519,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 313256,
+                "full": 313245
+              }
+            },
+            {
+              "parent_minor_faults": 71004,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 324577,
+                "full": 324566
+              }
+            },
+            {
+              "parent_minor_faults": 70255,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 335395,
+                "full": 335382
+              }
+            }
+          ],
+          "tiles_per_second": 82.74773525463671,
+          "peak_allocated_bytes": [
+            376029184,
+            376029184,
+            376029184,
+            376029184,
+            376029184
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-he5-wsi.pt",
+          "embeddings_sha256": "1b582484204a5676c3c4ba83386bd3a5b5023344376289ef969d6d0b12e87aa1",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 1.3049281543368758,
+          "trace_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-he5-wsi-trace.json"
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "retained runtime"
+    },
+    "retained-he3": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_3.tiff",
+        "slide_size_bytes": 644879226,
+        "slide_mtime_ns": 1773937680293422400,
+        "coordinates_sha256": "07a631339d1d9b58e05a24035fbc62003ef0ba9aba1389405da9e55113f89951",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "3cd78084d2db4697612f7d0779fb70be17c877a2b2c26fad14fb62ecb4c10d50",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.4074434489011765,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.74149533896707,
+            0.7731225159950554,
+            0.742897551972419,
+            0.7140554189682007,
+            0.789215117925778
+          ],
+          "median_seconds": 0.742897551972419,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 75357,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 138353,
+                "full": 138348
+              }
+            },
+            {
+              "parent_minor_faults": 70617,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 80416,
+                "full": 80410
+              }
+            },
+            {
+              "parent_minor_faults": 76243,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 85393,
+                "full": 85380
+              }
+            },
+            {
+              "parent_minor_faults": 76818,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 62618,
+                "full": 62613
+              }
+            },
+            {
+              "parent_minor_faults": 71098,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 93073,
+                "full": 93065
+              }
+            }
+          ],
+          "tiles_per_second": 86.14915990782008,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-he3-wsi.pt",
+          "embeddings_sha256": "943b60794081d635ca94b8e4f3a40f922d71d0b4ad4ba3bb6dd577bbfea47df3",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 1.314121984146472
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "retained runtime"
+    },
+    "retained-advised": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "advised-client-drop",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "3cd78084d2db4697612f7d0779fb70be17c877a2b2c26fad14fb62ecb4c10d50",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.7571627858560532,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.9194475910626352,
+            0.9105047900229692,
+            0.7347492680419236,
+            1.2427729340270162,
+            0.8928760769777
+          ],
+          "median_seconds": 0.9105047900229692,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 74001,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 115434,
+                "full": 115433
+              }
+            },
+            {
+              "parent_minor_faults": 67903,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 100101,
+                "full": 100093
+              }
+            },
+            {
+              "parent_minor_faults": 21648,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 71246,
+                "full": 71244
+              }
+            },
+            {
+              "parent_minor_faults": 75832,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 71278,
+                "full": 71260
+              }
+            },
+            {
+              "parent_minor_faults": 66370,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 89982,
+                "full": 89978
+              }
+            }
+          ],
+          "tiles_per_second": 70.29067908405564,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-advised-wsi.pt",
+          "embeddings_sha256": "0d22bc954bd6287f3ed80a693caf00c99cf0d47cca95b03ec7e6f0213434e206",
+          "cache_advice": [
+            {
+              "before": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            },
+            {
+              "before": {
+                "res": 32673792,
+                "pages": 7977,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              },
+              "advisory_only": true,
+              "error": null,
+              "after": {
+                "res": 0,
+                "pages": 0,
+                "size": 287303418,
+                "file": "data/histai/wsi/slide_H&E_5.tiff"
+              }
+            }
+          ],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 1.2565191810209417
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "retained runtime"
+    },
+    "retained-expanded": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/tmp/slide2vec-gpu-perf-slides/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1788791667658590806,
+        "coordinates_sha256": "fce08e9e2fd0a0874acc842dc80c8666c870ad5db051b206957df80f2ecd0edb",
+        "num_tiles": 256,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "3cd78084d2db4697612f7d0779fb70be17c877a2b2c26fad14fb62ecb4c10d50",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.2511038139928132,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            29.253737705061212,
+            3.9748765220865607,
+            3.990106913028285,
+            3.9109925490338355,
+            3.9331403409596533
+          ],
+          "median_seconds": 3.9748765220865607,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 363666,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 22892874,
+                "full": 22892875
+              },
+              "host_memory_psi_us": {
+                "some": 7696136,
+                "full": 7695608
+              }
+            },
+            {
+              "parent_minor_faults": 305449,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 43998,
+                "full": 43998
+              },
+              "host_memory_psi_us": {
+                "some": 240355,
+                "full": 240346
+              }
+            },
+            {
+              "parent_minor_faults": 307392,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 266946,
+                "full": 266931
+              }
+            },
+            {
+              "parent_minor_faults": 266073,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 69575,
+                "full": 69575
+              },
+              "host_memory_psi_us": {
+                "some": 446594,
+                "full": 446571
+              }
+            },
+            {
+              "parent_minor_faults": 299812,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 315353,
+                "full": 315328
+              }
+            }
+          ],
+          "tiles_per_second": 64.40451636108084,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-expanded-wsi.pt",
+          "embeddings_sha256": "a4f5bffe6bf7d1c899bb283cecfaac62b9bb8199129657832ee0176c3a4c32c9",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 1.328274300760754
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "retained runtime"
+    },
+    "retained-workers2": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 2,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "3cd78084d2db4697612f7d0779fb70be17c877a2b2c26fad14fb62ecb4c10d50",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.6501777058001608,
+      "modes": {
+        "wsi": {
+          "samples_seconds": [
+            0.5341331248637289,
+            0.5564586839172989,
+            0.5365108090918511,
+            0.5607734008226544,
+            0.5345520209521055
+          ],
+          "median_seconds": 0.5365108090918511,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 10611,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 23781,
+                "full": 23771
+              }
+            },
+            {
+              "parent_minor_faults": 5369,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 48657,
+                "full": 48656
+              }
+            },
+            {
+              "parent_minor_faults": 3999,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 37679,
+                "full": 37679
+              }
+            },
+            {
+              "parent_minor_faults": 8327,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 42618,
+                "full": 42619
+              }
+            },
+            {
+              "parent_minor_faults": 10331,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 34098,
+                "full": 34097
+              }
+            }
+          ],
+          "tiles_per_second": 119.28930212670356,
+          "peak_allocated_bytes": [
+            337494016,
+            337494016,
+            337494016,
+            337494016,
+            337494016
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "/data/pathology/projects/clement/code/slide2vec/output/gpu-performance-audit/retained-workers2-wsi.pt",
+          "embeddings_sha256": "f459a35a2708be7cd8ce0bac14ce816ed766116e6ef0f693e0f7f08449a4704d",
+          "cache_advice": []
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "retained runtime"
+    },
+    "lunit-cpu-transforms": {
+      "case": "inference",
+      "parameters": {
+        "model": "lunit",
+        "slide": "/data/pathology/projects/clement/code/slide2vec/data/histai/wsi/slide_H&E_5.tiff",
+        "slide_size_bytes": 287303418,
+        "slide_mtime_ns": 1773937659973389500,
+        "coordinates_sha256": "841848f671f4fad269742296e20a73a39c1be7831c39f1a0b209c7ae04281a0e",
+        "num_tiles": 64,
+        "tile_size": 224,
+        "batch_size": 16,
+        "workers": 0,
+        "backend": "openslide",
+        "use_supertiles": true,
+        "precision": "fp32",
+        "threads": 1,
+        "cache_policy": "warm",
+        "repeat": 5,
+        "warmup": 1
+      },
+      "environment": {
+        "python": "3.11.15",
+        "numpy": "1.26.4",
+        "hs2p": "4.4.3",
+        "transformers": "4.57.6",
+        "timm": "1.0.29",
+        "torch": "2.7.1+cu128",
+        "cuda": "12.8",
+        "device": "cuda",
+        "gpu": "NVIDIA GeForce RTX 2080 Ti",
+        "weight_revision": null,
+        "weight_hub_id": "1aurent/vit_small_patch8_224.lunit_dino"
+      },
+      "source_sha256": {
+        "scripts/benchmark_inference.py": "38f67d37c288169089b0da734c840337368010c00a606e5820d23106cc2da4c8",
+        "slide2vec/runtime/batching.py": "4dc47d46e0578d7844d06e0434914d1beb1be42db2f380ad7500413cba4d1aaa",
+        "slide2vec/runtime/preprocessing.py": "9a8f5e6a99733ae1454bffa1886645c491401825eaa6be5cd9adfe9e0af75af0",
+        "slide2vec/data/tile_reader.py": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "slide2vec/encoders/models/lunit.py": "7f1904e29185559fccf07491445e4529f8d76a468d1c463c280ac94c17aaf800"
+      },
+      "model_load_seconds": 1.8494079099036753,
+      "modes": {
+        "model-only": {
+          "samples_seconds": [
+            0.3401592089794576,
+            0.3397121769376099,
+            0.3439028700813651,
+            0.34356969385407865,
+            0.3456194601021707
+          ],
+          "median_seconds": 0.34356969385407865,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 899,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 111,
+                "full": 111
+              }
+            },
+            {
+              "parent_minor_faults": 18,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              }
+            },
+            {
+              "parent_minor_faults": 3,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              }
+            },
+            {
+              "parent_minor_faults": 5,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 2095,
+                "full": 2068
+              }
+            },
+            {
+              "parent_minor_faults": 5,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 4636,
+                "full": 4635
+              }
+            }
+          ],
+          "tiles_per_second": 186.2795268175841,
+          "peak_allocated_bytes": [
+            366395392,
+            366395392,
+            366395392,
+            366395392,
+            366395392
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-cpu-transforms-model-only.pt",
+          "embeddings_sha256": "ea6430b378b74617ebfa2a669f05014e29eeac9ef33b38aa5ba20e0488c13dcb",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 0.991878873195372
+        },
+        "cached": {
+          "samples_seconds": [
+            0.3777345730923116,
+            0.3753234068863094,
+            0.3831482019741088,
+            0.37878579716198146,
+            0.3948173529934138
+          ],
+          "median_seconds": 0.37878579716198146,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 33145,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 718,
+                "full": 712
+              }
+            },
+            {
+              "parent_minor_faults": 2922,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 4816,
+                "full": 4814
+              }
+            },
+            {
+              "parent_minor_faults": 20647,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 33988,
+                "full": 33987
+              }
+            },
+            {
+              "parent_minor_faults": 2613,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 88484,
+                "full": 88461
+              }
+            },
+            {
+              "parent_minor_faults": 6760,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 74102,
+                "full": 74100
+              }
+            }
+          ],
+          "tiles_per_second": 168.96092852349335,
+          "peak_allocated_bytes": [
+            376029184,
+            376029184,
+            376029184,
+            376029184,
+            376029184
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-cpu-transforms-cached.pt",
+          "embeddings_sha256": "0ba138b0be37db5ad828821a970a4ce0758faaa41be03f38e65576b9592e0d96",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 1.2611023082740926
+        },
+        "wsi": {
+          "samples_seconds": [
+            0.7458464070223272,
+            0.7732273759320378,
+            0.7314755360130221,
+            0.733708273852244,
+            0.7509720488451421
+          ],
+          "median_seconds": 0.7458464070223272,
+          "sample_resources": [
+            {
+              "parent_minor_faults": 71348,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 246264,
+                "full": 246252
+              }
+            },
+            {
+              "parent_minor_faults": 70407,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 274907,
+                "full": 274899
+              }
+            },
+            {
+              "parent_minor_faults": 66166,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 242693,
+                "full": 242683
+              }
+            },
+            {
+              "parent_minor_faults": 65575,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 298370,
+                "full": 298366
+              }
+            },
+            {
+              "parent_minor_faults": 66646,
+              "parent_major_faults": 0,
+              "cgroup_memory_psi_us": {
+                "some": 0,
+                "full": 0
+              },
+              "host_memory_psi_us": {
+                "some": 346616,
+                "full": 346610
+              }
+            }
+          ],
+          "tiles_per_second": 85.8085517305229,
+          "peak_allocated_bytes": [
+            376029184,
+            376029184,
+            376029184,
+            376029184,
+            376029184
+          ],
+          "max_abs_error": 0.0,
+          "embeddings_path": "output/gpu-performance-audit/lunit-cpu-transforms-wsi.pt",
+          "embeddings_sha256": "c939081b567ddfe03945c0bf3834ec4a11c4672d50aa03c10075bd368670e5c1",
+          "cache_advice": [],
+          "baseline_max_abs_error": 0.0,
+          "speedup": 1.35319709586562
+        }
+      },
+      "limitations": [
+        "Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. Unavailable counters are null."
+      ],
+      "audit_role": "experiment, not the final runtime",
+      "diagnostic_override": "Temporary wrapper restored original CPU preprocessing; source hashes do not represent this override."
+    }
+  },
+  "cached_weight_files": {
+    "lunit": {
+      "revision": "c23bc01cfbe022bc1f2a8a9306125a07818e4eb4",
+      "sha256": "0b7e0236ce430064b31485bbb6f85e661dc5eca0cde709e8f04d59f1c2b23e0b",
+      "size_bytes": 86694768
+    },
+    "phikonv2": {
+      "revision": "2ae989a9c40cffaa27f0a6cb29cc94d1d6f9a5fd",
+      "sha256": "261ae680fa699b3b951597fd57aa19c02ef735805acb104b93af69b36d928569",
+      "size_bytes": 1213455560
+    }
+  },
+  "diagnostic_limits": [
+    "Expanded candidate runs showed intermittent read-side stalls, including from RAM.",
+    "Native sample collection was stopped after 904 samples; 478 included the WSI reader, with sampling lag/errors.",
+    "Whole-run profiler diagnostic was terminated during an unusually long stall and is not a throughput measurement."
+  ],
+  "memory_pressure_observations": {
+    "cgroup_full_avg10_percent": 62.6,
+    "cgroup_full_avg60_percent": 43.4,
+    "host_full_avg10_percent": 31.02,
+    "note": "Read during anomalous runs; not per-sample attribution."
+  },
+  "retained_change": "CUDA scheduling overlap; original CPU preprocessing retained. GPU preprocessing prototype rejected.",
+  "qa_retained": {
+    "accounted_embedding_seconds": 9.3819,
+    "data_pipeline_fraction": 0.9607,
+    "data_pipeline_seconds": 9.0132,
+    "embedding_seconds": 11.2501,
+    "end_to_end_seconds": 16.9884,
+    "failed_slides": 0,
+    "forward_fraction": 0.0393,
+    "forward_seconds": 0.3687,
+    "gpu_busy_fraction": 0.0988,
+    "loader_wait_fraction": 0.9068,
+    "max_loader_wait_ms": 1226.718,
+    "mean_forward_ms": 12.2893,
+    "mean_loader_wait_ms": 283.4932,
+    "mean_preprocess_ms": 16.8516,
+    "mean_reader_open_ms": 8.219,
+    "mean_reader_read_ms": 274.4811,
+    "mean_ready_wait_ms": 0.0944,
+    "mean_worker_batch_ms": 282.7275,
+    "slide_artifacts": 0,
+    "slides_total": 1,
+    "slides_with_tiles": 1,
+    "success": true,
+    "tile_artifacts": 1,
+    "tiles_per_second": 27.9015,
+    "tiling_seconds": 5.5551,
+    "timed_batches": 30,
+    "total_tiles": 474
+  }
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ It ships with presets for the most widely used pathology foundation models.
    hierarchical
    output-layout
    glossary
+   performance
 
 .. toctree::
    :maxdepth: 1

--- a/docs/performance-audit-results.json
+++ b/docs/performance-audit-results.json
@@ -1,0 +1,410 @@
+{
+  "date": "2026-09-07",
+  "baseline_revision": "ab8959521ff6aea2e9c6fe8462be3ea471eaa4f8",
+  "timing_environment_note": "All timings below used installed hs2p 4.4.2. The 197-case correctness and real-fixture QA suite also passed with hs2p 4.4.3 loaded from an isolated package target.",
+  "scope": "CPU collation and CSV persistence; no claim of full pretrained model throughput or peak RSS reduction.",
+  "cpu_cases": {
+    "hierarchical": {
+      "before": {
+        "case": "hierarchical",
+        "parameters": {
+          "case": "hierarchical",
+          "repeat": 5,
+          "warmup": 1,
+          "threads": 1,
+          "regions": 2,
+          "region_size": 1024,
+          "tile_size": 256,
+          "rows": 10000,
+          "completed": 1000,
+          "slide": null
+        },
+        "environment": {
+          "python": "3.11.15",
+          "platform": "Linux-5.15.0-187-generic-x86_64-with-glibc2.35",
+          "torch": "2.7.1+cu128",
+          "numpy": "1.26.4",
+          "pandas": "3.0.5"
+        },
+        "seconds": [
+          0.08288466301746666,
+          0.07154374592937529,
+          0.0830684369429946,
+          0.08436419488862157,
+          0.0931343820411712
+        ],
+        "median_seconds": 0.0830684369429946,
+        "min_seconds": 0.07154374592937529,
+        "max_seconds": 0.0931343820411712,
+        "output_sha256": "e1c3f9ded0f1e38f63694966b29ed25db406ab55cb620ca769496a3c290b752a",
+        "source_sha256": "c55b7ad747a0fc99075020b68867d9025371f306d46e147eac82db46c04a385e",
+        "revision": "ab8959521ff6aea2e9c6fe8462be3ea471eaa4f8"
+      },
+      "after": {
+        "case": "hierarchical",
+        "parameters": {
+          "case": "hierarchical",
+          "repeat": 5,
+          "warmup": 1,
+          "threads": 1,
+          "regions": 2,
+          "region_size": 1024,
+          "tile_size": 256,
+          "rows": 10000,
+          "completed": 1000,
+          "slide": null
+        },
+        "environment": {
+          "python": "3.11.15",
+          "platform": "Linux-5.15.0-187-generic-x86_64-with-glibc2.35",
+          "torch": "2.7.1+cu128",
+          "numpy": "1.26.4",
+          "pandas": "3.0.5"
+        },
+        "seconds": [
+          0.022813010029494762,
+          0.016784907085821033,
+          0.016790971159934998,
+          0.01639058208093047,
+          0.013656269060447812
+        ],
+        "median_seconds": 0.016784907085821033,
+        "min_seconds": 0.013656269060447812,
+        "max_seconds": 0.022813010029494762,
+        "output_sha256": "e1c3f9ded0f1e38f63694966b29ed25db406ab55cb620ca769496a3c290b752a",
+        "source_sha256": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+        "revision": "ab8959521ff6aea2e9c6fe8462be3ea471eaa4f8",
+        "speedup": 4.948995935352317
+      },
+      "speedup": 4.948995935352317
+    },
+    "process-list": {
+      "before": {
+        "case": "process-list",
+        "parameters": {
+          "case": "process-list",
+          "repeat": 5,
+          "warmup": 1,
+          "threads": 1,
+          "regions": 2,
+          "region_size": 1024,
+          "tile_size": 256,
+          "rows": 10000,
+          "completed": 1000,
+          "slide": null
+        },
+        "environment": {
+          "python": "3.11.15",
+          "platform": "Linux-5.15.0-187-generic-x86_64-with-glibc2.35",
+          "torch": "2.7.1+cu128",
+          "numpy": "1.26.4",
+          "pandas": "3.0.5"
+        },
+        "seconds": [
+          1.6233368839602917,
+          1.5560297451447695,
+          1.5591882709413767,
+          1.5843179388903081,
+          1.5515629609581083
+        ],
+        "median_seconds": 1.5591882709413767,
+        "min_seconds": 1.5515629609581083,
+        "max_seconds": 1.6233368839602917,
+        "output_sha256": "b6163c0cae67544e9e1988743e31f1ad875a154b4ca7877e4ebb7a5a3ffad49c",
+        "source_sha256": "65ccbc118db449edf7014fa12b52a5c3d988e74531359b18f8bad91747f4400c",
+        "revision": "ab8959521ff6aea2e9c6fe8462be3ea471eaa4f8"
+      },
+      "after": {
+        "case": "process-list",
+        "parameters": {
+          "case": "process-list",
+          "repeat": 5,
+          "warmup": 1,
+          "threads": 1,
+          "regions": 2,
+          "region_size": 1024,
+          "tile_size": 256,
+          "rows": 10000,
+          "completed": 1000,
+          "slide": null
+        },
+        "environment": {
+          "python": "3.11.15",
+          "platform": "Linux-5.15.0-187-generic-x86_64-with-glibc2.35",
+          "torch": "2.7.1+cu128",
+          "numpy": "1.26.4",
+          "pandas": "3.0.5"
+        },
+        "seconds": [
+          0.07384687010198832,
+          0.07003257097676396,
+          0.0705054251011461,
+          0.07157046999782324,
+          0.07399658602662385
+        ],
+        "median_seconds": 0.07157046999782324,
+        "min_seconds": 0.07003257097676396,
+        "max_seconds": 0.07399658602662385,
+        "output_sha256": "b6163c0cae67544e9e1988743e31f1ad875a154b4ca7877e4ebb7a5a3ffad49c",
+        "source_sha256": "2ba0be4be76f4f0f37ed6bbe74b40661f81709fa13d96a4009e705c06550e7b2",
+        "revision": "ab8959521ff6aea2e9c6fe8462be3ea471eaa4f8",
+        "speedup": 21.785357438463073
+      },
+      "speedup": 21.785357438463073
+    },
+    "reconcile": {
+      "before": {
+        "case": "process-list",
+        "parameters": {
+          "case": "process-list",
+          "repeat": 3,
+          "warmup": 1,
+          "threads": 1,
+          "regions": 2,
+          "region_size": 1024,
+          "tile_size": 256,
+          "rows": 10000,
+          "completed": 10000,
+          "slide": null
+        },
+        "environment": {
+          "python": "3.11.15",
+          "platform": "Linux-5.15.0-187-generic-x86_64-with-glibc2.35",
+          "torch": "2.7.1+cu128",
+          "numpy": "1.26.4",
+          "pandas": "3.0.5"
+        },
+        "seconds": [
+          15.872406657086685,
+          16.01330602890812,
+          15.84019455080852
+        ],
+        "median_seconds": 15.872406657086685,
+        "min_seconds": 15.84019455080852,
+        "max_seconds": 16.01330602890812,
+        "output_sha256": "89bc31f0379bfbfcec04197c6ff290f55823a9647b4f131860c382b233ea1cdf",
+        "source_sha256": "65ccbc118db449edf7014fa12b52a5c3d988e74531359b18f8bad91747f4400c",
+        "revision": "ab8959521ff6aea2e9c6fe8462be3ea471eaa4f8"
+      },
+      "after": {
+        "case": "process-list",
+        "parameters": {
+          "case": "process-list",
+          "repeat": 3,
+          "warmup": 1,
+          "threads": 1,
+          "regions": 2,
+          "region_size": 1024,
+          "tile_size": 256,
+          "rows": 10000,
+          "completed": 10000,
+          "slide": null
+        },
+        "environment": {
+          "python": "3.11.15",
+          "platform": "Linux-5.15.0-187-generic-x86_64-with-glibc2.35",
+          "torch": "2.7.1+cu128",
+          "numpy": "1.26.4",
+          "pandas": "3.0.5"
+        },
+        "seconds": [
+          0.31083457078784704,
+          0.3146528929937631,
+          0.3067456460557878
+        ],
+        "median_seconds": 0.31083457078784704,
+        "min_seconds": 0.3067456460557878,
+        "max_seconds": 0.3146528929937631,
+        "output_sha256": "89bc31f0379bfbfcec04197c6ff290f55823a9647b4f131860c382b233ea1cdf",
+        "source_sha256": "2ba0be4be76f4f0f37ed6bbe74b40661f81709fa13d96a4009e705c06550e7b2",
+        "revision": "ab8959521ff6aea2e9c6fe8462be3ea471eaa4f8",
+        "speedup": 51.06383957503887
+      },
+      "speedup": 51.06383957503887
+    }
+  },
+  "real_slide": {
+    "methodology": {
+      "baseline": "ab8959521ff6aea2e9c6fe8462be3ea471eaa4f8",
+      "baseline_module": "git HEAD tile_reader.py compiled from temporary file",
+      "candidate_source_sha256": "ac4174f63fa09c831418554722d86c9e9ef37dce344ff070a29174204cd17f9a",
+      "fixture": "/data/pathology/projects/clement/code/slide2vec/tests/fixtures/input/test-wsi.tif",
+      "fixture_bytes": 26700580,
+      "backend": "hs2p OpenSlideReader",
+      "read_level": 0,
+      "region_coordinates": [
+        [
+          2048,
+          2048
+        ]
+      ],
+      "region_size_px": 1024,
+      "tile_size_px": 256,
+      "threads": 1,
+      "warmup_calls_per_implementation_per_case": 1,
+      "repeats": 5,
+      "order": "baseline,current on even repeat; current,baseline on odd repeat",
+      "timing_scope": "whole hierarchical collator: real reads, uint8 region packing, splitting, requested tile selection; no model",
+      "cache": "warm persistent reader handles and OS file cache; cold storage throughput not measured",
+      "python": "3.11.15 (main, Mar  3 2026, 09:26:23) [GCC 11.4.0]",
+      "torch": "2.7.1+cu128",
+      "platform": "Linux-5.15.0-187-generic-x86_64-with-glibc2.35",
+      "thread_environment": {
+        "OPENBLAS_NUM_THREADS": "1",
+        "OMP_NUM_THREADS": "1"
+      },
+      "limitations": "Shared host with concurrent workloads. Earlier 4-region 2048px attempt was interrupted during warmup after severe allocation/read delays; no throughput conclusion is drawn for that geometry. Complete model extraction and cold filesystem throughput are not measured."
+    },
+    "cases": {
+      "full": {
+        "requested_indices": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ],
+        "output_shape": [
+          16,
+          3,
+          256,
+          256
+        ],
+        "exact_indices_and_pixels": true,
+        "whole_collator_ms": {
+          "baseline": [
+            81.14918903447688,
+            70.81720908172429,
+            60.23765401914716,
+            81.8067688960582,
+            80.14103793539107
+          ],
+          "current": [
+            37.066994002088904,
+            36.72033315524459,
+            35.39293585345149,
+            37.20724582672119,
+            39.09206599928439
+          ]
+        },
+        "reader_read_ms": {
+          "baseline": [
+            33.73862197622657,
+            30.48769198358059,
+            30.55216697975993,
+            29.886229196563363,
+            30.540341045707464
+          ],
+          "current": [
+            31.60733706317842,
+            31.355180079117417,
+            30.40692093782127,
+            30.673285014927387,
+            32.17713418416679
+          ]
+        },
+        "median_ms": {
+          "baseline": 80.14103793539107,
+          "current": 37.066994002088904
+        },
+        "speedup": 2.162059268439052
+      },
+      "reordered_subset": {
+        "requested_indices": [
+          15,
+          0,
+          8,
+          3,
+          12,
+          4,
+          11,
+          7
+        ],
+        "output_shape": [
+          8,
+          3,
+          256,
+          256
+        ],
+        "exact_indices_and_pixels": true,
+        "whole_collator_ms": {
+          "baseline": [
+            78.21626798249781,
+            76.33628300391138,
+            54.26957900635898,
+            78.81325017660856,
+            54.545270977541804
+          ],
+          "current": [
+            35.201400984078646,
+            36.631711991503835,
+            35.51636706106365,
+            37.63795387931168,
+            35.319515969604254
+          ]
+        },
+        "reader_read_ms": {
+          "baseline": [
+            31.25333017669618,
+            30.48777114599943,
+            30.912655871361494,
+            32.12729305960238,
+            31.04234510101378
+          ],
+          "current": [
+            31.122887041419744,
+            32.77700603939593,
+            31.222200952470303,
+            33.36294600740075,
+            31.1684540938586
+          ]
+        },
+        "median_ms": {
+          "baseline": 76.33628300391138,
+          "current": 35.51636706106365
+        },
+        "speedup": 2.1493268968829393
+      }
+    },
+    "large_region_diagnostic": {
+      "shape": [
+        4,
+        3,
+        2048,
+        2048
+      ],
+      "open_seconds": 0.019230596022680402,
+      "read_seconds": 27.663633228978142,
+      "stack_seconds": 0.021312270080670714,
+      "contiguous_seconds": 0.05461251107044518,
+      "current_unfold_seconds": 0.0356422271579504,
+      "advanced_index_seconds": 0.06713819107972085,
+      "interpretation": "Single untimed-warmup diagnostic only; faulthandler caught hs2p make_white_canvas numpy.full during 20-second read stall. Host memory pressure full avg60 was about 18.75% before this probe."
+    }
+  },
+  "verification": {
+    "supported_hs2p": "4.4.3",
+    "tests_passed": 197,
+    "fixture_tiles": 474,
+    "fixture_feature_shape": [
+      474,
+      3
+    ],
+    "fixture_batches": 15,
+    "deterministic_csv_parity_cases": 32,
+    "additional_benchmark_checksum_test": "passed separately",
+    "pretrained_model_inference": "not run",
+    "multi_gpu_parity": "not run"
+  }
+}

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,175 @@
+# Measuring performance
+
+Use the CPU benchmark for changes to collation and process-list persistence, then the
+existing pipeline benchmarks for model/storage throughput. Run comparisons on the same
+host, dependency versions, inputs, thread settings and storage. Stop other benchmarks
+while timing; retain every repetition, including slow ones. Timing thresholds do not
+belong in CI.
+
+## Fast, offline measurements
+
+No weights, GPU, network access or private slide manifest are needed:
+
+```bash
+python scripts/benchmark_runtime.py --case hierarchical --output output/perf/hierarchical.json
+python scripts/benchmark_runtime.py --case process-list --output output/perf/flush.json
+python scripts/benchmark_runtime.py --case process-list --completed 10000 --repeat 3 --output output/perf/reconcile.json
+```
+
+The defaults use one PyTorch thread, one untimed warmup and five timed repetitions.
+Hierarchical collation reads two deterministic 1024×1024 RGB regions from an in-memory
+reader and returns 32 tiles of 256×256 pixels. Timing includes region packing, tile
+splitting and selection, but excludes fixture construction and checksum calculation.
+Use `--regions`, `--region-size`, `--tile-size`, and `--threads` to vary the workload.
+Large region batches can expose memory pressure that smaller measurements miss.
+
+The process-list case starts with 10,000 rows and completes 1,000 samples (the runtime's
+buffered tile checkpoint size). `--completed 10000` measures final reconciliation.
+Timing includes the actual CSV read, updates and atomic write in a temporary directory;
+resetting the initial CSV and hashing the result are outside the timer. This exercises
+warm filesystem caches, not durable storage throughput. `--rows` and `--completed`
+control the size. Temporary files are cleaned automatically.
+
+For real image reads using the checked-in fixture:
+
+```bash
+python scripts/benchmark_runtime.py --case hierarchical --regions 1 --region-size 1024 \
+  --slide tests/fixtures/input/test-wsi.tif --output output/perf/real-slide.json
+```
+
+This reads level-0 regions with OpenSlide, starting at (0, 0) in two columns. Warmup
+opens the reader and warms storage caches. OpenSlide and a real fixture (not an LFS
+pointer) are required. It measures collation, not encoder throughput.
+
+Each JSON contains all times, their median/range, parameters, dependency versions,
+Git revision, measured module hash and output SHA-256. `--compare before.json` rejects
+different parameters, environments or output hashes before reporting a speedup.
+A matching hash proves equality for that workload; retain the regression tests too.
+
+To compare a proposed change against an earlier revision without changing your working
+copy, replace `BASE_REF` with the baseline commit:
+
+```bash
+git worktree add --detach /tmp/slide2vec-before BASE_REF
+cp scripts/benchmark_runtime.py /tmp/slide2vec-before/scripts/benchmark_runtime.py
+python /tmp/slide2vec-before/scripts/benchmark_runtime.py --case hierarchical --output output/perf/before.json
+python scripts/benchmark_runtime.py --case hierarchical --compare output/perf/before.json --output output/perf/after.json
+```
+
+Both commands import their own checkout; the copied harness keeps methodology identical.
+Repeat with the same process-list or real-slide arguments on both commands. Alternate
+baseline and candidate runs when the host is noisy. Keep outputs outside the temporary
+checkout before removing it. A changed source hash distinguishes uncommitted code from
+its base revision.
+
+## Correctness and pipeline QA
+
+```bash
+python -m pytest tests/test_pooled_geometry.py tests/test_process_list_performance.py tests/test_benchmark_tooling.py --no-cov -q
+SLIDE2VEC_PERF_SMOKE=1 python -m pytest tests/test_benchmark_tooling.py -k real_fixture --no-cov -q
+```
+
+The regular tests cover exact byte pixels, reordered/duplicate subtiles, resize behavior,
+bounded tensor allocations, one-pass ID normalization, annotation isolation, and benchmark
+configuration/failure reporting. The opt-in test runs the existing end-to-end harness
+through `Pipeline.run` with the checked-in WSI and mask, a deterministic CPU mean encoder,
+and real readers. It checks 474 tiles, 15 batches and a finite `[474, 3]` saved tensor.
+It requires OpenSlide and ASAP mask support, but no pretrained weights. Changed upstream
+tiling behavior deliberately fails the expected-count check instead of silently measuring
+a different workload. It is a correctness smoke, not a foundation-model benchmark.
+
+For pretrained output parity, reuse `tests/test_output_consistency.py`; it requires PRISM
+weights, model access and the readers used by the existing CI image. The existing
+`gpu_integration` tests require two visible CUDA devices. Neither is substituted by the
+mean encoder smoke.
+
+## Full model and storage measurements
+
+Keep using the three existing entry points; they now share configuration adaptation and
+completed-work validation in `scripts/benchmark_common.py`:
+
+| Command | Purpose |
+| --- | --- |
+| `benchmark_embedding_throughput.py` | Sweep model, batch size, worker count and GPU count |
+| `benchmark_tile_read_strategies.py` | Compare readers while reusing prepared coordinates |
+| `benchmark_end_to_end_paths.py` | Compare complete tar/ASAP/cuCIM pipeline paths, including tiling |
+
+For example, with an accessible model configuration and a representative slide manifest:
+
+```bash
+python scripts/benchmark_embedding_throughput.py --csv slides.csv --config-file model.yaml \
+  --batch-sizes 32 64 --embedding-workers 2 4 --num-gpus 1 --repeat 3 --output-dir output/perf/sweep
+python scripts/benchmark_end_to_end_paths.py --csv slides.csv --config-file model.yaml \
+  --batch-size 32 --num-dataloader-workers 2 --num-preprocessing-workers 1 \
+  --warmup 1 --repeat 3 --output-dir output/perf/paths
+python scripts/benchmark_tile_read_strategies.py --help
+```
+
+The model config contains a current preset under `model.name` and any explicit geometry
+or precision settings. CPU construction is supported with `device: cpu`; pretrained
+CPU runs still need model weights. Reader comparison modes need their named backends,
+and model GPU runs need sufficient GPU memory. Use unique output directories: trial
+work directories are reset and heavy generated artifacts are removed by these scripts.
+They retain configs, logs, progress JSONL, trial CSVs and summary charts; `--chart-only`
+reuses saved trial CSVs. Root-level personal scripts are not required.
+
+Check exit codes, failure counts, completed work and consistent tile counts before
+comparing throughput. Failed or empty runs now fail the harness and do not become valid
+throughput results. Batch size can change embedding roundoff, so model output comparisons
+use the repository's tolerances. Do not silently change batch composition during an audit.
+
+Prefer repeated end-to-end wall time. `forward_ms` includes the blocking output transfer
+to CPU; `gpu_busy_fraction` is a derived wall-time ratio, **not measured GPU utilization**.
+Worker timings overlap and should not be summed as independent wall-clock costs. Use a
+CUDA profiler when attribution to kernels or transfers is required.
+
+## September 2026 audit
+
+The audit examined existing benchmark scripts, progress timing, CI and regression/WSI
+fixtures, then traced readers, batching, dense extraction, sharding, persistence and resume.
+Two production changes were retained:
+
+- Hierarchical splitting now rearranges uint8 pixels directly, removing float conversion,
+  im2col, rounding and clamping buffers. Tile ordering, selection and resizing are preserved.
+- Process-list completion now visits rows once and assigns each updated column in batches,
+  replacing one full scan and multiple masked writes per completed sample. Duplicate rows,
+  flat annotation sentinels and unfinished sibling annotations retain their behavior.
+  Empty provenance columns are explicitly writable as objects, fixing a reproduced pandas
+  error when filling a previously empty feature path.
+
+Measurements used Python 3.11.15, torch 2.7.1, NumPy 1.26.4, pandas 3.0.5 and hs2p 4.4.2
+on a shared Linux host. Median wall times:
+
+| Workload | Before | After | Speedup |
+| --- | ---: | ---: | ---: |
+| Real WSI collation, 16 tiles | 80.14 ms | 37.07 ms | 2.16× |
+| Real WSI collation, reordered 8-tile subset | 76.34 ms | 35.52 ms | 2.15× |
+| Synthetic collation, 32 tiles | 83.07 ms | 16.78 ms | 4.95× |
+| CSV flush, 1,000 of 10,000 rows | 1.559 s | 0.0716 s | 21.8× |
+| CSV reconciliation, all 10,000 rows | 15.872 s | 0.3108 s | 51.1× |
+
+Before/after raw results and limitations are in
+[performance-audit-results.json](performance-audit-results.json). These are CPU-path gains;
+no complete pretrained extraction speedup is claimed. The relevant 197-case correctness
+and real-fixture QA suite also passed with hs2p 4.4.3 (the minimum supported version)
+loaded in isolation; the host installation was left unchanged.
+
+The real-slide experiment alternated implementations for five warmed repetitions at
+(2048, 2048), with one 1024px region split into 256px tiles. Every repetition checked
+exact indices and pixels, including a reordered subset. Larger 2048px-region attempts
+encountered severe host allocation/read stalls; their noisy timings do not support a
+large-batch speedup claim. Use an otherwise idle host for production-sized memory tests.
+
+The tooling repair consolidated duplicate pipeline construction, config conversion,
+YAML loading and process-list parsing. It replaced removed API arguments and added
+regressions for failed/empty work, hierarchical artifacts and worker-setting precedence.
+The three sweep interfaces serve distinct measurement scopes and remain separate.
+
+Deferred opportunities: dense resume reads compatible sidecars twice, and shared-storage
+latency may make retaining parsed metadata worthwhile. This was traced but not optimized
+without a representative resume workload and filesystem baseline. Model startup, remote
+weight loading, multi-GPU transfers and cold storage need cached/authorized model weights,
+representative manifests, appropriate readers, and an otherwise idle GPU/storage setup.
+The database/N+1 category does not apply to the traced runtime: its hot persistence path
+is CSV plus per-artifact files. Existing supertile grouping and checkpoint batching were
+reused rather than replaced with another scheduling or caching system.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -123,6 +123,92 @@ to CPU; `gpu_busy_fraction` is a derived wall-time ratio, **not measured GPU uti
 Worker timings overlap and should not be summed as independent wall-clock costs. Use a
 CUDA profiler when attribution to kernels or transfers is required.
 
+## Fixed-coordinate pretrained inference
+
+Use the same runtime entry point to separate encoder compute from the cost of feeding it.
+This requires a compatible CUDA device, accessible pretrained weights and a real WSI.
+The audit's local H&E inputs are not distributed with the repository. Existing prepared
+coordinates can be supplied as an NPZ containing equally sized integer `x` and `y` vectors
+in level-0 pixels; reads use `--tile-size` at level 0, with no spacing inference.
+
+For example, reproduce the 64-coordinate H&E_5 workload recorded in
+`output/gpu-performance-audit/workload.json` and `he-5.npz`:
+
+```bash
+python - <<'PYCODE'
+from pathlib import Path
+import numpy as np
+
+output = Path("output/gpu-performance-audit")
+output.mkdir(parents=True, exist_ok=True)
+anchors = [(17408, 9216), (33792, 9216), (17408, 21504), (33792, 21504)]
+xy = np.array([(x + i * 224, y + j * 224)
+               for x, y in anchors for i in range(4) for j in range(4)], dtype=np.int64)
+np.savez(output / "he-5.npz", x=xy[:, 0], y=xy[:, 1])
+PYCODE
+
+python scripts/benchmark_runtime.py --case inference --model lunit \
+  --slide 'data/histai/wsi/slide_H&E_5.tiff' \
+  --coordinates output/gpu-performance-audit/he-5.npz --tile-size 224 \
+  --batch-size 16 --workers 0 --backend openslide --precision fp32 \
+  --modes model-only cached wsi --cache-policy warm --warmup 1 --repeat 5 \
+  --output output/gpu-performance-audit/before.json
+```
+
+The four 4×4 grids span separated 4096×4096 source TIFF blocks. They have no tissue
+filtering; verify dimensions and choose appropriate coordinates when using another slide.
+A 64-tile run is a bounded diagnostic, not evidence of whole-slide throughput. Expand the
+fixed workload before drawing conclusions about longer runs or other tissue distributions.
+
+| Mode | Timed work |
+| --- | --- |
+| `model-only` | Production forward on preprocessed device tensors, including CPU output transfer |
+| `cached` | Production preprocessing, transfer and forward on pre-read host byte tensors |
+| `wsi` | Production DataLoader/reader, preprocessing, transfer and forward |
+
+All modes preserve coordinate order and batch boundaries, including when supertiles are
+enabled. `--no-use-supertiles` disables grouped reads; `--workers` controls DataLoader
+workers explicitly. This isolates reader behavior and does not reproduce adaptive
+batch-size scheduling. Precision defaults to fp32; changing it changes the experiment.
+Model loading and preloading are outside the timed samples. CUDA synchronizes at timing
+boundaries; preloaded tensors remain allocated across modes, so reported peak allocation
+includes those buffers. Fixed-coordinate measurements exclude tissue detection, tiling
+and feature persistence; use the full pipeline harness for those costs.
+
+`--cache-policy warm` retains readers between repetitions and performs no eviction.
+`fresh-reader` closes owned readers/workers and includes reopening/startup in each sample,
+while filesystem caches remain uncontrolled. `advised-client-drop` additionally issues
+per-file `POSIX_FADV_DONTNEED` after closing owned readers, outside the timer. It records
+advisory errors and `fincore` observations where available. Advice and zero reported
+residency do not prove eviction on CIFS, and neither establishes **server-cold** storage.
+Cache policies apply only to `wsi`; preloaded modes do not evict input files. `/tmp` on the
+audit host is **tmpfs**, so staging there measures RAM-backed storage; report staging
+cost separately from extraction.
+
+Repeat the same command against the candidate with a distinct output path and
+`--compare output/gpu-performance-audit/before.json`. Comparison requires identical
+parameters, modes and environment, and checks saved embeddings with `rtol=atol=1e-4`
+before reporting speedup. Keep baseline JSON and its companion `.pt` files at their recorded paths;
+do not overwrite them. Each report retains every sample, throughput, peak allocated
+CUDA memory, model/dependency metadata, source hashes and embedding differences.
+Each timed sample also records parent-process minor/major page-fault deltas and Linux
+host/mounted-cgroup memory-pressure stall counters (`sample_resources`), collected
+outside the timer. Missing counters are null. Parent faults exclude reader workers;
+pressure counters are shared and cannot by themselves attribute stalls to this process.
+Inspect these alongside the complete timing distribution before accepting a speedup.
+
+Add `--profile` to export a separate untimed CPU/CUDA Chrome trace per mode next to the
+report. These extra profiler runs do not enter the timing statistics. Existing progress
+`forward_ms` measures host forward submission plus waiting for the CPU result, excluding
+overlapped prefetch. It is not GPU compute duration; historical values are not directly
+comparable after scheduling changes. `gpu_busy_fraction` is a host-time ratio, not measured
+GPU utilization. Use synchronized total time for throughput and traces for attribution. CPU-only correctness
+checks need no weights or GPU:
+
+```bash
+python -m pytest tests/test_inference_benchmark.py --no-cov -q
+```
+
 ## September 2026 audit
 
 The audit examined existing benchmark scripts, progress timing, CI and regression/WSI
@@ -168,8 +254,96 @@ The three sweep interfaces serve distinct measurement scopes and remain separate
 Deferred opportunities: dense resume reads compatible sidecars twice, and shared-storage
 latency may make retaining parsed metadata worthwhile. This was traced but not optimized
 without a representative resume workload and filesystem baseline. Model startup, remote
-weight loading, multi-GPU transfers and cold storage need cached/authorized model weights,
-representative manifests, appropriate readers, and an otherwise idle GPU/storage setup.
+weight loading and multi-GPU transfers remain unmeasured. The follow-up below measures
+cached pretrained inference and client-cache advice; server-cold storage still requires
+control or telemetry from the storage server.
 The database/N+1 category does not apply to the traced runtime: its hot persistence path
 is CSV plus per-artifact files. Existing supertile grouping and checkpoint batching were
 reused rather than replaced with another scheduling or caching system.
+
+
+## Pretrained GPU and storage follow-up
+
+The follow-up used cached Lunit and Phikon-v2 weights on an idle RTX 2080 Ti (11 GiB),
+fp32, batch size 16, one CPU thread, OpenSlide, supertiles, and hs2p 4.4.3 loaded from an
+isolated dependency directory. Python 3.11.15, torch 2.7.1+cu128, transformers 4.57.6 and
+timm 1.0.29 were unchanged between paired runs. Each measurement used one warmup and five
+repetitions; tables report medians. The baseline is commit `e6efef8` (the CPU audit).
+
+The retained runtime change submits CUDA inference before fetching/preprocessing the next
+batch, overlapping that host work with model compute. CPU and unsupported itemwise
+transforms retain their execution order. Preprocessing stays on its original device,
+preserving its numerical behavior. Each unpinned transfer gets its own pinned allocation,
+and CUDA inputs record their consumer stream to prevent reuse during asynchronous work.
+
+All rows below use 64 fixed tiles. Final Lunit outputs matched the baseline exactly.
+
+| Workload | Before | Retained change | Throughput ratio |
+| --- | ---: | ---: | ---: |
+| Lunit H&E_5: model-only | 0.341 s | 0.342 s | 1.00× |
+| Lunit H&E_5: cached pixels | 0.478 s | 0.393 s | 1.21× |
+| Lunit H&E_5: warm WSI | 1.009 s | 0.773 s | 1.30× |
+| Lunit H&E_3: warm WSI | 0.976 s | 0.743 s | 1.31× |
+| Lunit H&E_5: client-drop advice | 1.144 s | 0.911 s | 1.26× |
+
+Raw samples, source hashes, cached-weight SHA256/revisions, geometry and limitations are
+retained in [gpu-performance-audit-results.json](gpu-performance-audit-results.json).
+Runs prefixed `retained-` measure the final runtime. Other candidate runs are explicitly
+experimental; their timings do not describe the shipped implementation. Local `.pt`
+embeddings and large traces remain under `output/gpu-performance-audit/`.
+
+Phikon-v2 uses an unsupported transform closure and remains on the itemwise path. Its
+64-tile WSI comparison was 1.336 s versus 1.373 s and does not support a throughput gain.
+No precision, weights, geometry or batch-size changes were used to obtain the Lunit gains.
+
+An experiment also moved supported preprocessing onto the GPU, reducing the 64-tile
+Lunit host-to-device traffic from 38,535,168 to 9,633,888 bytes and producing additional
+throughput gains. It was dropped: interpolation introduced small embedding differences
+(maximum absolute error 0.000145), and larger-read results were too variable to justify
+changing the preprocessing path. Scheduling alone produced useful gains with exact
+pretrained outputs and keeps the smaller implementation. Historical GPU-preprocessing results are retained as
+experimental evidence, including slow samples.
+
+Expanding H&E_5 to 256 tiles (8×8 grids at the same four anchors, with 1792px
+supertile reads) exposed severe intermittent stalls. The GPU-preprocessing prototype's
+CIFS samples ranged from 5.61 to 51.92 s. RAM staging and disabling overlap did not
+eliminate them. The original runtime also stalled on recheck (14.15 s and 11.81 s,
+followed by approximately 5.1 s). Native samples during a stalled run were predominantly
+in OpenSlide/Pillow reads; sampling lag limits quantitative attribution. In a subsequent
+instrumented prototype run, a 43.97 s sample coincided with 36.78 s of shared cgroup memory-stall time; low-pressure samples took
+3.70–3.80 s. These counters support memory-pressure investigation but cannot attribute
+all shared stalls to the benchmark or prove the exact allocator mechanism. Removing
+CPU float intermediates can alter allocator reuse; no global allocator settings were
+changed. Do not extrapolate the 64-tile ratios to full slides or discard slow samples.
+
+The final scheduling-only 256-tile run had a 3.97 s median versus
+5.28 s, but retained a 29.25 s outlier with 22.89 s of shared cgroup
+memory-stall time. Including every sample, the means were 5.30 s before and
+9.01 s after. This is **not a uniform large-workload improvement**; memory-pressure
+isolation and longer paired runs are required before making that claim. All 256 embeddings
+matched the baseline exactly. The raw report retains every sample and its counters.
+
+The existing full pipeline harness ran with real Lunit weights and the repository
+WSI/mask fixture. Baseline and final runtime both completed 474 tiles and saved exactly
+equal `(474, 384)` embeddings. This is an end-to-end correctness check; a single fixture
+run does not establish end-to-end speedup. The 124-case relevant suite and 12-case focused
+final rerun passed, including CUDA ordering/lifetime tests. Structured reviews of the
+runtime, telemetry and final simplification returned no actionable findings.
+
+The 287,303,418-byte H&E_5 TIFF is on CIFS and has 4096×4096 JPEG source blocks.
+Reopening readers does not empty filesystem/server caches. Per-file cache advice is
+outside the measurement, and CIFS `fincore` observations do not establish actual eviction.
+An exploratory RAM-staging comparison barely changed warmed read/inference time while
+copying the entire slide cost 2.16 s separately; automatic whole-slide staging was not
+added. Worker counts remain workload-specific: warmed persistent-worker measurements
+exclude worker startup, while fresh-reader policy includes it.
+
+The final 64-tile WSI configuration measured 0.773 s with zero workers and 0.537 s with
+two persistent reader workers. Embeddings matched exactly. This is a configuration result,
+not a changed default; extra reader processes also consume additional memory.
+
+These results cover bounded level-0 workloads and one GPU. Actual server-cold performance
+requires an uncached server-side dataset or storage-admin cache control plus server I/O
+telemetry. Network weight downloads, multi-GPU scaling and complete large-slide extraction
+remain separate investigations. The benchmark exposes fixed inputs, cache controls,
+traces, resource counters and paired output checks for the next investigation.

--- a/scripts/benchmark_common.py
+++ b/scripts/benchmark_common.py
@@ -1,0 +1,148 @@
+"""Shared configuration adapter for the benchmark command-line workflows."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+
+def to_namespace(value: Any) -> Any:
+    if isinstance(value, dict):
+        return SimpleNamespace(**{key: to_namespace(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [to_namespace(item) for item in value]
+    return value
+
+
+def to_plain_data(value: Any) -> Any:
+    if value.__class__.__module__.startswith("omegaconf"):
+        from omegaconf import OmegaConf
+
+        return OmegaConf.to_container(value, resolve=True)
+    if isinstance(value, SimpleNamespace):
+        return {key: to_plain_data(item) for key, item in vars(value).items()}
+    if isinstance(value, dict):
+        return {key: to_plain_data(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [to_plain_data(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    import yaml
+
+    with path.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping config in {path}")
+    return data
+
+
+def build_pipeline(
+    config: dict[str, Any], *, reuse_coordinates: bool = False, worker_key: str = "num_dataloader_workers"
+):
+    """Adapt benchmark configs to the public API without loading model weights."""
+    from slide2vec import ExecutionOptions, Model, Pipeline, PreprocessingConfig
+
+    model_cfg = config.get("model", {})
+    tiling = config.get("tiling", {})
+    params = tiling.get("params", {})
+    speed = config.get("speed", {})
+    preview = dict(tiling.get("preview", {}))
+    # Historical benchmark configs used one preview switch.
+    if "save" in preview:
+        enabled = bool(preview.pop("save"))
+        preview.update(save_mask_preview=enabled, save_tiling_preview=enabled)
+    segmentation = dict(tiling.get("seg_params", {}))
+    use_otsu = segmentation.pop("use_otsu", False)
+    segmentation.pop("use_hsv", None)
+    if "method" not in segmentation:
+        segmentation["method"] = "otsu" if use_otsu else "hsv"
+    filtering = dict(tiling.get("filter_params", {}))
+    filtering.pop("max_n_holes", None)
+    coordinates = tiling.get("read_coordinates_from")
+    if reuse_coordinates and not coordinates:
+        coordinates = Path(config["output_dir"]) / "coordinates"
+    masks = tiling.get("masks", {})
+    if not masks and "tissue_threshold" in params:
+        masks = {"min_coverage": {"tissue": float(params["tissue_threshold"])}}
+    preprocessing = PreprocessingConfig(
+        backend=tiling.get("backend", "auto"),
+        mask_backend=tiling.get("mask_backend", "auto"),
+        requested_spacing_um=params.get("requested_spacing_um"),
+        requested_tile_size_px=params.get("requested_tile_size_px"),
+        requested_region_size_px=params.get("requested_region_size_px"),
+        region_tile_multiple=params.get("region_tile_multiple"),
+        tolerance=float(params.get("tolerance", 0.05)),
+        overlap=float(params.get("overlap", 0.0)),
+        masks=masks,
+        independent_sampling=bool(tiling.get("independent_sampling", True)),
+        read_coordinates_from=Path(coordinates) if coordinates else None,
+        read_tiles_from=Path(tiling["read_tiles_from"]) if tiling.get("read_tiles_from") else None,
+        on_the_fly=bool(tiling.get("on_the_fly", True)),
+        gpu_decode=bool(tiling.get("gpu_decode", False)),
+        adaptive_batching=bool(tiling.get("adaptive_batching", False)),
+        use_supertiles=bool(tiling.get("use_supertiles", True)),
+        jpeg_backend=tiling.get("jpeg_backend", "pil"),
+        num_cucim_workers=int(speed.get("num_cucim_workers") or tiling.get("num_cucim_workers", 4)),
+        resume=bool(config.get("resume", False)),
+        segmentation=segmentation,
+        filtering=filtering,
+        preview=preview,
+    )
+    device = config.get("device", "auto")
+    fallback_worker_key = "num_dataloader_workers" if worker_key == "num_workers_embedding" else "num_workers_embedding"
+    workers = speed.get(worker_key, speed.get(fallback_worker_key, speed.get("num_workers")))
+    execution = ExecutionOptions(
+        output_dir=Path(config["output_dir"]),
+        output_format=config.get("output_format", "pt"),
+        batch_size=int(model_cfg.get("batch_size", 32)),
+        num_workers_per_gpu=workers,
+        num_preprocessing_workers=speed.get("num_preprocessing_workers"),
+        num_gpus=1 if device == "cpu" else speed.get("num_gpus"),
+        precision=speed.get("precision"),
+        output_dtype=speed.get("output_dtype"),
+        prefetch_factor=int(speed.get("prefetch_factor_embedding", 4)),
+        save_tile_embeddings=bool(model_cfg.get("save_tile_embeddings", False)),
+        save_slide_embeddings=bool(model_cfg.get("save_slide_embeddings", False)),
+        save_latents=bool(model_cfg.get("save_latents", False)),
+    )
+    model = Model.from_preset(
+        str(model_cfg["name"]),
+        output_variant=model_cfg.get("output_variant"),
+        allow_non_recommended_settings=bool(model_cfg.get("allow_non_recommended_settings", False)),
+        device=device,
+    )
+    return Pipeline(model=model, preprocessing=preprocessing, execution=execution)
+
+
+def parse_process_list(path: Path) -> dict[str, int]:
+    """Count work and failures from the pipeline's persisted process list."""
+    import csv
+
+    if not path.is_file():
+        return {"slides_total": 0, "slides_with_tiles": 0, "failed_slides": 0, "total_tiles": 0}
+    with path.open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    tile_counts = [int(float(row.get("num_tiles") or 0)) for row in rows]
+    failed_slides = sum(
+        any(row.get(field) in {"error", "failed"} for field in ("tiling_status", "feature_status", "aggregation_status"))
+        for row in rows
+    )
+    return {
+        "slides_total": len(rows),
+        "slides_with_tiles": sum(count > 0 for count in tile_counts),
+        "failed_slides": failed_slides,
+        "total_tiles": sum(tile_counts),
+    }
+
+
+def validate_completed_work(process_stats: dict[str, int], result: Any) -> None:
+    """Failed or empty trials must never enter throughput summaries as successes."""
+    if process_stats["failed_slides"]:
+        raise RuntimeError(f"Benchmark pipeline reported {process_stats['failed_slides']} failed work units")
+    if process_stats["total_tiles"] <= 0 or not (
+        result.tile_artifacts or result.slide_artifacts or getattr(result, "hierarchical_artifacts", ())
+    ):
+        raise RuntimeError("Benchmark pipeline produced no completed embedding work")

--- a/scripts/benchmark_embedding_throughput.py
+++ b/scripts/benchmark_embedding_throughput.py
@@ -5,7 +5,6 @@ import copy
 import csv
 import json
 import math
-import os
 import random
 import shutil
 import statistics
@@ -36,6 +35,15 @@ def _prepend_repo_root_to_sys_path(paths: list[str]) -> list[str]:
 
 
 sys.path[:] = _prepend_repo_root_to_sys_path(sys.path)
+
+from scripts.benchmark_common import (  # noqa: E402
+    build_pipeline,
+    parse_process_list,
+    validate_completed_work,
+    load_yaml as _load_yaml,
+    to_namespace as _to_namespace,
+    to_plain_data as _to_plain_data,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -305,30 +313,6 @@ def build_trial_plan(
     return plan
 
 
-def _to_namespace(value: Any) -> Any:
-    if isinstance(value, dict):
-        return SimpleNamespace(**{key: _to_namespace(item) for key, item in value.items()})
-    if isinstance(value, list):
-        return [_to_namespace(item) for item in value]
-    return value
-
-
-def _to_plain_data(value: Any) -> Any:
-    if value.__class__.__module__.startswith("omegaconf"):
-        from omegaconf import OmegaConf
-
-        return OmegaConf.to_container(value, resolve=True)
-    if isinstance(value, SimpleNamespace):
-        return {key: _to_plain_data(item) for key, item in vars(value).items()}
-    if isinstance(value, dict):
-        return {key: _to_plain_data(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_to_plain_data(item) for item in value]
-    if isinstance(value, Path):
-        return str(value)
-    return value
-
-
 def build_trial_config(
     base_config: dict[str, Any] | SimpleNamespace,
     *,
@@ -353,16 +337,6 @@ def build_trial_config(
     config["speed"]["num_workers_embedding"] = int(embedding_workers)
     config["speed"]["num_gpus"] = int(num_gpus)
     return _to_namespace(config)
-
-
-def _load_yaml(path: Path) -> dict[str, Any]:
-    import yaml
-
-    with path.open(encoding="utf-8") as handle:
-        data = yaml.safe_load(handle) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"Expected mapping config in {path}")
-    return data
 
 
 def _load_cli_merged_config(path: Path) -> dict[str, Any]:
@@ -490,29 +464,6 @@ def extract_batch_timing_metrics(progress_path: Path) -> dict[str, float | int]:
         "mean_forward_ms": round(statistics.mean(forward_ms), 4),
         "loader_wait_fraction": round((sum(loader_wait_ms) + sum(ready_wait_ms)) / total_ms, 4) if total_ms > 0 else 0.0,
         "gpu_busy_fraction": round(statistics.mean(gpu_busy_fraction), 4),
-    }
-
-
-def parse_process_list(path: Path) -> dict[str, int]:
-    if not path.is_file():
-        return {
-            "slides_total": 0,
-            "slides_with_tiles": 0,
-            "failed_slides": 0,
-            "total_tiles": 0,
-        }
-
-    with path.open(newline="") as handle:
-        rows = list(csv.DictReader(handle))
-
-    total_tiles = sum(int(float(row.get("num_tiles") or 0)) for row in rows)
-    slides_with_tiles = sum(int(float(row.get("num_tiles") or 0)) > 0 for row in rows)
-    failed_slides = sum(row.get("tiling_status") == "failed" for row in rows)
-    return {
-        "slides_total": len(rows),
-        "slides_with_tiles": slides_with_tiles,
-        "failed_slides": failed_slides,
-        "total_tiles": total_tiles,
     }
 
 
@@ -779,62 +730,7 @@ def _resolve_gpu_label(value: str) -> str:
 
 
 def _build_model_pipeline_from_config(config: dict[str, Any]):
-    from slide2vec import ExecutionOptions, Model, Pipeline, PreprocessingConfig
-
-    model_cfg = config.get("model", {})
-    tiling_cfg = config.get("tiling", {})
-    params = tiling_cfg.get("params", {})
-    preview = dict(tiling_cfg.get("preview", {}))
-    preprocessing = PreprocessingConfig(
-        backend=str(tiling_cfg.get("backend", "asap")),
-        requested_spacing_um=float(params.get("requested_spacing_um", 0.5)),
-        requested_tile_size_px=int(params.get("requested_tile_size_px", 224)),
-        tolerance=float(params.get("tolerance", 0.05)),
-        overlap=float(params.get("overlap", 0.0)),
-        masks={"min_coverage": {"tissue": float(params.get("tissue_threshold", 0.01))}},
-        drop_holes=bool(params.get("drop_holes", False)),
-        use_padding=bool(params.get("use_padding", True)),
-        read_coordinates_from=(
-            Path(tiling_cfg["read_coordinates_from"])
-            if tiling_cfg.get("read_coordinates_from")
-            else Path(config["output_dir"]) / "coordinates"
-        ),
-        read_tiles_from=Path(tiling_cfg["read_tiles_from"]) if tiling_cfg.get("read_tiles_from") else None,
-        resume=bool(config.get("resume", False)),
-        segmentation=dict(tiling_cfg.get("seg_params", {})),
-        filtering=dict(tiling_cfg.get("filter_params", {})),
-        preview={
-            "save_mask_preview": bool(preview.get("save", False)),
-            "save_tiling_preview": bool(preview.get("save", False)),
-            "downsample": int(preview.get("downsample", 32)),
-        },
-    )
-    speed_cfg = config.get("speed", {})
-    execution = ExecutionOptions(
-        output_dir=Path(config["output_dir"]),
-        output_format=str(config.get("output_format", "pt")),
-        batch_size=int(model_cfg.get("batch_size", 1)),
-        num_workers=int(speed_cfg.get("num_workers_embedding", speed_cfg.get("num_workers", 0))),
-        num_gpus=int(speed_cfg["num_gpus"]) if speed_cfg.get("num_gpus") is not None else None,
-        precision=str(speed_cfg.get("precision", "fp32")),
-        prefetch_factor=int(speed_cfg.get("prefetch_factor_embedding", 4)),
-        persistent_workers=bool(speed_cfg.get("persistent_workers_embedding", True)),
-        save_tile_embeddings=bool(model_cfg.get("save_tile_embeddings", False)),
-        save_latents=bool(model_cfg.get("save_latents", False)),
-    )
-    model = Model.from_preset(
-        str(model_cfg["name"]),
-        level=model_cfg.get("level"),
-        mode=model_cfg.get("mode"),
-        arch=model_cfg.get("arch"),
-        pretrained_weights=model_cfg.get("pretrained_weights"),
-        input_size=model_cfg.get("input_size"),
-        patch_size=model_cfg.get("patch_size"),
-        token_size=model_cfg.get("token_size"),
-        normalize_embeddings=model_cfg.get("normalize_embeddings"),
-        device="auto",
-    )
-    return Pipeline(model=model, preprocessing=preprocessing, execution=execution)
+    return build_pipeline(config, reuse_coordinates=True, worker_key="num_workers_embedding")
 
 
 def _run_internal_harness(args: argparse.Namespace) -> int:
@@ -859,6 +755,7 @@ def _run_internal_harness(args: argparse.Namespace) -> int:
             result = pipeline.run(manifest_path=config["csv"])
         end_to_end_seconds = time.perf_counter() - t0
         process_stats = parse_process_list(output_dir / "process_list.csv")
+        validate_completed_work(process_stats, result)
         stage_seconds = extract_stage_seconds(progress_path)
         batch_timing = extract_batch_timing_metrics(progress_path)
         slides_total = int(process_stats["slides_total"])

--- a/scripts/benchmark_end_to_end_paths.py
+++ b/scripts/benchmark_end_to_end_paths.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from types import SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -68,6 +67,14 @@ def _prepend_repo_root_to_sys_path(paths: list[str]) -> list[str]:
 
 
 sys.path[:] = _prepend_repo_root_to_sys_path(sys.path)
+
+from scripts.benchmark_common import (  # noqa: E402
+    build_pipeline,
+    parse_process_list,
+    validate_completed_work,
+    load_yaml as _load_yaml,
+    to_plain_data as _to_plain_data,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -143,40 +150,6 @@ def write_slides_csv(slides: list[dict[str, Any]], path: Path) -> None:
             if has_spacing:
                 row["spacing_at_level_0"] = slide.get("spacing_at_level_0") or ""
             writer.writerow(row)
-
-
-def _load_yaml(path: Path) -> dict[str, Any]:
-    import yaml
-
-    with path.open(encoding="utf-8") as handle:
-        data = yaml.safe_load(handle) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"Expected mapping config in {path}")
-    return data
-
-
-def _to_namespace(value: Any) -> Any:
-    if isinstance(value, dict):
-        return SimpleNamespace(**{key: _to_namespace(item) for key, item in value.items()})
-    if isinstance(value, list):
-        return [_to_namespace(item) for item in value]
-    return value
-
-
-def _to_plain_data(value: Any) -> Any:
-    if value.__class__.__module__.startswith("omegaconf"):
-        from omegaconf import OmegaConf
-
-        return OmegaConf.to_container(value, resolve=True)
-    if isinstance(value, SimpleNamespace):
-        return {key: _to_plain_data(item) for key, item in vars(value).items()}
-    if isinstance(value, dict):
-        return {key: _to_plain_data(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_to_plain_data(item) for item in value]
-    if isinstance(value, Path):
-        return str(value)
-    return value
 
 
 def _load_cli_merged_config(path: Path) -> dict[str, Any]:
@@ -403,22 +376,6 @@ def extract_batch_timing_metrics(progress_path: Path) -> dict[str, float | int]:
     }
 
 
-def parse_process_list(path: Path) -> dict[str, int]:
-    if not path.is_file():
-        return {"slides_total": 0, "slides_with_tiles": 0, "failed_slides": 0, "total_tiles": 0}
-    with path.open(newline="") as handle:
-        rows = list(csv.DictReader(handle))
-    total_tiles = sum(int(float(row.get("num_tiles") or 0)) for row in rows)
-    slides_with_tiles = sum(int(float(row.get("num_tiles") or 0)) > 0 for row in rows)
-    failed_slides = sum(row.get("tiling_status") == "failed" for row in rows)
-    return {
-        "slides_total": len(rows),
-        "slides_with_tiles": slides_with_tiles,
-        "failed_slides": failed_slides,
-        "total_tiles": total_tiles,
-    }
-
-
 def save_csv(rows: list[dict[str, Any]], path: Path) -> None:
     if not rows:
         return
@@ -430,64 +387,7 @@ def save_csv(rows: list[dict[str, Any]], path: Path) -> None:
 
 
 def _build_pipeline_from_config_dict(config: dict[str, Any]):
-    from slide2vec import ExecutionOptions, Model, Pipeline, PreprocessingConfig
-
-    model_cfg = config.get("model", {})
-    tiling_cfg = config.get("tiling", {})
-    params = tiling_cfg.get("params", {})
-    preview = dict(tiling_cfg.get("preview", {}))
-    speed_cfg = config.get("speed", {})
-
-    preprocessing = PreprocessingConfig(
-        backend=str(tiling_cfg.get("backend", "cucim")),
-        requested_spacing_um=float(params.get("requested_spacing_um", 0.5)),
-        requested_tile_size_px=int(params.get("requested_tile_size_px", 256)),
-        tolerance=float(params.get("tolerance", 0.05)),
-        overlap=float(params.get("overlap", 0.0)),
-        masks={"min_coverage": {"tissue": float(params.get("tissue_threshold", 0.01))}},
-        drop_holes=bool(params.get("drop_holes", False)),
-        use_padding=bool(params.get("use_padding", True)),
-        read_coordinates_from=None,
-        read_tiles_from=None,
-        on_the_fly=bool(tiling_cfg.get("on_the_fly", True)),
-        gpu_decode=bool(tiling_cfg.get("gpu_decode", False)),
-        adaptive_batching=bool(tiling_cfg.get("adaptive_batching", False)),
-        use_supertiles=bool(tiling_cfg.get("use_supertiles", True)),
-        jpeg_backend=str(tiling_cfg.get("jpeg_backend", "turbojpeg")),
-        num_cucim_workers=int(speed_cfg.get("num_cucim_workers", tiling_cfg.get("num_cucim_workers", 4))),
-        resume=bool(config.get("resume", False)),
-        segmentation=dict(tiling_cfg.get("seg_params", {})),
-        filtering=dict(tiling_cfg.get("filter_params", {})),
-        preview={
-            "save_mask_preview": bool(preview.get("save", False)),
-            "save_tiling_preview": bool(preview.get("save", False)),
-            "downsample": int(preview.get("downsample", 32)),
-        },
-    )
-    execution = ExecutionOptions(
-        output_dir=Path(config["output_dir"]),
-        batch_size=int(model_cfg.get("batch_size", 256)),
-        num_workers=int(speed_cfg.get("num_dataloader_workers", speed_cfg.get("num_workers_embedding", 32))),
-        num_preprocessing_workers=int(speed_cfg.get("num_preprocessing_workers", 8)),
-        precision=str(speed_cfg.get("precision", "fp32")),
-        prefetch_factor=int(speed_cfg.get("prefetch_factor_embedding", 4)),
-        persistent_workers=bool(speed_cfg.get("persistent_workers_embedding", True)),
-        save_tile_embeddings=bool(model_cfg.get("save_tile_embeddings", False)),
-        save_latents=bool(model_cfg.get("save_latents", False)),
-    )
-    model = Model.from_preset(
-        str(model_cfg["name"]),
-        level=model_cfg.get("level", "tile"),
-        mode=model_cfg.get("mode"),
-        arch=model_cfg.get("arch"),
-        pretrained_weights=model_cfg.get("pretrained_weights"),
-        input_size=model_cfg.get("input_size"),
-        patch_size=model_cfg.get("patch_size"),
-        token_size=model_cfg.get("token_size"),
-        normalize_embeddings=model_cfg.get("normalize_embeddings"),
-        device="auto",
-    )
-    return Pipeline(model=model, preprocessing=preprocessing, execution=execution)
+    return build_pipeline(config, reuse_coordinates=False)
 
 
 def _run_internal_harness(args: argparse.Namespace) -> int:
@@ -511,6 +411,7 @@ def _run_internal_harness(args: argparse.Namespace) -> int:
             result = pipeline.run(manifest_path=config["csv"])
         end_to_end_seconds = time.perf_counter() - t0
         process_stats = parse_process_list(output_dir / "process_list.csv")
+        validate_completed_work(process_stats, result)
         metrics = {
             "success": True,
             "tile_artifacts": len(result.tile_artifacts),
@@ -977,7 +878,7 @@ def run_benchmark(args: argparse.Namespace) -> int:
     console.print(_make_summary_table(summary_rows))
     console.print(
         Panel(
-            f"[dim]end_to_end_by_path.png[/]\n[dim]stage_breakdown.png[/]\n[dim]embedding_subpath_breakdown.png[/]\n[dim]summary.csv[/]",
+            "[dim]end_to_end_by_path.png[/]\n[dim]stage_breakdown.png[/]\n[dim]embedding_subpath_breakdown.png[/]\n[dim]summary.csv[/]",
             title=f"[bold]Saved to[/] {output_dir}",
             expand=False,
         )

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -1,0 +1,296 @@
+"""Fixed-coordinate inference measurements, dispatched by benchmark_runtime.py.
+
+Model-only keeps prepared tensors on the device; cached keeps raw pixels on the host;
+WSI uses the production reader. All modes preserve input order and batch boundaries.
+"""
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+import platform
+from importlib.metadata import version
+import statistics
+import subprocess
+import time
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+
+def run_inference_benchmark(args):
+    for field in ("batch_size", "tile_size", "repeat", "threads"):
+        if getattr(args, field) < 1:
+            raise ValueError(f"{field} must be positive")
+    if args.workers < 0 or args.warmup < 0:
+        raise ValueError("workers and warmup must be nonnegative")
+    if not args.modes or set(args.modes) - {"model-only", "cached", "wsi"}:
+        raise ValueError("Unknown inference mode")
+    if args.cache_policy not in {"warm", "fresh-reader", "advised-client-drop"}:
+        raise ValueError("Unknown cache policy")
+    return _measure(args)
+
+
+def _sha256(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def _close_loader(loader):
+    # DataLoader has no public close API; ensure our worker readers are gone before advice.
+    iterator = getattr(loader, "_iterator", None)
+    if iterator is not None:
+        iterator._shutdown_workers()
+        loader._iterator = None
+    collator = getattr(loader, "collate_fn", None)
+    reader = getattr(getattr(collator, "_reader", None), "_reader", None)
+    if reader is not None:
+        close = getattr(reader, "close", None)
+        if close is not None:
+            close()
+        collator._reader._reader = None
+
+
+def _residency(path):
+    try:
+        completed = subprocess.run(
+            ["fincore", "--json", "--bytes", str(path)], capture_output=True, text=True, check=True,
+        )
+        return json.loads(completed.stdout)["fincore"][0]
+    except (OSError, subprocess.CalledProcessError, ValueError, KeyError):
+        return None
+
+
+def _advise_drop(path):
+    record = {"before": _residency(path), "advisory_only": True, "error": None}
+    try:
+        with Path(path).open("rb") as handle:
+            os.posix_fadvise(handle.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
+    except (AttributeError, OSError) as error:
+        record["error"] = str(error)
+    record["after"] = _residency(path)
+    return record
+
+
+def _measure(args):
+    import torch
+    from torch.utils.data import DataLoader
+    from slide2vec.data.dataset import TileIndexDataset
+    from slide2vec.data.tile_reader import OnTheFlyBatchTileCollator
+    from slide2vec.inference import load_model
+    from slide2vec.runtime.batching import build_batch_preprocessor, run_forward_pass
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+    from slide2vec.runtime.preprocessing import apply_transforms_itemwise
+
+    with np.load(args.coordinates, allow_pickle=False) as coordinates:
+        x, y = coordinates["x"], coordinates["y"]
+    if x.ndim != 1 or y.shape != x.shape or len(x) == 0:
+        raise ValueError("coordinates must contain equally sized, nonempty x and y vectors")
+    if not np.issubdtype(x.dtype, np.integer) or not np.issubdtype(y.dtype, np.integer):
+        raise ValueError("coordinates must be integer level-0 pixel locations")
+    if np.any(x < 0) or np.any(y < 0):
+        raise ValueError("coordinates must be nonnegative")
+    precision = getattr(args, "precision", "fp32")
+    if precision not in {"fp32", "fp16", "bf16"}:
+        raise ValueError("precision must be fp32, fp16, or bf16")
+    slide_stat = Path(args.slide).stat()
+    parameters = {
+        "model": args.model, "slide": str(Path(args.slide).resolve()),
+        "slide_size_bytes": slide_stat.st_size, "slide_mtime_ns": slide_stat.st_mtime_ns,
+        "coordinates_sha256": _sha256(args.coordinates), "num_tiles": len(x),
+        "tile_size": args.tile_size, "batch_size": args.batch_size, "workers": args.workers,
+        "backend": args.backend, "use_supertiles": args.use_supertiles,
+        "precision": precision, "threads": args.threads, "cache_policy": args.cache_policy,
+        "repeat": args.repeat, "warmup": args.warmup,
+    }
+    baseline = None
+    baseline_embeddings = {}
+    if getattr(args, "compare", None) is not None:
+        baseline = json.loads(Path(args.compare).read_text())
+        if baseline["parameters"] != parameters:
+            raise ValueError("Cannot compare inference runs with different parameters")
+        if set(baseline["modes"]) != set(args.modes):
+            raise ValueError("Cannot compare inference runs with different modes")
+        if Path(args.compare).resolve() == Path(args.output).resolve():
+            raise ValueError("Use a distinct output path to preserve the baseline")
+        output = Path(args.output)
+        baseline_paths = {
+            Path(measured["embeddings_path"]).resolve()
+            for measured in baseline["modes"].values()
+        }
+        output_paths = {
+            output.with_name(f"{output.stem}-{mode}.pt").resolve()
+            for mode in args.modes
+        }
+        if output_paths & baseline_paths:
+            raise ValueError("Use a distinct output stem to preserve the baseline embeddings")
+        baseline_embeddings = {
+            mode: torch.load(measured["embeddings_path"], map_location="cpu", weights_only=True)
+            for mode, measured in baseline["modes"].items()
+        }
+    device = getattr(args, "device", "cuda")
+    if str(device).startswith("cuda") and not torch.cuda.is_available():
+        raise RuntimeError("Inference benchmark requires CUDA (or an explicit CPU device)")
+    torch.set_num_threads(args.threads)
+    contract = EncoderInputContract.declared_pooled(
+        args.model, requested_tile_size_px=args.tile_size, allow_non_recommended_settings=False,
+    )
+    started = time.perf_counter()
+    print(f"Loading {args.model} on {device} ({precision})", flush=True)
+    loaded = load_model(name=args.model, encoder_input=contract, device=device)
+    cuda = loaded.device.type == "cuda"
+
+    def synchronize():
+        if cuda:
+            torch.cuda.synchronize(loaded.device)
+
+    synchronize()
+    model_load_seconds = time.perf_counter() - started
+    geometry = SimpleNamespace(
+        x=x, y=y, num_tiles=len(x), read_level=0, read_tile_size_px=args.tile_size,
+        requested_tile_size_px=args.tile_size, read_step_px=args.tile_size,
+        step_px_lv0=args.tile_size, tile_size_lv0=args.tile_size, overlap=0.,
+    )
+    preprocessor = build_batch_preprocessor(loaded, geometry)
+
+    def make_loader():
+        collator = OnTheFlyBatchTileCollator(
+            image_path=Path(args.slide), tiling_result=geometry, backend=args.backend,
+            num_cucim_workers=1, use_supertiles=args.use_supertiles,
+        )
+        options = dict(num_workers=args.workers, pin_memory=cuda)
+        if args.workers:
+            options.update(persistent_workers=True, prefetch_factor=2, multiprocessing_context="spawn")
+        # Keep caller coordinate order, including with supertiles; do not change GEMM batches.
+        return DataLoader(TileIndexDataset(np.arange(len(x))), batch_size=args.batch_size,
+                          collate_fn=collator, **options)
+
+    def autocast():
+        if cuda and precision != "fp32":
+            return torch.autocast("cuda", dtype=getattr(torch, {"fp16": "float16", "bf16": "bfloat16"}[precision]))
+        return nullcontext()
+
+    def forward(loader, prepare):
+        return run_forward_pass(loader, loaded, autocast(), batch_preprocessor=prepare, total_items=len(x))
+
+    raw_batches = None
+    prepared_batches = None
+    if {"cached", "model-only"}.intersection(args.modes):
+        reader_loader = make_loader()
+        try:
+            raw_batches = [(indices, pixels) for indices, pixels, *_ in reader_loader]
+        finally:
+            _close_loader(reader_loader)
+    if "model-only" in args.modes:
+        with torch.inference_mode():
+            prepared_batches = [
+                (indices, preprocessor(pixels) if preprocessor is not None else
+                 apply_transforms_itemwise(pixels, loaded.transforms).to(loaded.device))
+                for indices, pixels in raw_batches
+            ]
+        synchronize()
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    source_root = Path(__file__).resolve().parents[1]
+    source_names = ["scripts/benchmark_inference.py", "slide2vec/runtime/batching.py",
+                    "slide2vec/runtime/preprocessing.py", "slide2vec/data/tile_reader.py"]
+    encoder_source = Path(inspect.getfile(type(loaded.model)))
+    if encoder_source.is_relative_to(source_root):
+        source_names.append(str(encoder_source.relative_to(source_root)))
+    model_config = getattr(getattr(loaded.model, "_model", loaded.model), "config", None)
+    timm_config = getattr(getattr(loaded.model, "_model", None), "pretrained_cfg", {}) or {}
+    report = {
+        "case": "inference", "parameters": parameters,
+        "environment": {"python": platform.python_version(), "numpy": np.__version__,
+                        "hs2p": version("hs2p"), "transformers": version("transformers"), "timm": version("timm"),
+                        "torch": torch.__version__, "cuda": torch.version.cuda,
+                        "device": str(loaded.device),
+                        "gpu": torch.cuda.get_device_name(loaded.device) if cuda else None,
+                        "weight_revision": getattr(model_config, "_commit_hash", None) or timm_config.get("revision"),
+                        "weight_hub_id": getattr(model_config, "_name_or_path", None) or timm_config.get("hf_hub_id")},
+        "source_sha256": {name: _sha256(source_root / name) for name in source_names},
+        "model_load_seconds": model_load_seconds, "modes": {},
+        "limitations": ["Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
+                        "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
+                        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."],
+    }
+    if baseline is not None and baseline["environment"] != report["environment"]:
+        raise ValueError("Cannot compare inference runs with different environments")
+    reference = None
+    for mode in args.modes:
+        loader = make_loader() if mode == "wsi" else None
+        samples, peaks, cache_records = [], [], []
+        max_error = 0.
+        try:
+            for repetition in range(-args.warmup, args.repeat):
+                print(f"{args.model} {mode}: {'warmup' if repetition < 0 else 'sample'} "
+                      f"{repetition + 1 if repetition >= 0 else repetition + args.warmup + 1}", flush=True)
+                if mode == "wsi" and args.cache_policy != "warm":
+                    _close_loader(loader)
+                    loader = None
+                    if args.cache_policy == "advised-client-drop":
+                        cache_records.append(_advise_drop(args.slide))
+                synchronize()
+                if cuda:
+                    torch.cuda.reset_peak_memory_stats(loaded.device)
+                started = time.perf_counter()
+                if mode == "wsi":
+                    if loader is None:
+                        loader = make_loader()
+                    indices, embeddings = forward(loader, preprocessor)
+                elif mode == "cached":
+                    indices, embeddings = forward(raw_batches, preprocessor)
+                else:
+                    indices, embeddings = forward(prepared_batches, lambda pixels: pixels)
+                synchronize()
+                elapsed = time.perf_counter() - started
+                if repetition >= 0:
+                    samples.append(elapsed)
+                    peaks.append(torch.cuda.max_memory_allocated(loaded.device) if cuda else 0)
+                torch.testing.assert_close(indices, torch.arange(len(x)), rtol=0, atol=0)
+                if not torch.isfinite(embeddings).all():
+                    raise AssertionError("Inference produced nonfinite embeddings")
+                if reference is None:
+                    reference = embeddings.clone()
+                torch.testing.assert_close(embeddings, reference, rtol=1e-4, atol=1e-4)
+                max_error = max(max_error, float((embeddings.float() - reference.float()).abs().max()))
+            comparison = {}
+            if baseline is not None:
+                prior = baseline_embeddings[mode]
+                torch.testing.assert_close(embeddings, prior, rtol=1e-4, atol=1e-4)
+                comparison = {
+                    "baseline_max_abs_error": float((embeddings.float() - prior.float()).abs().max()),
+                    "speedup": baseline["modes"][mode]["median_seconds"] / statistics.median(samples),
+                }
+            embeddings_path = output.with_name(f"{output.stem}-{mode}.pt")
+            torch.save(embeddings, embeddings_path)
+            report["modes"][mode] = {
+                "samples_seconds": samples, "median_seconds": statistics.median(samples),
+                "tiles_per_second": len(x) / statistics.median(samples),
+                "peak_allocated_bytes": peaks, "max_abs_error": max_error,
+                "embeddings_path": str(embeddings_path), "embeddings_sha256": _sha256(embeddings_path),
+                "cache_advice": cache_records, **comparison,
+            }
+            if getattr(args, "profile", False):
+                activities = [torch.profiler.ProfilerActivity.CPU]
+                if cuda:
+                    activities.append(torch.profiler.ProfilerActivity.CUDA)
+                with torch.profiler.profile(activities=activities, record_shapes=True) as profile:
+                    if mode == "wsi":
+                        forward(loader, preprocessor)
+                    elif mode == "cached":
+                        forward(raw_batches, preprocessor)
+                    else:
+                        forward(prepared_batches, lambda pixels: pixels)
+                    synchronize()
+                trace = output.with_name(f"{output.stem}-{mode}-trace.json")
+                profile.export_chrome_trace(str(trace))
+                report["modes"][mode]["trace_path"] = str(trace)
+        finally:
+            if loader is not None:
+                _close_loader(loader)
+    output.write_text(json.dumps(report, indent=2) + "\n")
+    return report

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -38,6 +38,46 @@ def _sha256(path):
     return hashlib.sha256(Path(path).read_bytes()).hexdigest()
 
 
+def _resource_snapshot():
+    """Parent-process faults and shared Linux memory-pressure counters, when available."""
+    try:
+        import resource
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        minor, major = usage.ru_minflt, usage.ru_majflt
+    except (ImportError, AttributeError, OSError):
+        minor = major = None
+
+    def pressure(path):
+        try:
+            totals = {}
+            for line in Path(path).read_text().splitlines():
+                kind, *fields = line.split()
+                if kind in {"some", "full"}:
+                    totals[kind] = int(dict(field.split("=", 1) for field in fields)["total"])
+            return {kind: totals[kind] for kind in ("some", "full")}
+        except (OSError, ValueError, KeyError):
+            return None
+
+    return {
+        "parent_minor_faults": minor, "parent_major_faults": major,
+        "cgroup_memory_psi_us": pressure("/sys/fs/cgroup/memory.pressure"),
+        "host_memory_psi_us": pressure("/proc/pressure/memory"),
+    }
+
+
+def _resource_delta(before, after):
+    delta = {}
+    for key, start in before.items():
+        end = after[key]
+        if start is None or end is None:
+            delta[key] = None
+        elif isinstance(start, dict):
+            delta[key] = _resource_delta(start, end)
+        else:
+            delta[key] = end - start if end >= start else None
+    return delta
+
+
 def _close_loader(loader):
     # DataLoader has no public close API; ensure our worker readers are gone before advice.
     iterator = getattr(loader, "_iterator", None)
@@ -215,14 +255,17 @@ def _measure(args):
         "model_load_seconds": model_load_seconds, "modes": {},
         "limitations": ["Fixed level-0 coordinates; excludes tissue detection, tiling and output persistence.",
                         "Model-only includes CPU output transfer; preloaded tensors remain allocated across modes.",
-                        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed."],
+                        "Cache advice is not proof of eviction or server-cold storage; tmpfs is RAM-backed.",
+                        "Resource snapshots bracket each timed sample outside its timer. Faults cover only the parent process; "
+                        "host/cgroup PSI microseconds are shared pressure, not necessarily caused by this process. "
+                        "Unavailable counters are null."],
     }
     if baseline is not None and baseline["environment"] != report["environment"]:
         raise ValueError("Cannot compare inference runs with different environments")
     reference = None
     for mode in args.modes:
         loader = make_loader() if mode == "wsi" else None
-        samples, peaks, cache_records = [], [], []
+        samples, peaks, cache_records, sample_resources = [], [], [], []
         max_error = 0.
         try:
             for repetition in range(-args.warmup, args.repeat):
@@ -236,6 +279,7 @@ def _measure(args):
                 synchronize()
                 if cuda:
                     torch.cuda.reset_peak_memory_stats(loaded.device)
+                resources_before = _resource_snapshot() if repetition >= 0 else None
                 started = time.perf_counter()
                 if mode == "wsi":
                     if loader is None:
@@ -248,6 +292,7 @@ def _measure(args):
                 synchronize()
                 elapsed = time.perf_counter() - started
                 if repetition >= 0:
+                    sample_resources.append(_resource_delta(resources_before, _resource_snapshot()))
                     samples.append(elapsed)
                     peaks.append(torch.cuda.max_memory_allocated(loaded.device) if cuda else 0)
                 torch.testing.assert_close(indices, torch.arange(len(x)), rtol=0, atol=0)
@@ -269,6 +314,7 @@ def _measure(args):
             torch.save(embeddings, embeddings_path)
             report["modes"][mode] = {
                 "samples_seconds": samples, "median_seconds": statistics.median(samples),
+                "sample_resources": sample_resources,
                 "tiles_per_second": len(x) / statistics.median(samples),
                 "peak_allocated_bytes": peaks, "max_abs_error": max_error,
                 "embeddings_path": str(embeddings_path), "embeddings_sha256": _sha256(embeddings_path),

--- a/scripts/benchmark_runtime.py
+++ b/scripts/benchmark_runtime.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Repeatable CPU runtime benchmarks; see docs/performance.md for scope and comparison."""
+
+import argparse
+import hashlib
+from importlib.metadata import version
+import json
+import platform
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def hierarchical_workload(args):
+    from slide2vec.data.tile_reader import OnTheFlyHierarchicalBatchCollator
+
+    size, tile = args.region_size, args.tile_size
+    if size % tile:
+        raise ValueError('--region-size must be divisible by --tile-size')
+    per_region = (size // tile) ** 2
+    # Distinct pixels/channels/regions, without randomness or model weights.
+    region = np.arange(size * size * 3, dtype=np.uint8).reshape(size, size, 3)
+    regions = [(region + i).astype(np.uint8) for i in range(args.regions)]
+    collator = OnTheFlyHierarchicalBatchCollator(
+        image_path=args.slide or Path('synthetic.svs'),
+        tiling_result=SimpleNamespace(
+            read_level=0,
+            x=(np.arange(args.regions) % 2) * size if args.slide else np.arange(args.regions),
+            y=(np.arange(args.regions) // 2) * size if args.slide else np.zeros(args.regions),
+        ),
+        region_index=np.repeat(np.arange(args.regions), per_region),
+        subtile_index_within_region=np.tile(np.arange(per_region), args.regions),
+        read_region_size_px=size, read_tile_size_px=tile,
+        requested_tile_size_px=tile, backend='openslide',
+    )
+
+    class Reader:
+        def read_region(self, location, level, size):
+            return regions[location[0]]
+
+    # Exclude storage/decoding so this measures the complete CPU collation path.
+    if not args.slide:
+        collator._reader._reader = Reader()
+    indices = list(range(args.regions * per_region))
+
+    def run():
+        return collator(indices)[1]
+
+    def digest(result):
+        return hashlib.sha256(result.numpy().tobytes()).hexdigest()
+
+    return run, digest, lambda: None
+
+
+def process_list_workload(args):
+    from slide2vec.runtime.persistence import update_process_list_after_embedding
+
+    directory = tempfile.TemporaryDirectory(prefix='slide2vec-perf-')
+    path = Path(directory.name) / 'process_list.csv'
+    initial = pd.DataFrame({
+        'sample_id': [f'slide-{i}' for i in range(args.rows)],
+        'annotation': ['tissue'] * args.rows,
+        'feature_status': ['tbp'] * args.rows,
+    }).to_csv(index=False)
+    count = min(args.completed, args.rows)
+    slides = [SimpleNamespace(sample_id=f'slide-{i}') for i in range(count)]
+    artifacts = [
+        SimpleNamespace(sample_id=s.sample_id, annotation=None,
+                        path=Path('/benchmark/embeddings') / f'{s.sample_id}.pt')
+        for s in slides
+    ]
+
+    def reset():
+        path.write_text(initial)
+
+    def run():
+        update_process_list_after_embedding(
+            path, successful_slides=slides, persist_tile_embeddings=True,
+            persist_hierarchical_embeddings=False, include_slide_embeddings=False,
+            encoder_name='benchmark', output_variant='default', tile_artifacts=artifacts,
+            hierarchical_artifacts=[], slide_artifacts=[],
+        )
+        return path
+
+    def digest(result):
+        return hashlib.sha256(result.read_bytes()).hexdigest()
+
+    # Keep the temporary directory alive for the lifetime of these closures.
+    run.directory = directory
+    return run, digest, reset
+
+
+def positive_int(value):
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError('must be positive')
+    return parsed
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--case', choices=['hierarchical', 'process-list'], required=True)
+    parser.add_argument('--repeat', type=positive_int, default=5)
+    parser.add_argument('--warmup', type=positive_int, default=1)
+    parser.add_argument('--threads', type=positive_int, default=1)
+    parser.add_argument('--regions', type=positive_int, default=2)
+    parser.add_argument('--region-size', type=positive_int, default=1024)
+    parser.add_argument('--tile-size', type=positive_int, default=256)
+    parser.add_argument('--rows', type=positive_int, default=10000)
+    parser.add_argument('--completed', type=positive_int, default=1000)
+    parser.add_argument('--slide', type=Path, help='Read real level-0 regions with OpenSlide instead of synthetic pixels')
+    parser.add_argument('--compare', type=Path, help='Require matching workload/output and report speedup against this JSON')
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    if args.slide and args.case != 'hierarchical':
+        parser.error('--slide is only supported for --case hierarchical')
+    torch.set_num_threads(args.threads)
+    factory = hierarchical_workload if args.case == 'hierarchical' else process_list_workload
+    run, digest, reset = factory(args)
+    for _ in range(args.warmup):
+        reset()
+        result = run()
+        del result
+    samples = []
+    checksums = set()
+    for _ in range(args.repeat):
+        reset()
+        start = time.perf_counter()
+        result = run()
+        samples.append(time.perf_counter() - start)
+        checksums.add(digest(result))
+        del result
+    if len(checksums) != 1:
+        raise RuntimeError('Repeated runs produced different outputs')
+    report = {
+        'case': args.case,
+        'parameters': {k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+                       if k not in ('output', 'compare')},
+        'environment': {'python': platform.python_version(), 'platform': platform.platform(),
+                        'torch': torch.__version__, 'numpy': np.__version__, 'pandas': pd.__version__,
+                        'hs2p': version('hs2p')},
+        'seconds': samples, 'median_seconds': statistics.median(samples),
+        'min_seconds': min(samples), 'max_seconds': max(samples),
+        'output_sha256': checksums.pop(),
+    }
+    source = ('slide2vec/data/tile_reader.py' if args.case == 'hierarchical'
+              else 'slide2vec/runtime/persistence.py')
+    root = Path(__file__).resolve().parents[1]
+    report['source_sha256'] = hashlib.sha256((root / source).read_bytes()).hexdigest()
+    revision = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=root, capture_output=True, text=True)
+    report['revision'] = revision.stdout.strip() if revision.returncode == 0 else None
+    if args.compare:
+        baseline = json.loads(args.compare.read_text())
+        if baseline['parameters'] != report['parameters'] or baseline['environment'] != report['environment']:
+            raise ValueError('Baseline workload/environment differs; rerun with matching arguments and dependencies')
+        if baseline['output_sha256'] != report['output_sha256']:
+            raise ValueError('Baseline output differs; investigate correctness before comparing performance')
+        report['speedup'] = baseline['median_seconds'] / report['median_seconds']
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/benchmark_runtime.py
+++ b/scripts/benchmark_runtime.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Repeatable CPU runtime benchmarks; see docs/performance.md for scope and comparison."""
+"""Repeatable runtime benchmarks; see docs/performance.md for scope and comparison."""
 
 import argparse
 import hashlib
@@ -109,7 +109,7 @@ def positive_int(value):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--case', choices=['hierarchical', 'process-list'], required=True)
+    parser.add_argument('--case', choices=['hierarchical', 'process-list', 'inference'], required=True)
     parser.add_argument('--repeat', type=positive_int, default=5)
     parser.add_argument('--warmup', type=positive_int, default=1)
     parser.add_argument('--threads', type=positive_int, default=1)
@@ -120,8 +120,26 @@ def main():
     parser.add_argument('--completed', type=positive_int, default=1000)
     parser.add_argument('--slide', type=Path, help='Read real level-0 regions with OpenSlide instead of synthetic pixels')
     parser.add_argument('--compare', type=Path, help='Require matching workload/output and report speedup against this JSON')
+    parser.add_argument('--model', default='phikonv2', help='Pretrained encoder for inference measurements')
+    parser.add_argument('--coordinates', type=Path, help='NPZ of fixed level-0 x/y coordinates for inference')
+    parser.add_argument('--batch-size', type=positive_int, default=16)
+    parser.add_argument('--workers', type=int, default=0)
+    parser.add_argument('--backend', choices=['openslide', 'cucim', 'asap', 'vips'], default='openslide')
+    parser.add_argument('--modes', nargs='+', choices=['model-only', 'cached', 'wsi'], default=['model-only', 'cached', 'wsi'])
+    parser.add_argument('--use-supertiles', action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument('--cache-policy', choices=['warm', 'fresh-reader', 'advised-client-drop'], default='warm')
+    parser.add_argument('--precision', choices=['fp32', 'fp16', 'bf16'], default='fp32')
+    parser.add_argument('--device', choices=['cuda', 'cpu'], default='cuda')
+    parser.add_argument('--profile', action='store_true', help='Export separate untimed inference CPU/CUDA profiler traces')
     parser.add_argument('--output', type=Path, required=True)
     args = parser.parse_args()
+    if args.case == 'inference':
+        if args.slide is None or args.coordinates is None:
+            parser.error('--case inference requires --slide and --coordinates')
+        from scripts.benchmark_inference import run_inference_benchmark
+
+        print(json.dumps(run_inference_benchmark(args), indent=2))
+        return
     if args.slide and args.case != 'hierarchical':
         parser.error('--slide is only supported for --case hierarchical')
     torch.set_num_threads(args.threads)
@@ -145,7 +163,8 @@ def main():
     report = {
         'case': args.case,
         'parameters': {k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
-                       if k not in ('output', 'compare')},
+                       if k in ('case', 'repeat', 'warmup', 'threads', 'regions', 'region_size',
+                                'tile_size', 'rows', 'completed', 'slide')},
         'environment': {'python': platform.python_version(), 'platform': platform.platform(),
                         'torch': torch.__version__, 'numpy': np.__version__, 'pandas': pd.__version__,
                         'hs2p': version('hs2p')},

--- a/scripts/benchmark_tile_read_strategies.py
+++ b/scripts/benchmark_tile_read_strategies.py
@@ -13,8 +13,6 @@ Compares five configurations in increasing order of optimization:
 import argparse
 import csv
 import json
-import math
-import os
 import shutil
 import statistics
 import subprocess
@@ -105,6 +103,13 @@ def _prepend_repo_root_to_sys_path(paths: list[str]) -> list[str]:
 
 
 sys.path[:] = _prepend_repo_root_to_sys_path(sys.path)
+
+from scripts.benchmark_common import (  # noqa: E402
+    build_pipeline,
+    parse_process_list,
+    validate_completed_work,
+    load_yaml as _load_yaml,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -230,16 +235,6 @@ def write_slides_csv(slides: list[dict[str, Any]], path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Config helpers
 # ---------------------------------------------------------------------------
-
-def _load_yaml(path: Path) -> dict[str, Any]:
-    import yaml
-
-    with path.open(encoding="utf-8") as handle:
-        data = yaml.safe_load(handle) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"Expected mapping config in {path}")
-    return data
-
 
 def _write_yaml(data: dict[str, Any], path: Path) -> None:
     import yaml
@@ -469,22 +464,6 @@ def extract_batch_timing_metrics(progress_path: Path) -> dict[str, float | int]:
     }
 
 
-def parse_process_list(path: Path) -> dict[str, int]:
-    if not path.is_file():
-        return {"slides_total": 0, "slides_with_tiles": 0, "failed_slides": 0, "total_tiles": 0}
-    with path.open(newline="") as handle:
-        rows = list(csv.DictReader(handle))
-    total_tiles = sum(int(float(row.get("num_tiles") or 0)) for row in rows)
-    slides_with_tiles = sum(int(float(row.get("num_tiles") or 0)) > 0 for row in rows)
-    failed_slides = sum(row.get("tiling_status") == "failed" for row in rows)
-    return {
-        "slides_total": len(rows),
-        "slides_with_tiles": slides_with_tiles,
-        "failed_slides": failed_slides,
-        "total_tiles": total_tiles,
-    }
-
-
 def save_csv(rows: list[dict[str, Any]], path: Path) -> None:
     if not rows:
         return
@@ -500,72 +479,7 @@ def save_csv(rows: list[dict[str, Any]], path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def _build_pipeline_from_config_dict(config: dict[str, Any]):
-    from slide2vec import ExecutionOptions, Model, Pipeline, PreprocessingConfig
-
-    model_cfg = config.get("model", {})
-    tiling_cfg = config.get("tiling", {})
-    params = tiling_cfg.get("params", {})
-    preview = dict(tiling_cfg.get("preview", {}))
-    speed_cfg = config.get("speed", {})
-
-    preprocessing = PreprocessingConfig(
-        backend=str(tiling_cfg.get("backend", "cucim")),
-        requested_spacing_um=float(params.get("requested_spacing_um", 0.5)),
-        requested_tile_size_px=int(params.get("requested_tile_size_px", 256)),
-        tolerance=float(params.get("tolerance", 0.05)),
-        overlap=float(params.get("overlap", 0.0)),
-        masks={"min_coverage": {"tissue": float(params.get("tissue_threshold", 0.01))}},
-        drop_holes=bool(params.get("drop_holes", False)),
-        use_padding=bool(params.get("use_padding", True)),
-        read_coordinates_from=(
-            Path(tiling_cfg["read_coordinates_from"])
-            if tiling_cfg.get("read_coordinates_from")
-            else Path(config["output_dir"]) / "coordinates"
-        ),
-        read_tiles_from=(
-            Path(tiling_cfg["read_tiles_from"])
-            if tiling_cfg.get("read_tiles_from")
-            else None
-        ),
-        on_the_fly=bool(tiling_cfg.get("on_the_fly", True)),
-        gpu_decode=bool(tiling_cfg.get("gpu_decode", False)),
-        adaptive_batching=bool(tiling_cfg.get("adaptive_batching", False)),
-        use_supertiles=bool(tiling_cfg.get("use_supertiles", True)),
-        jpeg_backend=str(tiling_cfg.get("jpeg_backend", "turbojpeg")),
-        num_cucim_workers=int(speed_cfg.get("num_cucim_workers", tiling_cfg.get("num_cucim_workers", 4))),
-        resume=bool(config.get("resume", False)),
-        segmentation=dict(tiling_cfg.get("seg_params", {})),
-        filtering=dict(tiling_cfg.get("filter_params", {})),
-        preview={
-            "save_mask_preview": bool(preview.get("save", False)),
-            "save_tiling_preview": bool(preview.get("save", False)),
-            "downsample": int(preview.get("downsample", 32)),
-        },
-    )
-    execution = ExecutionOptions(
-        output_dir=Path(config["output_dir"]),
-        batch_size=int(model_cfg.get("batch_size", 256)),
-        num_workers=int(speed_cfg.get("num_dataloader_workers", speed_cfg.get("num_workers_embedding", 32))),
-        num_preprocessing_workers=int(speed_cfg.get("num_preprocessing_workers", 8)),
-        precision=str(speed_cfg.get("precision", "fp32")),
-        prefetch_factor=int(speed_cfg.get("prefetch_factor_embedding", 4)),
-        persistent_workers=bool(speed_cfg.get("persistent_workers_embedding", True)),
-        save_tile_embeddings=bool(model_cfg.get("save_tile_embeddings", False)),
-        save_latents=bool(model_cfg.get("save_latents", False)),
-    )
-    model = Model.from_preset(
-        str(model_cfg["name"]),
-        level=model_cfg.get("level", "tile"),
-        mode=model_cfg.get("mode"),
-        arch=model_cfg.get("arch"),
-        pretrained_weights=model_cfg.get("pretrained_weights"),
-        input_size=model_cfg.get("input_size"),
-        patch_size=model_cfg.get("patch_size"),
-        token_size=model_cfg.get("token_size"),
-        normalize_embeddings=model_cfg.get("normalize_embeddings"),
-        device="auto",
-    )
-    return Pipeline(model=model, preprocessing=preprocessing, execution=execution)
+    return build_pipeline(config, reuse_coordinates=True)
 
 
 def _run_internal_harness(args: argparse.Namespace) -> int:
@@ -590,6 +504,7 @@ def _run_internal_harness(args: argparse.Namespace) -> int:
             result = pipeline.run(manifest_path=config["csv"])
         end_to_end_seconds = time.perf_counter() - t0
         process_stats = parse_process_list(output_dir / "process_list.csv")
+        validate_completed_work(process_stats, result)
         stage_seconds = extract_stage_seconds(progress_path)
         batch_timing = extract_batch_timing_metrics(progress_path)
         slides_total = int(process_stats["slides_total"])
@@ -1036,6 +951,7 @@ def _print_log_panel(console: "Any", log_path: Path, title: str = "Error log") -
         log = "(no output captured)"
     console.print(Panel(log, title=f"[red]{title}[/]", border_style="red", highlight=False))
 
+
 def _make_summary_table(summary_rows: list[dict[str, Any]], *, baseline_mode: str = "tar") -> "Any":
     from rich.table import Table
 
@@ -1260,9 +1176,9 @@ def run_benchmark(args: argparse.Namespace) -> int:
     console.print(
         Panel(
             (
-                f"[dim]throughput_by_strategy.png[/]\n[dim]timing_breakdown.png[/]\n[dim]summary.csv[/]"
+                "[dim]throughput_by_strategy.png[/]\n[dim]timing_breakdown.png[/]\n[dim]summary.csv[/]"
                 if len(batch_sizes) == 1
-                else f"[dim]throughput_by_batch_size.png[/]\n[dim]throughput_by_strategy_bs*.png[/]\n[dim]timing_breakdown_bs*.png[/]\n[dim]summary.csv[/]"
+                else "[dim]throughput_by_batch_size.png[/]\n[dim]throughput_by_strategy_bs*.png[/]\n[dim]timing_breakdown_bs*.png[/]\n[dim]summary.csv[/]"
             ),
             title=f"[bold]Saved to[/] {output_dir}",
             expand=False,

--- a/slide2vec/data/tile_reader.py
+++ b/slide2vec/data/tile_reader.py
@@ -510,14 +510,14 @@ def _unfold_region_tensor_uint8(region_tensor: torch.Tensor, tile_size: int) -> 
         return torch.empty((0, 0, 3, tile_size, tile_size), dtype=torch.uint8)
     if int(region_tensor.shape[-1]) % tile_size != 0 or int(region_tensor.shape[-2]) % tile_size != 0:
         raise ValueError("Region tensor dimensions must be divisible by the tile size")
-    unfolded = torch.nn.functional.unfold(
-        region_tensor.to(torch.float32),
-        kernel_size=tile_size,
-        stride=tile_size,
+    batch, channels, height, width = region_tensor.shape
+    # Disjoint tiles need only a layout change. Keep pixels as bytes instead of
+    # materializing float regions and im2col buffers, then converting them back.
+    return (
+        region_tensor.reshape(batch, channels, height // tile_size, tile_size, width // tile_size, tile_size)
+        .permute(0, 2, 4, 1, 3, 5)
+        .reshape(batch, -1, channels, tile_size, tile_size)
     )
-    unfolded = unfolded.transpose(1, 2)
-    reshaped = unfolded.reshape(region_tensor.shape[0], -1, region_tensor.shape[1], tile_size, tile_size)
-    return reshaped.round().clamp(0, 255).to(torch.uint8)
 
 
 def _area_resize_tile_batch(

--- a/slide2vec/runtime/batching.py
+++ b/slide2vec/runtime/batching.py
@@ -60,10 +60,6 @@ def build_batch_preprocessor_for_tile_images(
         return None
 
     def preprocess(batch):
-        # Transfer the pinned byte batch before expanding it to float and replay
-        # supported transforms on the encoder device.
-        if batch.device != loaded.device:
-            batch = batch.to(loaded.device, non_blocking=str(loaded.device).startswith("cuda"))
         image = prepare_batch_tensor(batch)
         if spec.resize_size is None:
             image = resize_image_batch(
@@ -71,6 +67,8 @@ def build_batch_preprocessor_for_tile_images(
                 (int(requested_tile_size_px), int(requested_tile_size_px)),
             )
         image = apply_batch_transform_spec(image, spec)
+        if image.device != loaded.device:
+            image = image.to(loaded.device, non_blocking=str(loaded.device).startswith("cuda"))
         return image.contiguous()
 
     return preprocess

--- a/slide2vec/runtime/batching.py
+++ b/slide2vec/runtime/batching.py
@@ -60,6 +60,10 @@ def build_batch_preprocessor_for_tile_images(
         return None
 
     def preprocess(batch):
+        # Transfer the pinned byte batch before expanding it to float and replay
+        # supported transforms on the encoder device.
+        if batch.device != loaded.device:
+            batch = batch.to(loaded.device, non_blocking=str(loaded.device).startswith("cuda"))
         image = prepare_batch_tensor(batch)
         if spec.resize_size is None:
             image = resize_image_batch(
@@ -67,8 +71,6 @@ def build_batch_preprocessor_for_tile_images(
                 (int(requested_tile_size_px), int(requested_tile_size_px)),
             )
         image = apply_batch_transform_spec(image, spec)
-        if image.device != loaded.device:
-            image = image.to(loaded.device, non_blocking=str(loaded.device).startswith("cuda"))
         return image.contiguous()
 
     return preprocess
@@ -110,7 +112,8 @@ class BatchPrefetcher:
         self.loaded = loaded
         self.batch_preprocessor = batch_preprocessor
         self.copy_stream = self._make_copy_stream()
-        self._pinned_host_buffer = None
+        self.defer_preload = self.copy_stream is not None and batch_preprocessor is not None
+        self._exhausted = False
         self._next_batch: PreparedBatch | None = None
         self._preload()
 
@@ -132,18 +135,10 @@ class BatchPrefetcher:
             return image
         if image.device.type != "cpu" or image.is_pinned():
             return image
-        if (
-            self._pinned_host_buffer is None
-            or tuple(self._pinned_host_buffer.shape) != tuple(image.shape)
-            or self._pinned_host_buffer.dtype != image.dtype
-        ):
-            self._pinned_host_buffer = torch.empty(
-                image.shape,
-                dtype=image.dtype,
-                pin_memory=True,
-            )
-        self._pinned_host_buffer.copy_(image)
-        return self._pinned_host_buffer
+        # A shared staging buffer could be overwritten by the next preload while
+        # its asynchronous H2D copy is still pending. PyTorch tracks the lifetime
+        # of each pinned allocation until the transfer completes.
+        return image.pin_memory()
 
     def _prepare_batch(self, image):
         preprocess_start = time.perf_counter()
@@ -160,10 +155,13 @@ class BatchPrefetcher:
         return prepared, preprocess_ms
 
     def _preload(self) -> None:
+        if self._exhausted or self._next_batch is not None:
+            return
         wait_start = time.perf_counter()
         try:
             batch = next(self.iterator)
         except StopIteration:
+            self._exhausted = True
             self._next_batch = None
             return
         loader_wait_ms = (time.perf_counter() - wait_start) * 1000.0
@@ -206,6 +204,7 @@ class BatchPrefetcher:
         return self
 
     def __next__(self) -> PreparedBatch:
+        self._preload()
         if self._next_batch is None:
             raise StopIteration
         current = self._next_batch
@@ -213,8 +212,12 @@ class BatchPrefetcher:
             ready_start = time.perf_counter()
             current_stream = torch.cuda.current_stream(device=self.loaded.device)
             current_stream.wait_stream(self.copy_stream)
+            if torch.is_tensor(current.image) and current.image.is_cuda:
+                current.image.record_stream(current_stream)
             current.ready_wait_ms = (time.perf_counter() - ready_start) * 1000.0
-        self._preload()
+        self._next_batch = None
+        if not self.defer_preload:
+            self._preload()
         return current
 
 
@@ -254,8 +257,16 @@ def iter_forward_batches(
             image = prepared_batch.image
             _record_encoder_input_size(loaded, image)
             forward_start = time.perf_counter()
-            embedding = loaded.model.encode_tiles(image).detach().cpu()
+            embedding = loaded.model.encode_tiles(image).detach()
             forward_ms = (time.perf_counter() - forward_start) * 1000.0
+            if prefetcher.defer_preload:
+                # Launch CUDA work before blocking on the next reader batch. CPU
+                # and itemwise transforms retain their original execution order.
+                prefetcher._preload()
+            result_start = time.perf_counter()
+            embedding = embedding.cpu()
+            # Residual host time excludes the overlapping preload, not GPU time.
+            forward_ms += (time.perf_counter() - result_start) * 1000.0
             current_indices = torch.as_tensor(prepared_batch.indices, dtype=torch.long).detach().cpu()
             processed += int(embedding.shape[0])
             batch_index += 1

--- a/slide2vec/runtime/persistence.py
+++ b/slide2vec/runtime/persistence.py
@@ -230,44 +230,42 @@ def update_process_list_after_embedding(
         feature_success_ids = {slide.sample_id for slide in successful_slides}
     feature_success_keys = set(feature_path_by_key)
     annotation_aware = any(annotation is not None for _, annotation in feature_success_keys)
+    successful_ids = {slide.sample_id for slide in successful_slides}
     row_annotations = _row_annotation_series(df)
-    for slide in successful_slides:
-        mask = df["sample_id"].astype(str) == slide.sample_id
-        if annotation_aware:
-            # Resolve each (sample_id, annotation) row independently so per-class paths and
-            # statuses don't bleed across the slide's other annotation rows. An incremental
-            # update may contain only one finished annotation, so unmatched siblings stay
-            # untouched until their own artifact is available.
-            for annotation in _row_annotations(row_annotations, mask):
-                # ``== None`` is element-wise False in pandas, so match the flat None key
-                # via isna() and real classes via equality.
-                if annotation is None:
-                    row_mask = mask & row_annotations.isna()
-                else:
-                    row_mask = mask & (row_annotations == annotation)
-                key = (slide.sample_id, annotation)
-                mapped_feature_path = feature_path_by_key.get(key)
-                if mapped_feature_path is not None:
-                    df.loc[row_mask, "feature_status"] = "success"
-                    df.loc[row_mask, "feature_path"] = mapped_feature_path
-                    df.loc[row_mask, "encoder_name"] = encoder_name
-                    df.loc[row_mask, "output_variant"] = output_variant
-                    df.loc[row_mask, "feature_kind"] = feature_kind
-                if include_slide_embeddings and key in slide_success_keys:
-                    df.loc[row_mask, "aggregation_status"] = "success"
-        else:
-            feature_status = "success" if slide.sample_id in feature_success_ids else "error"
-            df.loc[mask, "feature_status"] = feature_status
-            mapped_feature_path = feature_path_by_key.get((slide.sample_id, None))
-            if mapped_feature_path is not None:
-                df.loc[mask, "feature_path"] = mapped_feature_path
-                df.loc[mask, "encoder_name"] = encoder_name
-                df.loc[mask, "output_variant"] = output_variant
-                df.loc[mask, "feature_kind"] = feature_kind
-            if include_slide_embeddings:
-                df.loc[mask, "aggregation_status"] = (
-                    "success" if slide.sample_id in slide_success_ids else "error"
-                )
+    status_rows, statuses = [], []
+    feature_rows, feature_paths = [], []
+    aggregation_rows, aggregation_statuses = [], []
+    # Visit each CSV row once, including duplicate rows. The old per-slide masks
+    # repeatedly converted/scanned the whole table during every checkpoint flush.
+    for index, sample_id, annotation in zip(df.index, df["sample_id"].astype(str), row_annotations):
+        if sample_id not in successful_ids:
+            continue
+        key = (sample_id, _normalized_annotation(annotation) if annotation_aware else None)
+        mapped_feature_path = feature_path_by_key.get(key)
+        if not annotation_aware or mapped_feature_path is not None:
+            status_rows.append(index)
+            statuses.append("success" if sample_id in feature_success_ids else "error")
+        if mapped_feature_path is not None:
+            feature_rows.append(index)
+            feature_paths.append(mapped_feature_path)
+        # An incremental annotation update leaves unfinished sibling classes alone.
+        if include_slide_embeddings and (not annotation_aware or key in slide_success_keys):
+            aggregation_rows.append(index)
+            aggregation_statuses.append("success" if sample_id in slide_success_ids else "error")
+
+    if status_rows:
+        df.loc[status_rows, "feature_status"] = statuses
+    if feature_rows:
+        # Empty CSV columns are inferred as floats. Explicit object columns also
+        # allow provenance to be filled on pandas versions that reject upcasting.
+        for column in ("feature_path", "encoder_name", "output_variant", "feature_kind"):
+            df[column] = df[column].astype(object)
+        df.loc[feature_rows, "feature_path"] = feature_paths
+        df.loc[feature_rows, "encoder_name"] = encoder_name
+        df.loc[feature_rows, "output_variant"] = output_variant
+        df.loc[feature_rows, "feature_kind"] = feature_kind
+    if aggregation_rows:
+        df.loc[aggregation_rows, "aggregation_status"] = aggregation_statuses
     atomic_write_dataframe_csv(df, process_list_path)
 
 
@@ -291,13 +289,3 @@ def _row_annotation_series(df: pd.DataFrame) -> pd.Series:
     if "annotation" not in df.columns:
         return pd.Series([np.nan] * len(df), index=df.index, dtype=object)
     return df["annotation"].map(lambda value: _normalized_annotation(value) or np.nan)
-
-
-def _row_annotations(row_annotations: pd.Series, mask: pd.Series) -> list[str | None]:
-    """Distinct normalized annotations present in the masked rows (``None`` for flat rows)."""
-    seen: list[str | None] = []
-    for value in row_annotations[mask].tolist():
-        normalized = None if value is None or (isinstance(value, float) and pd.isna(value)) else value
-        if normalized not in seen:
-            seen.append(normalized)
-    return seen

--- a/tests/test_benchmark_tooling.py
+++ b/tests/test_benchmark_tooling.py
@@ -1,0 +1,193 @@
+"""Benchmark configuration stays compatible with the public pipeline API."""
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("module_name,builder,reuses_coordinates", [
+    ("benchmark_end_to_end_paths", "_build_pipeline_from_config_dict", False),
+    ("benchmark_tile_read_strategies", "_build_pipeline_from_config_dict", True),
+    ("benchmark_embedding_throughput", "_build_model_pipeline_from_config", True),
+])
+def test_benchmark_config_preserves_requested_pipeline_settings(module_name, builder, reuses_coordinates):
+    module = importlib.import_module(f"scripts.{module_name}")
+    pipeline = getattr(module, builder)({
+        "output_dir": "/tmp/benchmark-config-only",
+        "device": "cpu",
+        "model": {"name": "phikonv2", "batch_size": 8},
+        "speed": {"num_dataloader_workers": 2, "precision": "fp32"},
+        "tiling": {
+            "backend": "openslide",
+            "params": {"requested_spacing_um": 0.5, "requested_tile_size_px": 224},
+            "masks": {"min_coverage": {"tissue": 0.3}},
+            "preview": {"save": False},
+        },
+    })
+    assert pipeline.execution.batch_size == 8
+    assert pipeline.execution.num_workers_per_gpu == 2
+    assert pipeline.execution.num_gpus == 1
+    assert pipeline.execution.precision == "fp32"
+    assert pipeline.preprocessing.backend == "openslide"
+    assert pipeline.preprocessing.requested_tile_size_px == 224
+    assert pipeline.preprocessing.requested_spacing_um == 0.5
+    assert pipeline.preprocessing.masks["min_coverage"]["tissue"] == 0.3
+    assert pipeline.preprocessing.preview["save_mask_preview"] is False
+    assert pipeline.preprocessing.read_coordinates_from == (
+        Path("/tmp/benchmark-config-only/coordinates") if reuses_coordinates else None
+    )
+
+
+@pytest.mark.parametrize("module_name,builder", [
+    ("benchmark_end_to_end_paths", "_build_pipeline_from_config_dict"),
+    ("benchmark_tile_read_strategies", "_build_pipeline_from_config_dict"),
+    ("benchmark_embedding_throughput", "_build_model_pipeline_from_config"),
+])
+@pytest.mark.parametrize("process_rows", [
+    "broken,error,,10\n",
+    "broken,success,error,10\n",
+    "empty,success,,0\n",
+])
+def test_benchmark_harness_rejects_failed_or_empty_work(tmp_path, monkeypatch, module_name, builder, process_rows):
+    import json
+    from types import SimpleNamespace
+
+    module = importlib.import_module(f"scripts.{module_name}")
+    (tmp_path / "process_list.csv").write_text(
+        "sample_id,tiling_status,feature_status,num_tiles\n" + process_rows
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"output_dir: {tmp_path}\ncsv: unused.csv\n")
+    pipeline = SimpleNamespace(run=lambda **kwargs: SimpleNamespace(tile_artifacts=[object()], slide_artifacts=[]))
+    monkeypatch.setattr(module, builder, lambda config: pipeline)
+    args = SimpleNamespace(
+        harness_config=config_path, config_file=config_path,
+        metrics_json=tmp_path / "metrics.json", progress_jsonl=tmp_path / "progress.jsonl",
+    )
+
+    assert module._run_internal_harness(args) == 1
+    metrics = json.loads(args.metrics_json.read_text())
+    assert metrics["success"] is False
+    assert metrics["tiles_per_second"] == 0.0
+
+
+def test_benchmark_accepts_completed_hierarchical_artifacts():
+    from types import SimpleNamespace
+    from scripts.benchmark_common import validate_completed_work
+
+    validate_completed_work(
+        {"failed_slides": 0, "total_tiles": 4},
+        SimpleNamespace(tile_artifacts=[], slide_artifacts=[], hierarchical_artifacts=[object()]),
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("SLIDE2VEC_PERF_SMOKE") != "1",
+    reason="Set SLIDE2VEC_PERF_SMOKE=1 for the real WSI reader and CPU encoder smoke test",
+)
+def test_benchmark_real_fixture_cpu_pipeline(tmp_path, monkeypatch):
+    """Run real reading, batching, persistence and metrics without pretrained weights."""
+    import json
+    from types import SimpleNamespace
+
+    import torch
+    from torchvision import transforms
+    import yaml
+
+    from slide2vec.api import Model
+    from slide2vec.runtime.types import LoadedModel
+    from scripts.benchmark_end_to_end_paths import _run_internal_harness
+
+    class MeanEncoder:
+        encoder = SimpleNamespace(pretrained_cfg={})
+
+        def encode_tiles(self, image):
+            return image.mean(dim=(-2, -1))
+
+    loaded = LoadedModel(
+        name="phikonv2", level="tile", model=MeanEncoder(),
+        transforms=transforms.Compose([transforms.ToTensor()]),
+        feature_dim=3, device=torch.device("cpu"),
+    )
+    monkeypatch.setattr(Model, "_load_backend", lambda self: loaded)
+    monkeypatch.setattr(Model, "_load_backend_without_transform", lambda self: loaded)
+    fixtures = Path(__file__).parent / "fixtures" / "input"
+    manifest = tmp_path / "slides.csv"
+    manifest.write_text(
+        f'sample_id,image_path,mask_path\ntest-wsi,{fixtures / "test-wsi.tif"},{fixtures / "test-mask.tif"}\n'
+    )
+    config = {
+        "csv": str(manifest), "output_dir": str(tmp_path), "device": "cpu",
+        "model": {"name": "phikonv2", "batch_size": 32},
+        "speed": {"num_dataloader_workers": 0, "num_preprocessing_workers": 1, "num_gpus": 1, "precision": "fp32"},
+        "tiling": {
+            "backend": "openslide", "mask_backend": "asap", "on_the_fly": True, "use_supertiles": False,
+            "params": {"requested_spacing_um": 0.5, "requested_tile_size_px": 224, "tolerance": 0.07},
+            "preview": {"save": False},
+        },
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+    args = SimpleNamespace(
+        harness_config=config_path, metrics_json=tmp_path / "metrics.json", progress_jsonl=tmp_path / "progress.jsonl",
+    )
+    original_threads = torch.get_num_threads()
+    try:
+        torch.set_num_threads(1)
+        assert _run_internal_harness(args) == 0
+    finally:
+        torch.set_num_threads(original_threads)
+    metrics = json.loads(args.metrics_json.read_text())
+    assert metrics["success"] is True
+    assert metrics["failed_slides"] == 0
+    assert metrics["total_tiles"] == 474
+    assert metrics["tile_artifacts"] == 1
+    assert metrics["timed_batches"] == 15
+    features = torch.load(tmp_path / "tile_embeddings" / "test-wsi.pt", weights_only=True)
+    assert features.shape == (474, 3)
+    assert bool(torch.isfinite(features).all())
+
+
+@pytest.mark.parametrize("module_name,builder,expected_workers", [
+    ("benchmark_end_to_end_paths", "_build_pipeline_from_config_dict", 2),
+    ("benchmark_tile_read_strategies", "_build_pipeline_from_config_dict", 2),
+    ("benchmark_embedding_throughput", "_build_model_pipeline_from_config", 7),
+])
+def test_benchmark_worker_override_beats_legacy_config(module_name, builder, expected_workers):
+    module = importlib.import_module(f"scripts.{module_name}")
+    pipeline = getattr(module, builder)({
+        "output_dir": "/tmp/benchmark-config-only", "device": "cpu",
+        "model": {"name": "phikonv2"},
+        "speed": {"num_dataloader_workers": 2, "num_workers_embedding": 7},
+    })
+    assert pipeline.execution.num_workers_per_gpu == expected_workers
+
+
+def test_runtime_benchmark_checks_expected_pixels_and_rejects_changed_baseline(tmp_path, monkeypatch):
+    import hashlib
+    import json
+    import sys
+    from scripts import benchmark_runtime
+
+    output = tmp_path / 'result.json'
+    arguments = ['benchmark_runtime.py', '--case', 'hierarchical', '--regions', '1',
+                 '--region-size', '4', '--tile-size', '2', '--repeat', '1', '--output', str(output)]
+    monkeypatch.setattr(sys, 'argv', arguments)
+    benchmark_runtime.main()
+    report = json.loads(output.read_text())
+    # Four RGB tiles, channel-first inside each tile, row-major across the region.
+    expected_pixels = bytes([
+        0, 3, 12, 15, 1, 4, 13, 16, 2, 5, 14, 17,
+        6, 9, 18, 21, 7, 10, 19, 22, 8, 11, 20, 23,
+        24, 27, 36, 39, 25, 28, 37, 40, 26, 29, 38, 41,
+        30, 33, 42, 45, 31, 34, 43, 46, 32, 35, 44, 47,
+    ])
+    assert report['output_sha256'] == hashlib.sha256(expected_pixels).hexdigest()
+    baseline = tmp_path / 'before.json'
+    report['output_sha256'] = 'changed-output'
+    baseline.write_text(json.dumps(report))
+    monkeypatch.setattr(sys, 'argv', [*arguments, '--compare', str(baseline)])
+    with pytest.raises(ValueError, match='Baseline output differs'):
+        benchmark_runtime.main()

--- a/tests/test_inference_benchmark.py
+++ b/tests/test_inference_benchmark.py
@@ -1,0 +1,97 @@
+"""Behavioral checks for the fixed-coordinate inference measurement workflow."""
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize("field,value,message", [
+    ("batch_size", 0, "batch_size must be positive"),
+    ("modes", ["unknown"], "Unknown inference mode"),
+    ("cache_policy", "server-cold", "Unknown cache policy"),
+])
+def test_inference_benchmark_rejects_invalid_workloads(field, value, message):
+    from scripts.benchmark_inference import run_inference_benchmark
+
+    args = SimpleNamespace(batch_size=2, tile_size=224, repeat=1, warmup=0,
+                           workers=0, threads=1, modes=["cached"], cache_policy="warm")
+    setattr(args, field, value)
+    with pytest.raises(ValueError, match=message):
+        run_inference_benchmark(args)
+
+
+def test_inference_modes_preserve_coordinates_batches_and_embeddings(tmp_path, monkeypatch):
+    import json
+    import numpy as np
+    import torch
+    from torchvision.transforms import Compose, ToTensor
+    import slide2vec.inference
+    import slide2vec.data.tile_reader
+    from slide2vec.runtime.types import LoadedModel
+    from scripts.benchmark_inference import run_inference_benchmark
+
+    class Encoder:
+        def encode_tiles(self, images):
+            return images.mean(dim=(2, 3))
+
+    class Reader:
+        def read_region(self, location, level, size):
+            return np.full((size[1], size[0], 3), location[0], dtype=np.uint8)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(slide2vec.inference, "load_model", lambda **kwargs: LoadedModel(
+        name="phikonv2", level="tile", model=Encoder(), transforms=Compose([ToTensor()]),
+        feature_dim=3, device=torch.device("cpu"),
+    ))
+    monkeypatch.setattr(slide2vec.data.tile_reader, "_open_wsi_backend", lambda *a: Reader())
+    slide = tmp_path / "slide.tif"
+    slide.write_bytes(b"mock slide")
+    coordinates = tmp_path / "coordinates.npz"
+    np.savez(coordinates, x=np.array([255, 0, 255]), y=np.array([0, 0, 224]))
+    output = tmp_path / "result.json"
+    args = SimpleNamespace(
+        model="phikonv2", slide=slide, coordinates=coordinates, tile_size=224,
+        batch_size=2, workers=0, backend="openslide", modes=["model-only", "cached", "wsi"],
+        repeat=1, warmup=0, threads=1, output=output, profile=False,
+        use_supertiles=False, cache_policy="fresh-reader", device="cpu", precision="fp32",
+    )
+    result = run_inference_benchmark(args)
+    assert set(result["modes"]) == {"model-only", "cached", "wsi"}
+    expected = torch.tensor([[1., 1., 1.], [0., 0., 0.], [1., 1., 1.]])
+    for mode, measured in result["modes"].items():
+        assert len(measured["samples_seconds"]) == 1
+        assert measured["max_abs_error"] == 0
+        torch.testing.assert_close(torch.load(measured["embeddings_path"], weights_only=True), expected)
+    assert json.loads(output.read_text())["parameters"]["num_tiles"] == 3
+    args.compare = output
+    args.output = tmp_path / "after.json"
+    comparison = run_inference_benchmark(args)
+    for measured in comparison["modes"].values():
+        assert measured["baseline_max_abs_error"] == 0
+        assert "speedup" in measured
+    baseline_payload = (tmp_path / "result-cached.pt").read_bytes()
+    args.output = tmp_path / "result.txt"
+    with pytest.raises(ValueError, match="preserve the baseline embeddings"):
+        run_inference_benchmark(args)
+    assert (tmp_path / "result-cached.pt").read_bytes() == baseline_payload
+
+
+def test_inference_comparison_rejects_different_coordinates_before_model_load(tmp_path):
+    import json
+    import numpy as np
+    from scripts.benchmark_inference import run_inference_benchmark
+
+    coordinates = tmp_path / "coordinates.npz"
+    np.savez(coordinates, x=np.array([0]), y=np.array([0]))
+    slide = tmp_path / "slide.tif"
+    slide.write_bytes(b"mock slide")
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"parameters": {"coordinates_sha256": "different"}}))
+    with pytest.raises(ValueError, match="different parameters"):
+        run_inference_benchmark(SimpleNamespace(
+            model="never-load-this-model", slide=slide, coordinates=coordinates, tile_size=224,
+            batch_size=2, workers=0, backend="openslide", modes=["wsi"],
+            repeat=1, warmup=0, threads=1, output=tmp_path / "after.json", profile=False,
+            use_supertiles=False, cache_policy="warm", device="cpu", precision="fp32", compare=baseline,
+        ))

--- a/tests/test_inference_benchmark.py
+++ b/tests/test_inference_benchmark.py
@@ -20,6 +20,7 @@ def test_inference_benchmark_rejects_invalid_workloads(field, value, message):
 
 
 def test_inference_modes_preserve_coordinates_batches_and_embeddings(tmp_path, monkeypatch):
+    import itertools
     import json
     import numpy as np
     import torch
@@ -28,6 +29,15 @@ def test_inference_modes_preserve_coordinates_batches_and_embeddings(tmp_path, m
     import slide2vec.data.tile_reader
     from slide2vec.runtime.types import LoadedModel
     from scripts.benchmark_inference import run_inference_benchmark
+    import scripts.benchmark_inference as benchmark
+
+    snapshots = itertools.cycle([
+        {"parent_minor_faults": 10, "parent_major_faults": 1,
+         "cgroup_memory_psi_us": {"some": 100, "full": 50}, "host_memory_psi_us": None},
+        {"parent_minor_faults": 17, "parent_major_faults": 3,
+         "cgroup_memory_psi_us": {"some": 120, "full": 55}, "host_memory_psi_us": None},
+    ])
+    monkeypatch.setattr(benchmark, "_resource_snapshot", lambda: next(snapshots))
 
     class Encoder:
         def encode_tiles(self, images):
@@ -62,6 +72,10 @@ def test_inference_modes_preserve_coordinates_batches_and_embeddings(tmp_path, m
     for mode, measured in result["modes"].items():
         assert len(measured["samples_seconds"]) == 1
         assert measured["max_abs_error"] == 0
+        assert measured["sample_resources"] == [{
+            "parent_minor_faults": 7, "parent_major_faults": 2,
+            "cgroup_memory_psi_us": {"some": 20, "full": 5}, "host_memory_psi_us": None,
+        }]
         torch.testing.assert_close(torch.load(measured["embeddings_path"], weights_only=True), expected)
     assert json.loads(output.read_text())["parameters"]["num_tiles"] == 3
     args.compare = output
@@ -75,6 +89,35 @@ def test_inference_modes_preserve_coordinates_batches_and_embeddings(tmp_path, m
     with pytest.raises(ValueError, match="preserve the baseline embeddings"):
         run_inference_benchmark(args)
     assert (tmp_path / "result-cached.pt").read_bytes() == baseline_payload
+
+
+@pytest.mark.parametrize("available", [True, False])
+def test_resource_snapshot_reads_pressure_totals_or_reports_unavailable(monkeypatch, available):
+    import resource
+    from pathlib import Path
+    from scripts.benchmark_inference import _resource_snapshot
+
+    def usage(_):
+        if not available:
+            raise OSError("unavailable")
+        return SimpleNamespace(ru_minflt=13, ru_majflt=2)
+
+    def read(path):
+        if not available:
+            raise OSError("unavailable")
+        if str(path) == "/sys/fs/cgroup/memory.pressure":
+            return "some avg10=0.00 avg60=0.00 avg300=0.00 total=123\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=45\n"
+        assert str(path) == "/proc/pressure/memory"
+        return "some avg10=0.00 total=789\nfull avg10=0.00 total=67\n"
+
+    monkeypatch.setattr(resource, "getrusage", usage)
+    monkeypatch.setattr(Path, "read_text", read)
+    assert _resource_snapshot() == {
+        "parent_minor_faults": 13 if available else None,
+        "parent_major_faults": 2 if available else None,
+        "cgroup_memory_psi_us": {"some": 123, "full": 45} if available else None,
+        "host_memory_psi_us": {"some": 789, "full": 67} if available else None,
+    }
 
 
 def test_inference_comparison_rejects_different_coordinates_before_model_load(tmp_path):

--- a/tests/test_pooled_geometry.py
+++ b/tests/test_pooled_geometry.py
@@ -277,3 +277,36 @@ def test_slide_and_patient_models_inherit_tile_dependency_geometry():
         "spacing_um": 0.5,
         "source_encoder": "lunit",
     }
+
+
+def test_hierarchical_collator_preserves_reordered_subtiles_with_bounded_allocations(monkeypatch):
+    """Splitting byte pixels must not allocate full float copies of every region."""
+    from slide2vec.data import tile_reader
+
+    pixels = np.array([[0, 1, 2, 3], [4, 5, 6, 7],
+                       [8, 9, 10, 11], [12, 13, 14, 255]], dtype=np.uint8)
+    regions = [np.repeat(pixels[:, :, None], 3, axis=2),
+               np.full((4, 4, 3), 100, dtype=np.uint8)]
+
+    class Reader:
+        def read_region(self, location, level, size):
+            return regions[location[0]]
+
+    monkeypatch.setattr(tile_reader, '_open_wsi_backend', lambda *args: Reader())
+    collator = tile_reader.OnTheFlyHierarchicalBatchCollator(
+        image_path='slide.svs',
+        tiling_result=SimpleNamespace(read_level=0, x=np.array([0, 1]), y=np.array([0, 0])),
+        region_index=np.array([0, 0, 0, 0, 1, 1, 1, 1]),
+        subtile_index_within_region=np.array([0, 1, 2, 3, 0, 1, 2, 3]),
+        read_region_size_px=4, read_tile_size_px=2, requested_tile_size_px=2,
+        backend='openslide',
+    )
+    with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU], profile_memory=True) as profile:
+        indices, tiles, _ = collator([7, 3, 0, 3])
+
+    assert indices.tolist() == [7, 3, 0, 3]
+    expected = torch.tensor([[[100, 100], [100, 100]], [[10, 11], [14, 255]],
+                             [[0, 1], [4, 5]], [[10, 11], [14, 255]]], dtype=torch.uint8)
+    assert torch.equal(tiles, expected[:, None].expand(-1, 3, -1, -1))
+    allocated = sum(max(0, event.self_cpu_memory_usage) for event in profile.key_averages())
+    assert allocated <= 8 * (2 * 3 * 4 * 4)

--- a/tests/test_process_list_performance.py
+++ b/tests/test_process_list_performance.py
@@ -1,0 +1,54 @@
+"""Behavior and work bounds for incremental process-list reconciliation."""
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+
+from slide2vec.runtime.persistence import update_process_list_after_embedding
+
+
+def test_process_list_normalizes_sample_ids_once(tmp_path, monkeypatch):
+    path = tmp_path / 'process_list.csv'
+    path.write_text('sample_id,feature_status\na,tbp\nb,tbp\nc,tbp\nuntouched,tbp\n')
+    original = pd.Series.astype
+    conversions = []
+
+    def counted(series, *args, **kwargs):
+        if series.name == 'sample_id':
+            conversions.append(len(series))
+        return original(series, *args, **kwargs)
+
+    monkeypatch.setattr(pd.Series, 'astype', counted)
+    update_process_list_after_embedding(
+        path, successful_slides=[SimpleNamespace(sample_id=s) for s in ['a', 'b', 'c', 'a']],
+        persist_tile_embeddings=True, persist_hierarchical_embeddings=False,
+        include_slide_embeddings=False, encoder_name='encoder', output_variant=None,
+        tile_artifacts=[SimpleNamespace(sample_id='a', annotation=None, path=Path('/features/a.pt'))],
+        hierarchical_artifacts=[], slide_artifacts=[],
+    )
+    result = pd.read_csv(path).fillna('')
+    assert result[['sample_id', 'feature_status', 'feature_path']].values.tolist() == [
+        ['a', 'success', '/features/a.pt'], ['b', 'error', ''], ['c', 'error', ''], ['untouched', 'tbp', ''],
+    ]
+    assert len(conversions) <= 1
+
+
+def test_process_list_keeps_unfinished_annotation_rows_unchanged(tmp_path):
+    path = tmp_path / 'process_list.csv'
+    path.write_text('sample_id,annotation,feature_status,feature_path,aggregation_status\n'
+                    'a,tumor,tbp,,tbp\na,stroma,tbp,,tbp\na,tissue,tbp,,tbp\n'
+                    'a,tumor,tbp,,tbp\nb,tumor,tbp,,tbp\n')
+    update_process_list_after_embedding(
+        path, successful_slides=[SimpleNamespace(sample_id='a'), SimpleNamespace(sample_id='a')],
+        persist_tile_embeddings=False, persist_hierarchical_embeddings=False,
+        include_slide_embeddings=True, encoder_name='encoder', output_variant='default',
+        tile_artifacts=[], hierarchical_artifacts=[],
+        slide_artifacts=[SimpleNamespace(sample_id='a', annotation='tumor', path=Path('/features/a.pt')),
+                         SimpleNamespace(sample_id='a', annotation=None, path=Path('/features/flat.pt'))],
+    )
+    result = pd.read_csv(path).fillna('')
+    assert result[['feature_status', 'feature_path', 'aggregation_status']].values.tolist() == [
+        ['success', '/features/a.pt', 'success'], ['tbp', '', 'tbp'],
+        ['success', '/features/flat.pt', 'success'], ['success', '/features/a.pt', 'success'],
+        ['tbp', '', 'tbp'],
+    ]

--- a/tests/test_runtime_batching.py
+++ b/tests/test_runtime_batching.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import torch
+import pytest
 from torchvision.transforms import functional as tvF
 
 from slide2vec.runtime.batching import dataloader_kwargs
@@ -51,3 +52,93 @@ def test_dataloader_kwargs_uses_spawn_only_when_worker_processes_are_enabled():
         prefetch_factor=3,
         worker_start_method="spawn",
     ) == {"num_workers": 0}
+
+
+def test_batched_preprocessing_transfers_bytes_before_normalizing(monkeypatch):
+    """Do not expand a byte image into a float transfer buffer on the host."""
+    from types import SimpleNamespace
+    from torchvision import transforms
+    from slide2vec.runtime.batching import build_batch_preprocessor_for_tile_images
+
+    transferred_dtypes = []
+    original_to = torch.Tensor.to
+
+    def capture_transfer(image, *args, **kwargs):
+        if args and args[0] == torch.device('cuda'):
+            transferred_dtypes.append(image.dtype)
+            return image  # Exercise the transfer boundary without requiring a GPU.
+        return original_to(image, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, 'to', capture_transfer)
+    loaded = SimpleNamespace(name='test', device=torch.device('cuda'), transforms=transforms.Compose([
+        transforms.ToTensor(), transforms.Normalize([0.5] * 3, [0.5] * 3),
+    ]))
+    preprocess = build_batch_preprocessor_for_tile_images(loaded, requested_tile_size_px=2)
+    pixels = torch.tensor([[[[0, 255], [255, 0]]] * 3], dtype=torch.uint8)
+    expected = torch.tensor([[[[-1.0, 1.0], [1.0, -1.0]]] * 3])
+
+    assert torch.equal(preprocess(pixels), expected)
+    assert transferred_dtypes == [torch.uint8]
+
+
+def test_cuda_prefetch_keeps_distinct_unpinned_batches_intact():
+    import pytest
+    from contextlib import nullcontext
+    from torchvision import transforms
+    from slide2vec.runtime.batching import build_batch_preprocessor_for_tile_images, run_forward_pass
+    from slide2vec.runtime.types import LoadedModel
+
+    if not torch.cuda.is_available():
+        pytest.skip('requires one CUDA device')
+
+    class Encoder:
+        def encode_tiles(self, image):
+            return image.mean(dim=(-2, -1))
+
+    loaded = LoadedModel(name='test', level='tile', model=Encoder(), feature_dim=3,
+                         device=torch.device('cuda'), transforms=transforms.Compose([
+                             transforms.ToTensor(), transforms.Normalize([0.5] * 3, [0.5] * 3),
+                         ]))
+    batches = [(torch.arange(8), torch.zeros((8, 3, 224, 224), dtype=torch.uint8)),
+               (torch.arange(8, 16), torch.full((8, 3, 224, 224), 255, dtype=torch.uint8)),
+               (torch.arange(16, 19), torch.zeros((3, 3, 224, 224), dtype=torch.uint8))]
+    preprocess = build_batch_preprocessor_for_tile_images(loaded, requested_tile_size_px=224)
+    indices, features = run_forward_pass(batches, loaded, nullcontext(), batch_preprocessor=preprocess, total_items=19)
+    assert indices.tolist() == list(range(19))
+    assert features.tolist() == [[-1.0] * 3] * 8 + [[1.0] * 3] * 8 + [[-1.0] * 3] * 3
+    assert batches[0][1].count_nonzero().item() == 0
+    assert batches[1][1].min().item() == 255
+
+
+@pytest.mark.parametrize("device,expected_order", [
+    ("cpu", ["load first", "load second", "encode", "encode"]),
+    ("cuda", ["load first", "encode", "load second", "encode"]),
+])
+def test_forward_overlaps_loading_only_on_cuda(device, expected_order):
+    from contextlib import nullcontext
+    from slide2vec.runtime.batching import run_forward_pass
+    from slide2vec.runtime.types import LoadedModel
+
+    import pytest
+    if device == 'cuda' and not torch.cuda.is_available():
+        pytest.skip('requires one CUDA device')
+
+    operations = []
+
+    def batches():
+        operations.append('load first')
+        yield torch.tensor([0]), torch.full((1, 3, 2, 2), 2.0)
+        operations.append('load second')
+        yield torch.tensor([1]), torch.full((1, 3, 2, 2), 3.0)
+
+    class Encoder:
+        def encode_tiles(self, image):
+            operations.append('encode')
+            return image.mean(dim=(-2, -1))
+
+    loaded = LoadedModel(name='test', level='tile', model=Encoder(), feature_dim=3,
+                         device=torch.device(device), transforms=None)
+    indices, features = run_forward_pass(batches(), loaded, nullcontext(), batch_preprocessor=lambda x: x.to(loaded.device), total_items=2)
+    assert indices.tolist() == [0, 1]
+    assert features.tolist() == [[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]
+    assert operations == expected_order

--- a/tests/test_runtime_batching.py
+++ b/tests/test_runtime_batching.py
@@ -54,33 +54,6 @@ def test_dataloader_kwargs_uses_spawn_only_when_worker_processes_are_enabled():
     ) == {"num_workers": 0}
 
 
-def test_batched_preprocessing_transfers_bytes_before_normalizing(monkeypatch):
-    """Do not expand a byte image into a float transfer buffer on the host."""
-    from types import SimpleNamespace
-    from torchvision import transforms
-    from slide2vec.runtime.batching import build_batch_preprocessor_for_tile_images
-
-    transferred_dtypes = []
-    original_to = torch.Tensor.to
-
-    def capture_transfer(image, *args, **kwargs):
-        if args and args[0] == torch.device('cuda'):
-            transferred_dtypes.append(image.dtype)
-            return image  # Exercise the transfer boundary without requiring a GPU.
-        return original_to(image, *args, **kwargs)
-
-    monkeypatch.setattr(torch.Tensor, 'to', capture_transfer)
-    loaded = SimpleNamespace(name='test', device=torch.device('cuda'), transforms=transforms.Compose([
-        transforms.ToTensor(), transforms.Normalize([0.5] * 3, [0.5] * 3),
-    ]))
-    preprocess = build_batch_preprocessor_for_tile_images(loaded, requested_tile_size_px=2)
-    pixels = torch.tensor([[[[0, 255], [255, 0]]] * 3], dtype=torch.uint8)
-    expected = torch.tensor([[[[-1.0, 1.0], [1.0, -1.0]]] * 3])
-
-    assert torch.equal(preprocess(pixels), expected)
-    assert transferred_dtypes == [torch.uint8]
-
-
 def test_cuda_prefetch_keeps_distinct_unpinned_batches_intact():
     import pytest
     from contextlib import nullcontext


### PR DESCRIPTION
Hierarchical collation expanded byte regions to float merely to split tiles, CSV reconciliation repeatedly scanned every row, and the CUDA loop fetched the next batch before launching the current forward pass. Split byte tensors directly, reconcile rows in one pass, and submit CUDA inference before fetching/preprocessing the next batch. Preserve original preprocessing, CPU/itemwise execution order, batch order and outputs; track allocation lifetimes across asynchronous copies.

Measured median results:

| Workload | Before | After |
| --- | ---: | ---: |
| Real WSI collation, 16 tiles | 80.14 ms | 37.07 ms |
| Checkpoint update, 1,000 of 10,000 rows | 1.559 s | 0.0716 s |
| Full 10,000-row reconciliation | 15.872 s | 0.3108 s |
| Lunit, 64 H&E_5 tiles, cached pixels | 0.478 s | 0.393 s |
| Lunit, 64 H&E_5 tiles, warm WSI | 1.009 s | 0.773 s |
| Lunit, 64 H&E_3 tiles, warm WSI | 0.976 s | 0.743 s |
| Lunit, 64 H&E_5 tiles, client-cache advice | 1.144 s | 0.911 s |

GPU comparisons used cached pretrained weights, RTX 2080 Ti, fp32, fixed batch size 16, one warmup and five repetitions, with hs2p 4.4.3. Final Lunit embeddings matched the baseline exactly. Phikon-v2's unchanged itemwise path showed no gain. The earlier CPU timings used hs2p 4.4.2; correctness was also checked against the supported 4.4.3 version.

Consolidate the existing benchmark builders and extend `benchmark_runtime.py` with model-only, cached-pixel and WSI modes, paired embedding checks, cache policies, optional CPU/CUDA traces, and per-sample page-fault/memory-pressure counters. Reject failed/empty trials and baseline artifact overwrites. Retain repeatable commands and raw results in `docs/performance.md` and the two audit JSON files. Also fix the reproduced pandas error when filling empty provenance columns.

Larger-workload limits matter: the final 256-tile trial improved median time from 5.28 s to 3.97 s, but a 29.25 s memory-pressure outlier made the mean worse (5.30 s to 9.01 s). The original runtime also stalled on recheck. Keep every sample and resource counter; this does not establish uniform whole-slide acceleration. Client cache advice does not establish server-cold performance. RAM staging added a 2.16 s copy cost with little benefit in the exploratory workload. A GPU-preprocessing prototype was excluded to preserve exact outputs and keep the smaller change.

Validation: the original 197-case suite passed, followed by a 124-case relevant suite and a 12-case focused final rerun. The existing full pipeline harness completed 474 fixture tiles with real Lunit weights; baseline and final saved 474×384 embeddings were exactly equal. Pixel/CSV parity checks, changed-file lint and diff checks passed. Structured autoreview of the initial branch, CUDA runtime, telemetry and final simplification returned no actionable findings.
