### PR TITLE
docs: fix quickstart examples and clarify extraction workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,162 +3,88 @@
 [![PyPI version](https://img.shields.io/pypi/v/slide2vec?label=pypi&logo=pypi&color=3776AB)](https://pypi.org/project/slide2vec/)
 [![Docs](https://img.shields.io/badge/docs-website-blue)](https://clemsgrs.github.io/slide2vec/)
 
-`slide2vec` is a Python package for efficient encoding of whole-slide images using publicly available foundation models. It builds on [`hs2p`](https://pypi.org/project/hs2p/) for fast preprocessing and exposes a focused surface around `Model`, `Pipeline`, and `ExecutionOptions`.
+`slide2vec` encodes whole-slide images with publicly available pathology foundation models. It uses [`hs2p`](https://pypi.org/project/hs2p/) for tissue detection and tiling, and handles batching, multi-GPU execution, and embedding storage.
 
-Documentation site: [https://clemsgrs.github.io/slide2vec/](https://clemsgrs.github.io/slide2vec/)
+## Install
 
-## Installation
+Python 3.10 or newer is required:
 
 ```shell
 pip install slide2vec
-pip install "slide2vec[fm]"
 ```
 
-`slide2vec` keeps the base install focused on the core package surface. Use `slide2vec[fm]` when you want the PyPI-hosted FM dependencies.
+Many models need additional dependencies available through `pip install "slide2vec[fm]"`. See the [model installation guide](https://clemsgrs.github.io/slide2vec/models.html#model-installation) for model-specific extras, separate environments, and upstream packages.
 
-Some model backends still rely on upstream Git repositories that PyPI will not accept as package metadata. Install those separately when needed:
+For gated models such as Virchow2, request access on the model's Hugging Face page and authenticate with `hf auth login` or an `HF_TOKEN` environment variable.
 
-```shell
-pip install git+https://github.com/lilab-stanford/MUSK.git
-pip install git+https://github.com/Mahmoodlab/CONCH.git
-pip install git+https://github.com/prov-gigapath/prov-gigapath.git
-```
-
-AtlasPatch-backed tissue segmentation is available through hs2p's `sam2` path in the bundled install.
-
-Waiv encoders use a separately tested Transformers 5 runtime. Install them in
-their own environment with `pip install "slide2vec[waiv]"`; the `waiv` extra is
-incompatible with the existing `fm`, `prism`, and `titan` dependency pins.
-
-## Python API
+## Embed a slide
 
 ```python
-from slide2vec import Model
-from slide2vec.utils.config import hf_login
-
-hf_login()
+from slide2vec import Model, PreprocessingConfig
 
 model = Model.from_preset("virchow2")
-embedded = model.embed_slide("/path/to/slide.svs")
+preprocessing = PreprocessingConfig(requested_spacing_um=0.5)
+embedded = model.embed_slide("/path/to/slide.svs", preprocessing=preprocessing)
 
-tile_embeddings = embedded.tile_embeddings
-x = embedded.x
-y = embedded.y
+tile_embeddings = embedded.tile_embeddings  # (N, 2560)
+x, y = embedded.x, embedded.y               # level-0 tile coordinates
 ```
 
-Use `list_models()` when you want to inspect the shipped presets programmatically:
+The preset supplies tile size and precision defaults. Declare spacing explicitly for models such as Virchow2 that support several scales. Use `list_models()` to list presets, or filter with `list_models("tile")`, `list_models("slide")`, or `list_models("patient")`.
 
-```python
-from slide2vec import list_models
+See [getting started](https://clemsgrs.github.io/slide2vec/getting-started.html) for preprocessing and execution settings, and the [API guide](https://clemsgrs.github.io/slide2vec/api.html) for patient embeddings, image inputs, and dense grids.
 
-all_models = list_models()
-tile_models = list_models("tile")
-slide_models = list_models("slide")
-patient_models = list_models("patient")
+## Save a batch
+
+Create a CSV manifest:
+
+```csv
+sample_id,image_path
+slide-1,/data/slide-1.svs
+slide-2,/data/slide-2.svs
 ```
 
-Use `Pipeline(...)` for manifest-driven batch processing when you want artifacts written to disk instead of only in-memory outputs:
+Optional `mask_path` and `spacing_at_level_0` columns supply a mask or correct missing or incorrect level-0 spacing. Patient-level models also require `patient_id`; see the [manifest schema](https://clemsgrs.github.io/slide2vec/manifest.html).
 
 ```python
-from slide2vec import ExecutionOptions, Pipeline, PreprocessingConfig
+from slide2vec import ExecutionOptions, Model, Pipeline, PreprocessingConfig
 
 pipeline = Pipeline(
-    model=model,
-    preprocessing=PreprocessingConfig(
-        requested_spacing_um=0.5,
-        requested_tile_size_px=224,
-        masks={"min_coverage": {"tissue": 0.1}},
-    ),
-    execution=ExecutionOptions(output_dir="outputs/demo"),
+    model=Model.from_preset("virchow2"),
+    preprocessing=PreprocessingConfig(requested_spacing_um=0.5),
+    execution=ExecutionOptions(output_dir="outputs/run"),
 )
 result = pipeline.run(manifest_path="/path/to/slides.csv")
 ```
 
-By default, `ExecutionOptions()` uses all available GPUs. Set `ExecutionOptions(num_gpus=4)` when you want to cap the sharding explicitly.
+Runs use all available GPUs by default; set `ExecutionOptions(num_gpus=2)` to limit them. Embeddings are saved as `.pt` tensors with metadata sidecars. Use `ExecutionOptions(output_format="npz")` for NumPy archives. The [output guide](https://clemsgrs.github.io/slide2vec/output-layout.html) describes directories, shapes, coordinates, and progress records.
 
-### Hierarchical Feature Extraction
+Add `region_tile_multiple=6` to the preprocessing config to group tiles into 6×6 regions. These produce `(num_regions, 36, feature_dim)` tensors in `hierarchical_embeddings/`; see [hierarchical features](https://clemsgrs.github.io/slide2vec/hierarchical.html).
 
-Tile embeddings can be spatially grouped into regions for downstream models that consume region-level structure. Enable it by setting `region_tile_multiple` on `PreprocessingConfig`:
-
-```python
-preprocessing = PreprocessingConfig(
-    requested_spacing_um=0.5,
-    requested_tile_size_px=224,
-    region_tile_multiple=6,  # 6x6 tiles per region
-)
-embedded = model.embed_slide("/path/to/slide.svs", preprocessing=preprocessing)
-```
-
-Hierarchical outputs have shape `(num_regions, tiles_per_region, feature_dim)` and are written to `hierarchical_embeddings/` when persisted.
-
-See the [hierarchical features guide](https://clemsgrs.github.io/slide2vec/hierarchical.html) for details.
-
-### Input Manifest
-
-Manifest-driven runs use the schema below. `mask_path` and `spacing_at_level_0` are optional.
-
-```csv
-sample_id,image_path,mask_path,spacing_at_level_0
-slide-1,/path/to/slide-1.svs,/path/to/mask-1.png,0.25
-slide-2,/path/to/slide-2.svs,,
-...
-```
-
-Use `spacing_at_level_0` when the slide file reports a missing or incorrect level-0 spacing and you want to override it.
-
-
-### Outputs
-
-The package writes explicit artifact directories:
-
-- `tile_embeddings/<sample_id>.pt` or `.npz`
-- `tile_embeddings/<sample_id>.meta.json`
-- `hierarchical_embeddings/<sample_id>.pt` or `.npz` (when `region_tile_multiple` is set)
-- `hierarchical_embeddings/<sample_id>.meta.json`
-- `slide_embeddings/<sample_id>.pt` or `.npz`
-- `slide_embeddings/<sample_id>.meta.json`
-- optional `slide_latents/<sample_id>.pt` or `.npz`
-
-`.pt` remains the default format. `.npz` is available through `ExecutionOptions(output_format="npz")`.
-
-### Supported Models
-
-`slide2vec` currently ships presets for 28 tile-level models, 4 slide-level models,
-and 1 patient-level model.
-For the full catalog and preset names, see the [model zoo](https://clemsgrs.github.io/slide2vec/models.html).
-
-## CLI
-
-The CLI is a thin wrapper over the package API.  
-Bundled configs live under `slide2vec/configs/preprocessing/` and `slide2vec/configs/models/`.
+The same batch workflow is available from the terminal:
 
 ```shell
 slide2vec /path/to/config.yaml
 ```
 
-By default, manifest-driven CLI runs use all available GPUs. Set `speed.num_gpus=4` when you want to cap the sharding explicitly.
-
-New to the CLI or doing batch runs to disk? Start with the [CLI guide](https://clemsgrs.github.io/slide2vec/cli.html) for the config-driven workflow and common run patterns.
+The [CLI guide](https://clemsgrs.github.io/slide2vec/cli.html) provides a complete config example, overrides, and resume instructions.
 
 ## Docker
 
 [![Docker Version](https://img.shields.io/docker/v/waticlems/slide2vec?sort=semver&label=docker&logo=docker&color=2496ED)](https://hub.docker.com/r/waticlems/slide2vec)
 
-Docker remains available when you prefer a containerized runtime:
-
 ```shell
 docker pull waticlems/slide2vec:latest
 docker run --rm -it \
     -v /path/to/your/data:/data \
-    -e HF_TOKEN=<your-huggingface-api-token> \
+    -e HF_TOKEN \
     waticlems/slide2vec:latest
 ```
 
-## Documentation
+Set `HF_TOKEN` in your shell before starting the container.
 
-- [Documentation website](https://clemsgrs.github.io/slide2vec/)
-- [API guide](https://clemsgrs.github.io/slide2vec/api.html)
-- [CLI guide](https://clemsgrs.github.io/slide2vec/cli.html)
+## More documentation
+
 - [Model zoo](https://clemsgrs.github.io/slide2vec/models.html)
-- [Performance benchmarks and QA](docs/performance.md)
-- [`tutorials/api_walkthrough.ipynb`](tutorials/api_walkthrough.ipynb) for a notebook walkthrough of the API
+- [Performance benchmarks and QA](https://clemsgrs.github.io/slide2vec/performance.html)
+- [API walkthrough notebook](tutorials/api_walkthrough.ipynb)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,31 +1,36 @@
 API Guide
 =========
 
-Reference for the Python API. See :doc:`getting-started` for introductory
-examples.
+Use ``Model`` for in-memory slide and patient embeddings, image artifacts,
+or dense grids. Use ``Pipeline`` for manifest-driven slide processing. See
+:doc:`getting-started` for installation and a first slide.
 
-``slide2vec`` exposes two main workflows:
+.. list-table::
+   :header-rows: 1
 
-- direct in-memory embedding with :meth:`Model.embed_slide` /
-  :meth:`Model.embed_slides`
-- artifact generation with :meth:`Pipeline.run`
-
-Encoder provider diagnostics
-----------------------------
-
-.. autoclass:: slide2vec.EncoderProviderDiagnostic
-   :members:
-
-.. autofunction:: slide2vec.list_encoder_provider_diagnostics
-
-See :doc:`models` for provider packaging, transactional discovery, and trust
-guidance.
+   * - Input and outcome
+     - Entry point
+   * - Slides → in-memory tile or slide embeddings
+     - :meth:`~slide2vec.Model.embed_slide`, :meth:`~slide2vec.Model.embed_slides`
+   * - Manifest → saved slide artifacts
+     - :meth:`~slide2vec.Pipeline.run`
+   * - A patient's slides → patient embedding
+     - :meth:`~slide2vec.Model.embed_patient`, :meth:`~slide2vec.Model.embed_patients`
+   * - Image files → saved vectors
+     - :meth:`~slide2vec.Model.embed_images`
+   * - Slide coordinates or image files → saved dense grids
+     - :meth:`~slide2vec.Model.embed_regions_dense`, :meth:`~slide2vec.Model.embed_images_dense`
+   * - Augmented tensors → live dense grids
+     - :meth:`~slide2vec.Model.prepare_dense_encoder`
 
 EmbeddedSlide
 -------------
 
-:meth:`Model.embed_slide` and :meth:`Model.embed_slides` return
-:class:`~slide2vec.EmbeddedSlide` objects:
+``embed_slide`` returns one :class:`~slide2vec.EmbeddedSlide` when the run
+produces a single annotation bag. A string ``annotation`` selects one bag;
+a list selects several and returns them in the requested order.
+``embed_slides`` returns ``{sample_id: {annotation: EmbeddedSlide}}``.
+See :ref:`annotation-aware-sampling` for examples.
 
 .. autoclass:: slide2vec.EmbeddedSlide
    :members:
@@ -34,15 +39,8 @@ EmbeddedSlide
 PreprocessingConfig
 -------------------
 
-.. autoclass:: slide2vec.PreprocessingConfig
-   :members:
-   :undoc-members:
-   :no-index:
-   :exclude-members: from_config, with_backend, with_mask_backend
-
-For a full breakdown of backends, segmentation methods, and preview options,
-see :doc:`preprocessing`.
-
+See :doc:`preprocessing` for the :class:`~slide2vec.PreprocessingConfig`
+field reference, readers, segmentation, annotation sampling, and previews.
 
 ExecutionOptions
 -----------------
@@ -50,13 +48,91 @@ ExecutionOptions
 .. autoclass:: slide2vec.ExecutionOptions
    :members:
    :undoc-members:
-   :exclude-members: from_config, resolved_num_workers, with_output_dir
+   :exclude-members: from_config, resolved_num_workers_per_gpu, resolved_image_num_workers_per_gpu, with_output_dir
+
+Pipeline
+---------
+
+Use :class:`~slide2vec.Pipeline` for manifest-driven batch processing and disk
+outputs:
+
+.. code-block:: python
+
+   from slide2vec import ExecutionOptions, Model, Pipeline, PreprocessingConfig
+
+   model = Model.from_preset("virchow2")
+   pipeline = Pipeline(
+       model=model,
+       preprocessing=PreprocessingConfig(
+           requested_spacing_um=0.5,
+           requested_tile_size_px=224,
+           masks={"min_coverage": {"tissue": 0.1}},
+       ),
+       execution=ExecutionOptions(output_dir="outputs/demo", num_gpus=2),
+   )
+
+   result = pipeline.run(manifest_path="/path/to/slides.csv")
+
+See :doc:`manifest` for the full manifest schema.
+
+``Pipeline.run(...)`` returns a :class:`~slide2vec.RunResult`:
+
+.. autoclass:: slide2vec.RunResult
+   :members:
+   :undoc-members:
+
+See :doc:`output-layout` for the full on-disk directory structure and file schemas.
+
+Per-slide completion callback
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``Pipeline.run_with_coordinates(coordinates_dir, *, slides=None,
+on_slide_persisted=None)`` and ``Model.embed_tiles(slides, tiling_results, *,
+preprocessing=None, execution=None, on_slide_persisted=None)`` accept an
+optional ``on_slide_persisted`` callable. slide2vec calls it in the calling
+process, synchronously, once per persisted ``(sample_id, annotation)`` work
+unit with that unit's :class:`~slide2vec.TileEmbeddingArtifact` (or
+:class:`~slide2vec.HierarchicalEmbeddingArtifact` under hierarchical
+preprocessing), after the artifact file is complete on disk and before the
+entry point returns. With ``num_gpus > 1`` it fires as each rank reports a
+finished slide, not after the whole stage returns.
+
+.. code-block:: python
+
+   def commit(artifact):
+       print(artifact.sample_id, artifact.path)
+
+   result = pipeline.run_with_coordinates("outputs/demo", on_slide_persisted=commit)
+
+Zero-tile slides, slides skipped by ``resume``, and slides that fail do not
+fire the callback. An exception raised inside it propagates out of the entry
+point. The return value is unchanged and still lists every artifact.
+
+
+Hierarchical Feature Extraction
+---------------------------------
+
+Enable hierarchical mode by setting ``region_tile_multiple`` in
+:class:`~slide2vec.PreprocessingConfig`:
+
+.. code-block:: python
+
+   from slide2vec import PreprocessingConfig
+
+   preprocessing = PreprocessingConfig(
+       requested_spacing_um=0.5,
+       requested_tile_size_px=224,
+       region_tile_multiple=6,   # 6×6 = 36 tiles per region
+   )
+
+The tile embeddings tensor will have shape ``(R, T, D)`` instead of ``(N, D)``.
+See :doc:`hierarchical` for the full explanation.
 
 Patient-level embedding
 ------------------------
 
-For patient-level models, use :meth:`Model.embed_patient` for a single patient
-or :meth:`Model.embed_patients` for a batch.
+For patient-level models, use :meth:`~slide2vec.Model.embed_patient` for a single patient
+or :meth:`~slide2vec.Model.embed_patients` for a batch.
 
 Single patient
 ~~~~~~~~~~~~~~
@@ -103,7 +179,7 @@ Images to Embeddings
 
 When your images already exist as files — a patch benchmark (BACH, CRC,
 PCam, …) or an exported ROI set — there is no slide to tile.
-:meth:`Model.embed_images` encodes those images directly and writes one
+:meth:`~slide2vec.Model.embed_images` encodes those images directly and writes one
 embedding artifact per image:
 
 .. code-block:: python
@@ -122,11 +198,13 @@ embedding artifact per image:
    print(artifacts[0].path)         # outputs/bach/image_embeddings/bach-001.pt
    print(artifacts[0].feature_dim)  # 2560
 
-The run splits images across all visible GPUs and resumes automatically:
-re-issue the same call to restart an interrupted run. ``sample_id`` is the
+The run uses the GPUs selected by ``ExecutionOptions.num_gpus`` and resumes
+automatically when repeated with the same output directory. ``sample_id`` is the
 artifact's identity and must be unique within a run; slide2vec never derives
-it from the filename. Mixed-size inputs are fine — each image goes through the
-encoder's shipped transform before batching.
+it from the filename. Mixed-size inputs are supported: each image goes through
+the encoder's shipped transform before batching. ``spacing_at_level_0`` is
+not accepted by this pooled image API; use dense extraction when physical
+spacing is part of the request.
 
 .. autoclass:: slide2vec.ImageSpec
    :members:
@@ -136,27 +214,10 @@ encoder's shipped transform before batching.
    :members:
    :undoc-members:
 
-Hierarchical Feature Extraction
----------------------------------
-
-Enable hierarchical mode by setting ``region_tile_multiple`` in
-:class:`~slide2vec.PreprocessingConfig`:
-
-.. code-block:: python
-
-   preprocessing = PreprocessingConfig(
-       requested_spacing_um=0.5,
-       requested_tile_size_px=224,
-       region_tile_multiple=6,   # 6×6 = 36 tiles per region
-   )
-
-The tile embeddings tensor will have shape ``(R, T, D)`` instead of ``(N, D)``.
-See :doc:`hierarchical` for the full explanation.
-
 Live Dense Encoding after Augmentation
 --------------------------------------
 
-Use :meth:`Model.prepare_dense_encoder` when your training or inference loop
+Use :meth:`~slide2vec.Model.prepare_dense_encoder` when your training or inference loop
 already owns image/mask reading and joint augmentation. You hand slide2vec one
 CPU RGB ``uint8`` tensor in ``(3, H, W)`` layout; slide2vec owns normalization,
 padding, device transfer, and the frozen no-grad encode.
@@ -224,13 +285,14 @@ with the same geometry.
 Persisted Region Grids
 ----------------------
 
-:meth:`Model.embed_regions_dense` accepts level-0 point coordinates and the
+:meth:`~slide2vec.Model.embed_regions_dense` accepts level-0 point coordinates and the
 same optional source-spacing declaration as dense images:
 
 .. code-block:: python
 
-   from slide2vec import DenseOptions, ExecutionOptions, SlideRegions
+   from slide2vec import DenseOptions, ExecutionOptions, Model, SlideRegions
 
+   model = Model.from_preset("virchow2")
    artifacts = model.embed_regions_dense(
        [SlideRegions(
            sample_id="slide-1",
@@ -252,7 +314,7 @@ Dense Grids from Images
 
 When the supervision arrives as image/mask pairs rather than slides —
 segmentation and detection datasets, exported ROI sets —
-:meth:`Model.embed_images_dense` is the image-sourced counterpart of
+:meth:`~slide2vec.Model.embed_images_dense` is the image-sourced counterpart of
 ``embed_regions_dense``: the image *is* the region, so there is no ROI
 coordinate plan.
 
@@ -277,12 +339,12 @@ coordinate plan.
    )
 
    print(artifacts[0].path)        # outputs/ocelot/dense_image_embeddings/ocelot-001.pt
-   print(artifacts[0].grid_shape)  # (74, 74) for a 1024px image on a 14px patch encoder
+   print(artifacts[0].grid_shape)  # (74, 74) after padding 1024 to 1036 pixels
 
-Everything after the pixels arrive is shared with the ROI path: the same
-geometry resolution, padding, whole-image-vs-sliding encode, and
-``feature_kind`` choice. The run splits images across all visible GPUs and
-resumes automatically: re-issue the same call to restart an interrupted run.
+The image and region APIs share padding, whole-image or sliding-window
+encoding, and the ``feature_kind`` choice. The run uses the GPUs selected by
+``ExecutionOptions.num_gpus`` and automatically reuses compatible artifacts
+when repeated with the same output directory.
 
 PNG/JPEG inputs require ``ImageSpec.spacing_at_level_0``, because they carry
 no embedded physical spacing. ``target_size`` is a declaration, not a resize:
@@ -341,60 +403,49 @@ so values are non-negative and a channel's spatial sum is ``<= 1`` (the
 prefix-token key columns carry the remaining mass). The input must be divisible
 by the encoder patch size.
 
-Pipeline
----------
 
-Use :class:`~slide2vec.Pipeline` for manifest-driven batch processing and disk
-outputs:
 
-.. code-block:: python
+Method and artifact reference
+-----------------------------
 
-   from slide2vec import ExecutionOptions, Model, Pipeline, PreprocessingConfig
-
-   model = Model.from_preset("virchow2")
-   pipeline = Pipeline(
-       model=model,
-       preprocessing=PreprocessingConfig(
-           requested_spacing_um=0.5,
-           requested_tile_size_px=224,
-           masks={"min_coverage": {"tissue": 0.1}},
-       ),
-       execution=ExecutionOptions(output_dir="outputs/demo", num_gpus=2),
-   )
-
-   result = pipeline.run(manifest_path="/path/to/slides.csv")
-
-See :doc:`manifest` for the full manifest schema.
-
-``Pipeline.run(...)`` returns a :class:`~slide2vec.RunResult`:
-
-.. autoclass:: slide2vec.RunResult
+.. autoclass:: slide2vec.Model
    :members:
    :undoc-members:
 
-See :doc:`output-layout` for the full on-disk directory structure and file schemas.
+.. autoclass:: slide2vec.Pipeline
+   :members:
+   :undoc-members:
 
-Per-slide completion callback
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: slide2vec.DenseOptions
+   :members:
+   :undoc-members:
 
-``Pipeline.run_with_coordinates(coordinates_dir, *, slides=None,
-on_slide_persisted=None)`` and ``Model.embed_tiles(slides, tiling_results, *,
-preprocessing=None, execution=None, on_slide_persisted=None)`` accept an
-optional ``on_slide_persisted`` callable. slide2vec calls it in the calling
-process, synchronously, once per persisted ``(sample_id, annotation)`` work
-unit with that unit's :class:`~slide2vec.TileEmbeddingArtifact` (or
-:class:`~slide2vec.HierarchicalEmbeddingArtifact` under hierarchical
-preprocessing), after the artifact file is complete on disk and before the
-entry point returns. With ``num_gpus > 1`` it fires as each rank reports a
-finished slide, not after the whole stage returns.
+.. autoclass:: slide2vec.SlideRegions
+   :members:
+   :undoc-members:
 
-.. code-block:: python
+.. autoclass:: slide2vec.TileEmbeddingArtifact
+   :members:
+   :undoc-members:
 
-   def commit(artifact):
-       print(artifact.sample_id, artifact.path)
+.. autoclass:: slide2vec.HierarchicalEmbeddingArtifact
+   :members:
+   :undoc-members:
 
-   result = pipeline.run_with_coordinates("outputs/demo", on_slide_persisted=commit)
+.. autoclass:: slide2vec.SlideEmbeddingArtifact
+   :members:
+   :undoc-members:
 
-Zero-tile slides, slides skipped by ``resume``, and slides that fail do not
-fire the callback. An exception raised inside it propagates out of the entry
-point. The return value is unchanged and still lists every artifact.
+.. autoclass:: slide2vec.DenseRegionArtifact
+   :members:
+   :undoc-members:
+
+Encoder provider diagnostics
+----------------------------
+
+.. autoclass:: slide2vec.EncoderProviderDiagnostic
+   :members:
+
+.. autofunction:: slide2vec.list_encoder_provider_diagnostics
+
+See :doc:`models` for provider packaging and discovery behavior.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,41 +1,114 @@
 CLI Guide
 =========
 
-The CLI is usually the better fit for:
+Use the CLI to process a slide manifest and save embeddings with a reusable
+YAML configuration. Complete :doc:`installation and model authentication
+<getting-started>` first.
 
-- batch processing many slides from a manifest
-- reproducible config-file-driven runs
-- generating on-disk embedding artifacts for later use
+Run a batch
+-----------
 
+Create a CSV :doc:`manifest`:
 
-Basic Command
--------------
+.. code-block:: text
+
+   sample_id,image_path
+   slide-1,/data/slide-1.svs
+   slide-2,/data/slide-2.svs
+
+Save the following as ``config.yaml``:
+
+.. code-block:: yaml
+
+   csv: /path/to/slides.csv
+   output_dir: outputs/virchow2
+   model:
+     name: virchow2
+   tiling:
+     params:
+       requested_spacing_um: 0.5
+
+Then run:
 
 .. code-block:: shell
 
-   slide2vec /path/to/config.yaml
+   slide2vec config.yaml
 
-This command:
+The CLI builds a ``Model`` and ``Pipeline`` and writes artifacts to
+``outputs/virchow2/<YYYY-MM-DD_HH_MM>/``. The directory includes the resolved
+``config.yaml`` and ``process_list.csv``; see :doc:`output-layout` for the
+embedding and coordinate files. If ``HF_TOKEN`` is unset, the CLI prompts for
+a Hugging Face token, even when you have already logged in. Set it in the
+environment for unattended runs.
 
-- loads the config file
-- builds a ``Model``, ``PreprocessingConfig``, and ``Pipeline``
-- runs ``Pipeline.run(manifest_path=cfg.csv)``
+Configure a run
+---------------
 
-What the Config Controls
--------------------------
+Omitted settings come from the `bundled defaults
+<https://github.com/clemsgrs/slide2vec/blob/main/slide2vec/configs/default.yaml>`_.
+The model preset supplies tile size and precision when unset. Spacing can
+also be inferred when the preset has a single supported spacing or declares
+a default; models such as Virchow2 require it explicitly. Runs use all
+available GPUs by default.
 
-In practice, the config controls:
+Add settings to the YAML file or override them on the command line with
+``key=value`` arguments:
 
-- the path to the input manifest (see :doc:`manifest` for details)
-- preprocessing/tiling parameters (see :doc:`preprocessing` for details)
-- which model preset to use (see :doc:`models` for available presets)
-- output directory
-- execution parameters (see :ref:`execution-options` for details)
+.. code-block:: shell
 
-The main bundled defaults live under `slide2vec/configs/default.yaml <https://github.com/clemsgrs/slide2vec/blob/main/slide2vec/configs/default.yaml>`_.
+   slide2vec config.yaml model.batch_size=64 speed.num_gpus=2
 
-Outputs
--------
+The main configuration sections are:
 
-The CLI writes artifact directories under ``output_dir``. See :doc:`output-layout`
-for the full directory structure and persisted file schemas.
+.. list-table::
+   :header-rows: 1
+
+   * - Setting
+     - Controls
+   * - ``csv``, ``output_dir``
+     - Input :doc:`manifest` and output location
+   * - ``model``
+     - Preset, output variant, batch size, and optional intermediate embeddings
+   * - ``tiling``
+     - :doc:`preprocessing`, masks, geometry, and previews
+   * - ``speed``
+     - GPU and worker counts, precision, and :ref:`output dtype <execution-options>`
+
+Command options
+---------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Effect
+   * - ``--output-dir PATH``
+     - Override the base output directory
+   * - ``--skip-datetime``
+     - Write directly into the base output directory
+   * - ``--tiling-only``
+     - Write tiling artifacts without embedding
+   * - ``--run-on-cpu``
+     - Run model inference on CPU with ``fp32`` precision
+   * - ``--help``
+     - Show command usage
+
+For example, save directly to a chosen directory on CPU:
+
+.. code-block:: shell
+
+   slide2vec config.yaml --run-on-cpu --skip-datetime --output-dir outputs/cpu
+
+Resume a run
+------------
+
+Set ``resume=true`` and identify the existing run directory:
+
+.. code-block:: shell
+
+   slide2vec config.yaml resume=true resume_dirname=2026-09-08_10_30
+
+This reuses ``<output_dir>/2026-09-08_10_30/``. For a run created with
+``--skip-datetime``, omit ``resume_dirname`` to reuse the base output directory.
+Keep the model and preprocessing settings consistent with the saved run;
+use a new output directory when changing the extraction recipe.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,10 @@ extensions = [
 templates_path = ["_templates"]
 exclude_patterns = [
     "_build",
+    # Local engineering notes are not part of the published user guide.
+    "adr",
+    "agents",
+    "research",
     "Thumbs.db",
     ".DS_Store",
 ]

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,150 +1,157 @@
 Getting Started
 ===============
 
+Install slide2vec, embed a slide in Python, or save a batch of embeddings from
+a manifest.
+
 Installation
 ------------
+
+Python 3.10 or newer is required. Install the package with:
 
 .. code-block:: shell
 
    pip install slide2vec
 
-For foundation model dependencies, add the ``fm`` extra:
+Some presets need additional dependencies; see :ref:`model-installation` for
+extras and upstream packages. The ``fm`` extra includes dependencies for many
+foundation models:
 
 .. code-block:: shell
 
    pip install "slide2vec[fm]"
 
-Quickstart
-----------
+For gated models, request access from the model's Hugging Face page in the
+:doc:`models` guide, then authenticate before loading weights:
 
-The most basic way to embed a slide is with ``Model.embed_slide(...)``:
+.. code-block:: shell
 
-.. code-block:: python
+   hf auth login
 
-   from slide2vec import Model
+You can also supply an ``HF_TOKEN`` environment variable. The examples below
+use ``virchow2``, which requires access to its gated weights.
 
-   model = Model.from_preset("virchow2")
-   embedded = model.embed_slide("/path/to/slide.svs")
-
-   tile_embeddings = embedded.tile_embeddings  # shape (N, D)
-   slide_embedding = embedded.slide_embedding  # shape (D,)
-   x, y = embedded.x, embedded.y               # tile coordinates
-
-``embed_slide`` returns an :class:`~slide2vec.EmbeddedSlide` with tile
-embeddings, coordinates, and metadata.
-
-To process a sequence of slides in one call, use ``embed_slides``:
-
-.. code-block:: python
-
-   results = model.embed_slides(
-       ["/path/to/slide1.svs", "/path/to/slide2.svs"],
-   )
-   for embedded in results:
-       print(embedded.sample_id, embedded.tile_embeddings.shape)
-
-``embed_slides`` distributes slides across all available GPUs and returns one
-:class:`~slide2vec.EmbeddedSlide` per input, in the same order.
-
-
-Supported Models
-----------------
-
-The full list of supported models is available in the :doc:`models` guide. To see all available presets:
-
-.. code-block:: python
-
-   from slide2vec import list_models
-
-   list_models()  # ["virchow", "virchow2", "moozy", ...]
-
-
-Controlling Preprocessing
--------------------------
-
-Existing models come with built-in tiling defaults matched to their intended use.
-By default, ``slide2vec`` picks these model-aware defaults automatically.
-
-Pass :class:`~slide2vec.PreprocessingConfig` to override tiling defaults:
+Embed a slide
+-------------
 
 .. code-block:: python
 
    from slide2vec import Model, PreprocessingConfig
 
    model = Model.from_preset("virchow2")
+   preprocessing = PreprocessingConfig(requested_spacing_um=0.5)
+   embedded = model.embed_slide("/path/to/slide.svs", preprocessing=preprocessing)
+
+   tile_embeddings = embedded.tile_embeddings  # shape (N, 2560)
+   x, y = embedded.x, embedded.y               # shape (N,), level-0 pixels
+
+``N`` is the number of selected tiles. ``embed_slide`` returns an
+:class:`~slide2vec.EmbeddedSlide` containing the embeddings, coordinates, and
+metadata. Its ``slide_embedding`` is ``None`` for tile encoders such as
+Virchow2; slide-level presets also produce a slide embedding.
+
+For several slides, ``embed_slides`` returns a mapping keyed by sample ID,
+then annotation label. The default tissue-only run uses the label ``"tissue"``:
+
+.. code-block:: python
+
+   results = model.embed_slides(
+       ["/path/to/slide1.svs", "/path/to/slide2.svs"],
+       preprocessing=preprocessing,
+   )
+   for sample_id, bags in results.items():
+       print(sample_id, bags["tissue"].tile_embeddings.shape)
+
+For path inputs, the sample ID defaults to the filename stem. See
+:ref:`annotation-aware-sampling` for selecting multiple annotation classes.
+
+Choose a model
+--------------
+
+Browse the :doc:`models` guide or list installed presets without loading
+weights:
+
+.. code-block:: python
+
+   from slide2vec import list_models
+
+   list_models()           # all presets
+   list_models("tile")     # one embedding per tile
+   list_models("slide")    # aggregate tiles into a slide embedding
+   list_models("patient")  # aggregate a patient's slides
+
+Control preprocessing
+---------------------
+
+The preset supplies tile size and, when unambiguous, spacing defaults.
+Models with several supported spacings, including Virchow2, require an explicit
+``requested_spacing_um``. Use :class:`~slide2vec.PreprocessingConfig` to set
+geometry and tissue selection:
+
+.. code-block:: python
+
+   from slide2vec import PreprocessingConfig
+
    preprocessing = PreprocessingConfig(
        requested_spacing_um=0.5,
        requested_tile_size_px=224,
        masks={"min_coverage": {"tissue": 0.1}},
-       backend="auto",
-       segmentation={"method": "hsv"},
    )
    embedded = model.embed_slide("/path/to/slide.svs", preprocessing=preprocessing)
 
-To restrict feature extraction to specific annotated classes (e.g. embed only
-tumor-annotated tiles), customize the ``masks`` block — see
-:ref:`annotation-aware-sampling`.
-
-See :doc:`preprocessing` for advanced settings.
+See :doc:`preprocessing` for readers, segmentation, annotated masks, and
+previews, or :doc:`hierarchical` to group tiles into regions.
 
 .. _execution-options:
 
-Controlling Execution
----------------------
+Control execution
+-----------------
 
-By default, ``slide2vec`` uses all available GPUs, a batch size of 32, and infers precision from the
-model's registered ``precision`` field.
-
-Pass :class:`~slide2vec.ExecutionOptions` to control GPU count, batch size,
-compute precision, and the on-disk feature dtype:
+By default, runs use all available GPUs, a batch size of 32, and the model's
+registered precision. To limit a run to one GPU:
 
 .. code-block:: python
 
-   from slide2vec import ExecutionOptions, Model
+   from slide2vec import ExecutionOptions
 
-   model = Model.from_preset("virchow2")
-   execution = ExecutionOptions(
-       num_gpus=2,
-       batch_size=32,
-       precision="fp16",      # forward-pass dtype: "fp16", "bf16", "fp32", or None (auto)
-       output_dtype=None,     # saved feature dtype: "fp16", "fp32", or None (follow precision)
+   execution = ExecutionOptions(num_gpus=1, batch_size=32)
+   embedded = model.embed_slide(
+       "/path/to/slide.svs", preprocessing=preprocessing, execution=execution,
    )
-   embedded = model.embed_slide("/path/to/slide.svs", execution=execution)
 
-``output_dtype`` controls the dtype the tile, slide, hierarchical, and patient features are
-written in. Left as ``None`` (the default), it follows ``precision`` — an ``fp16`` run stores
-``fp16`` features, while ``bf16``/``fp32`` store ``fp32`` — so you can force a compact ``fp16``
-cache or a lossless ``fp32`` one independently of the compute precision. The equivalent config
-key is ``speed.output_dtype``.
+For CPU inference, construct the model with
+``Model.from_preset("virchow2", device="cpu")``.
 
-See :doc:`api` for the full field reference.
+``ExecutionOptions.precision`` controls the forward-pass dtype (``"fp16"``,
+``"bf16"``, ``"fp32"``, or ``None`` for the model default).
+``output_dtype`` independently controls feature storage (``"fp16"`` or
+``"fp32"``). Left as ``None``, it follows precision: ``fp16`` stores ``fp16``;
+``bf16`` and ``fp32`` store ``fp32``. The equivalent CLI config keys are
+``speed.precision`` and ``speed.output_dtype``. See :doc:`api` for the field
+reference.
 
-Batch Processing with Pipeline
--------------------------------
+Save a batch to disk
+--------------------
 
-For manifest-driven batch runs that persist artifacts to disk, build a
-:class:`~slide2vec.Pipeline`:
+Use :class:`~slide2vec.Pipeline` with a CSV :doc:`manifest`:
+
+.. code-block:: text
+
+   sample_id,image_path
+   slide-1,/data/slide-1.svs
+   slide-2,/data/slide-2.svs
 
 .. code-block:: python
 
-   from slide2vec import Model, Pipeline
-   from slide2vec import PreprocessingConfig, ExecutionOptions
+   from slide2vec import ExecutionOptions, Model, Pipeline, PreprocessingConfig
 
-   model = Model.from_preset("virchow2")
    pipeline = Pipeline(
-       model=model,
-       preprocessing=PreprocessingConfig(
-         requested_spacing_um=0.5,
-         requested_tile_size_px=224
-      ),
-       execution=ExecutionOptions(
-         output_dir="outputs/run",
-         num_gpus=2
-      ),
+       model=Model.from_preset("virchow2"),
+       preprocessing=PreprocessingConfig(requested_spacing_um=0.5),
+       execution=ExecutionOptions(output_dir="outputs/run"),
    )
-
    result = pipeline.run(manifest_path="/path/to/slides.csv")
 
-See :doc:`manifest` for the full manifest schema and :doc:`output-layout` for
-the files written to ``output_dir``. You can also run batch jobs from the
-terminal — see the :doc:`cli` guide.
+The run writes embeddings, coordinate files, and progress records under
+``outputs/run``. See :doc:`output-layout` to load the results, or :doc:`cli`
+to run the same workflow from a YAML config.

--- a/docs/hierarchical.rst
+++ b/docs/hierarchical.rst
@@ -1,8 +1,9 @@
 Hierarchical Features
 =====================
 
-Hierarchical mode groups tiles into spatial regions before embedding, so the
-output carries both local (tile) and contextual (region) information.
+Hierarchical mode preserves the spatial grouping of tile embeddings in a
+region-by-tile tensor for downstream region-aware aggregators. The tile
+encoder embeds each tile independently.
 
 Concept
 -------
@@ -10,9 +11,8 @@ Concept
 In standard mode, slide2vec tiles a slide and returns a flat ``(N, D)`` tensor
 — one embedding per tile.
 
-In hierarchical mode, tiles are additionally grouped into non-overlapping
-rectangular *regions*. Each region contains exactly ``T = region_tile_multiple²``
-tiles arranged in a square grid. The output shape becomes
+In hierarchical mode, tiles are grouped into square *regions*. Each region
+contains exactly ``T = region_tile_multiple²`` tiles arranged in a square grid. The output shape becomes
 ``(R, T, D)`` where:
 
 - ``R`` — number of regions (depends on tissue area)
@@ -65,19 +65,19 @@ The tile embeddings tensor for a hierarchically processed slide has shape
    embedded = model.embed_slide("/path/to/slide.svs", preprocessing=preprocessing)
 
    # embedded.tile_embeddings: Tensor of shape (R, T, D)
-   # e.g. (512, 36, 1280) for virchow2 with region_tile_multiple=6
+   # e.g. (512, 36, 2560) for virchow2 with region_tile_multiple=6
 
-Coordinates (``embedded.x``, ``embedded.y``) are also reshaped to ``(R, T)``
-so that ``x[r, t]`` / ``y[r, t]`` gives the level-0 pixel position of tile
-``t`` in region ``r``.
+Coordinates (``embedded.x``, ``embedded.y``) have shape ``(R,)`` and give
+the level-0 pixel origins of the parent regions. Within each region, tile
+embeddings follow row-major order (left to right, then top to bottom).
 
 When running :class:`~slide2vec.Pipeline`, hierarchical artifacts are written
-to ``hierarchical_embeddings/`` alongside the usual ``tile_embeddings/``
-directory. See :doc:`output-layout` for the full directory structure.
+to ``hierarchical_embeddings/``. Each artifact contains the ``(R, T, D)``
+tensor; no duplicate flat tile tensor is written. See :doc:`output-layout`
+for the directory structure.
 
 Compatibility
 -------------
 
 Hierarchical extraction is supported for all **tile-level** models.
-It is not compatible with slide-level or patient-level encoders (those operate
-on the slide as a whole, not on individual tiles).
+Slide-level and patient-level presets reject hierarchical preprocessing.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,13 @@
 slide2vec
 ==========
 
-``slide2vec`` is a slide encoding library for computational pathology.
+``slide2vec`` encodes whole-slide images with pathology foundation models.
+It uses `hs2p <https://github.com/clemsgrs/hs2p>`_ for tissue detection and
+tiling, and handles batching, multi-GPU execution, and embedding storage.
 
-It provides a unified API to make whole-slide encoding with Foundation Models
-straightforward. Building on top of `hs2p <https://github.com/clemsgrs/hs2p>`_,
-it abstracts away the complexities of working with whole-slide images, handling tiling,
-batching, and multi-GPU distribution so you can go from a slide path to an
-embedding tensor in a few lines.
-
-It ships with presets for the most widely used pathology foundation models.
+Use ``Model`` for in-memory slide embeddings or ``Pipeline`` and the CLI to
+process a manifest and save artifacts. Start with installation and a first
+slide, then choose the workflow below.
 
 .. raw:: html
 
@@ -17,11 +15,11 @@ It ships with presets for the most widely used pathology foundation models.
      <div class="s2v-card-grid">
        <a class="s2v-card" href="getting-started.html">
          <h3>Getting started</h3>
-         <p>An overview of what slide2vec is and how to use it.</p>
+         <p>Install slide2vec and encode your first slide.</p>
        </a>
        <a class="s2v-card" href="api.html">
          <h3>API Guide</h3>
-         <p>Embed a slide directly from Python.</p>
+         <p>Work with slides, patients, images, and dense grids in Python.</p>
        </a>
        <a class="s2v-card" href="cli.html">
          <h3>CLI</h3>

--- a/docs/manifest.rst
+++ b/docs/manifest.rst
@@ -1,8 +1,7 @@
 Input Manifest
 ==============
 
-Both :class:`~slide2vec.Pipeline` and the CLI expect a csv manifest with
-the slides to process.
+Use a CSV manifest to pass slides to :class:`~slide2vec.Pipeline` or the CLI.
 
 Schema
 ------
@@ -19,11 +18,12 @@ Schema
      - Unique identifier for the slide; used as the output file stem
    * - ``image_path``
      - yes
-     - Absolute path to the slide file
+     - Path to the slide file; absolute paths are recommended
    * - ``mask_path``
      - no
-     - Path to a pre-computed binary tissue mask. When blank, slide2vec
-       generates the mask on the fly using the configured segmentation method
+     - Path to a binary tissue mask or a multilabel annotation mask; see
+       :ref:`annotation-aware-sampling`. For tissue-only sampling, a blank
+       value uses the configured segmentation method
    * - ``spacing_at_level_0``
      - no
      - Override for the slide's native level-0 spacing (µm/px). When blank,
@@ -41,7 +41,9 @@ Example
    slide-1,/data/slide-1.svs,/data/mask-1.png,0.25
    slide-2,/data/slide-2.svs,,
 
-``mask_path`` and ``spacing_at_level_0`` may be left blank for any row.
+Relative image and mask paths resolve from the working directory, not the
+manifest's directory. ``spacing_at_level_0`` may be left blank when the image
+metadata supplies its physical spacing.
 
 .. _patient-manifest-format:
 
@@ -58,8 +60,7 @@ to group slides that belong to the same patient:
    slide-1b,/data/slide-1b.svs,patient-1
    slide-2a,/data/slide-2a.svs,patient-2
 
-Slides sharing the same ``patient_id`` are aggregated into a single
-:class:`~slide2vec.EmbeddedPatient` by the model's patient encoder.
+Slides sharing the same ``patient_id`` contribute to one patient embedding.
 ``sample_id`` remains the unique slide identifier.
 Both identifier columns are read as text, so values such as ``0007`` retain
 their leading zeros. Every ``patient_id`` must be non-empty after surrounding
@@ -69,8 +70,12 @@ whitespace is ignored; invalid rows are rejected before tiling begins.
 Per-slide embeddings
 ~~~~~~~~~~~~~~~~~~~~
 
-| When running a patient-level model via ``Pipeline``, the intermediate per-slide
-  embeddings can be saved alongside the patient embeddings by setting
-  ``save_slide_embeddings: true`` in config (or
-  ``ExecutionOptions(save_slide_embeddings=True)`` in the Python API).
-| Slide embeddings are written to ``slide_embeddings/`` in the output directory.
+To also save intermediate slide embeddings under ``slide_embeddings/``, use
+this CLI configuration:
+
+.. code-block:: yaml
+
+   model:
+     save_slide_embeddings: true
+
+The Python equivalent is ``ExecutionOptions(save_slide_embeddings=True)``.

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,19 +1,26 @@
 Model Zoo
 =========
 
-To see all available presets:
+Choose a tile, slide, or patient encoder below. List installed presets without
+loading weights:
 
 .. code-block:: python
 
    from slide2vec import list_models
 
-   list_models()        # all presets
-   list_models("tile")  # tile-level only
-   list_models("slide") # slide-level only
+   list_models()           # all presets
+   list_models("tile")     # tile-level only
+   list_models("slide")    # slide-level only
+   list_models("patient")  # patient-level only
 
 
 Tile-level encoders
 -------------------
+
+Spacing values are supported scales, in microns per pixel. If a preset
+supports several scales and has no registered default, pass
+``PreprocessingConfig(requested_spacing_um=...)`` explicitly for slide
+extraction.
 
 .. list-table::
    :header-rows: 1
@@ -21,7 +28,7 @@ Tile-level encoders
    * - Preset
      - Model
      - Output dim
-     - Spacing (um)
+     - Spacing (µm/px)
    * - ``lunit``
      - `Lunit ViT-S/8 <https://huggingface.co/1aurent/vit_small_patch8_224.lunit_dino>`_
      - 384
@@ -136,6 +143,18 @@ Tile-level encoders
      - ``0.5``
 
 
+Slash-separated dimensions denote output variants. For example, Virchow2
+uses ``cls_patch_mean`` (2560 dimensions) by default; select its 1280-dimensional
+CLS vector with:
+
+.. code-block:: python
+
+   from slide2vec import Model
+
+   model = Model.from_preset("virchow2", output_variant="cls")
+
+
+
 Slide-level encoders
 --------------------
 
@@ -145,7 +164,7 @@ Slide-level encoders
    * - Preset
      - Model
      - Tile encoder
-     - Spacing (um)
+     - Spacing (µm/px)
      - Output dim
    * - ``gigapath-slide``
      - `GigaPath <https://huggingface.co/prov-gigapath/prov-gigapath>`_
@@ -188,7 +207,7 @@ when using the Python API).
    * - Preset
      - Model
      - Tile encoder
-     - Spacing (um)
+     - Spacing (µm/px)
      - Output dim
    * - ``moozy``
      - `MOOZY <https://huggingface.co/AtlasAnalyticsLab/MOOZY>`_
@@ -197,14 +216,43 @@ when using the Python API).
      - 768
 
 
+.. _model-installation:
+
 Installation extras
 -------------------
 
-Some presets need extra dependencies. Install them with the matching extra,
-for example ``pip install "slide2vec[prism2]"``. Some extras (``prism2``,
-``waiv``) have dependency pins that are incompatible with the others; install
-those in their own environment. Gated upstream repositories additionally
-require Hugging Face access approval and ``hf auth login``.
+Install ``slide2vec[fm]`` for the shared foundation-model dependencies, or use
+the model-specific extras declared in `pyproject.toml
+<https://github.com/clemsgrs/slide2vec/blob/main/pyproject.toml>`_. Extras with
+conflicting dependency pins need separate environments:
+
+- ``slide2vec[prism2]`` pins a different Transformers version from ``fm``,
+  ``prism``, and ``titan`` and requires FlashAttention.
+- ``slide2vec[waiv]`` supplies the Transformers 5 runtime for ``phaet`` and
+  ``mascaret``; it conflicts with the ``fm``, ``prism``, ``prism2``, and
+  ``titan`` extras.
+
+For example, install PRISM2 in its own environment with:
+
+.. code-block:: shell
+
+   pip install "slide2vec[prism2]"
+
+The ``musk``, ``conch``, and ``gigapath-slide`` presets also require upstream
+packages that are not included in the PyPI extras. The tile-only ``gigapath``
+preset uses timm and does not need the GigaPath package. Install the relevant
+package below:
+
+.. code-block:: shell
+
+   pip install git+https://github.com/lilab-stanford/MUSK.git
+   pip install git+https://github.com/Mahmoodlab/CONCH.git
+   pip install git+https://github.com/prov-gigapath/prov-gigapath.git
+
+Gated models require access approval on their linked Hugging Face page, plus
+``hf auth login`` or an ``HF_TOKEN`` environment variable. The base install
+also includes hs2p's ``sam2`` dependencies for AtlasPatch tissue segmentation;
+see :doc:`preprocessing` to enable it.
 
 
 Dense grids and attention maps

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -2,8 +2,8 @@ Output Layout
 =============
 
 When running :class:`~slide2vec.Pipeline` (via the Python API or the CLI),
-slide2vec writes artifacts under the directory specified by
-:attr:`~slide2vec.ExecutionOptions.output_dir`.
+slide2vec writes artifacts under :attr:`~slide2vec.ExecutionOptions.output_dir`.
+The CLI normally creates a timestamped run subdirectory; see :doc:`cli`.
 
 Directory Structure
 -------------------
@@ -11,30 +11,37 @@ Directory Structure
 .. code-block:: text
 
    <output_dir>/
-   ├── tile_embeddings/
+   ├── tile_embeddings/               ← flat tile features, when saved
    │   ├── <sample_id>.pt
    │   └── <sample_id>.meta.json
    ├── hierarchical_embeddings/       ← only when region_tile_multiple is set
    │   ├── <sample_id>.pt
    │   └── <sample_id>.meta.json
-   ├── slide_embeddings/              ← only for slide-level models
+   ├── slide_embeddings/              ← slide features, when saved
    │   ├── <sample_id>.pt
    │   └── <sample_id>.meta.json
-   ├── slide_latents/                 ← only when save_latents=True
+   ├── slide_latents/                 ← PRISM with save_latents=True
    │   └── <sample_id>.pt
    ├── patient_embeddings/            ← only for patient-level models
    │   ├── <patient_id>.pt
    │   └── <patient_id>.meta.json
    ├── tiles/
    │   ├── <sample_id>.coordinates.npz
-   │   └── <sample_id>.coordinates.meta.json
+   │   ├── <sample_id>.coordinates.meta.json
+   │   └── <sample_id>.tiles.tar       ← when extracting tiles to tar
    ├── preview/
    │   ├── mask/                      ← only when save_mask_preview=True
-   │   │   └── <sample_id>.png
+   │   │   └── <sample_id>.jpg
    │   └── tiling/                    ← only when save_tiling_preview=True
-   │       └── <sample_id>.png
+   │       └── <sample_id>.jpg
    ├── process_list.csv
-   └── config.yaml
+   └── config.yaml                    ← CLI configuration snapshot
+
+Tile-level models save tile features; slide- and patient-level models save
+them only with ``save_tile_embeddings=True``. Hierarchical preprocessing
+writes ``hierarchical_embeddings/`` instead of flat tile features. Slide-level
+models save slide embeddings; patient-level models also save them when
+``save_slide_embeddings=True``. In YAML, these save flags belong under ``model``.
 
 
 Per-Annotation Namespacing
@@ -42,8 +49,8 @@ Per-Annotation Namespacing
 
 The layout above is the tissue-only (default) case. When
 :ref:`annotation-aware sampling <annotation-aware-sampling>` is enabled, each
-sampled class gets its own ``<class>/`` subdirectory under every embedding
-directory, and the tiling artifacts are namespaced the same way:
+sampled class gets its own ``<class>/`` subdirectory for tile, hierarchical,
+slide, and latent artifacts. Tiling artifacts use the same namespace:
 
 .. code-block:: text
 
@@ -58,10 +65,10 @@ directory, and the tiling artifacts are namespaced the same way:
    │   ├── tumor/<sample_id>.coordinates.npz
    │   └── stroma/<sample_id>.coordinates.npz
    └── preview/
-       ├── mask/<sample_id>.png            ← one multi-label mask preview per slide
+       ├── mask/<sample_id>.jpg            ← one multilabel mask preview per slide
        └── tiling/
-           ├── tumor/<sample_id>.png
-           └── stroma/<sample_id>.png
+           ├── tumor/<sample_id>.jpg
+           └── stroma/<sample_id>.jpg
 
 The ``tissue`` class and the structural ``merged`` output collapse to the flat
 root shown earlier — there is no ``tissue/`` or ``merged/`` subdirectory.
@@ -72,16 +79,20 @@ pair, each recording that class's own ``feature_path``.
 Embedding Files
 ---------------
 
-All ``.pt`` files can be loaded with :func:`torch.load`:
+The CLI and Python API default to PyTorch ``.pt`` files:
 
 .. code-block:: python
 
    import torch
 
-   tile_embeddings = torch.load("outputs/run/tile_embeddings/slide-1.pt")
+   tile_embeddings = torch.load(
+       "outputs/run/tile_embeddings/slide-1.pt", map_location="cpu", weights_only=True
+   )
    # tile_embeddings: Tensor of shape (N, D)
 
-   slide_embedding = torch.load("outputs/run/slide_embeddings/slide-1.pt")
+   slide_embedding = torch.load(
+       "outputs/run/slide_embeddings/slide-1.pt", map_location="cpu", weights_only=True
+   )
    # slide_embedding: Tensor of shape (D,)
 
 Shapes by artifact type:
@@ -100,24 +111,36 @@ Shapes by artifact type:
    * - ``patient_embeddings``
      - ``(D,)``
 
-Dense grids are not written by :class:`~slide2vec.Pipeline` or the CLI. They
-are produced by :meth:`~slide2vec.Model.embed_regions_dense` (slide ROIs) and
+For pooled embeddings, the Python API also accepts
+``ExecutionOptions(output_format="npz")``. These compressed NumPy archives
+store the same arrays under ``features``; tile archives may also contain
+``tile_index``. Latent archives use ``latents`` instead:
+
+.. code-block:: python
+
+   import numpy as np
+
+   with np.load("outputs/run/tile_embeddings/slide-1.npz", allow_pickle=False) as data:
+       tile_embeddings = data["features"]
+
+Dense grids always use ``.pt`` and are produced by
+:meth:`~slide2vec.Model.embed_regions_dense` (slide ROIs) and
 :meth:`~slide2vec.Model.embed_images_dense` (pre-cropped images); see
-:doc:`api` for usage.
+:doc:`api`. :class:`~slide2vec.Pipeline` and the CLI do not write dense grids.
 
 
 Embedding Meta Files
 --------------------
 
-Each ``.pt`` embedding file has a companion ``.meta.json`` with provenance and
-shape information. The exact fields depend on the artifact type.
-``feature_dtype`` records the dtype the features were written in (``"fp16"`` or
+Each embedding payload has a companion ``.meta.json`` with provenance and
+shape information. The examples below show selected fields.
+For pooled embeddings, ``feature_dtype`` records the stored dtype (``"fp16"`` or
 ``"fp32"``), as resolved from ``ExecutionOptions.output_dtype`` (see
 :ref:`execution-options`).
 
 **tile_embeddings**
 
-.. code-block:: text
+.. code-block:: json
 
    {
       "sample_id": "slide-1",
@@ -137,30 +160,38 @@ shape information. The exact fields depend on the artifact type.
       "requested_tile_size_px": 224,
       "encoder_input_size_px": 224,
       "requested_spacing_um": 0.5,
-      "tile_size_lv0": 224,
+      "tile_size_lv0": 448
    }
 
 ``encoder_input_size_px`` is always present and is ``null`` for a zero-tile
-artifact, because no tensor reached the encoder. ``requested_spacing_um``
+artifact, because no tensor reached the encoder. A flat zero-tile result has
+only a metadata sidecar, with ``num_tiles: 0`` and ``feature_dim: null``;
+hierarchical results also write an empty tensor. ``requested_spacing_um``
 describes the canonical tile request; the encoder input size reports only the
 observed post-transform pixels.
 
 **hierarchical_embeddings**
 
-Same fields as ``tile_embeddings`` (except
-``"artifact_type": "hierarchical_embeddings"``), plus:
+Hierarchical metadata records region geometry and row-major subtile order.
+Selected fields:
 
-.. code-block:: text
+.. code-block:: json
 
    {
-     ...
+     "artifact_type": "hierarchical_embeddings",
      "num_regions": 512,
      "tiles_per_region": 36,
+     "region_tile_multiple": 6,
+     "requested_tile_size_px": 224,
+     "read_tile_size_px": 224,
+     "requested_region_size_px": 1344,
+     "read_region_size_px": 1344,
+     "subtile_order": "row_major"
    }
 
 **slide_embeddings**
 
-.. code-block:: text
+.. code-block:: json
 
    {
      "sample_id": "slide-1",
@@ -168,31 +199,32 @@ Same fields as ``tile_embeddings`` (except
      "encoder_level": "slide",
      "encoder_name": "prism",
      "feature_dim": 1280,
+     "feature_dtype": "fp32",
      "format": "pt",
-     "image_path": "/data/slide-1.tif",
+     "image_path": "/data/slide-1.tif"
    }
 
 **patient_embeddings**
 
-.. code-block:: text
+.. code-block:: json
 
    {
      "patient_id": "patient-1",
      "artifact_type": "patient_embeddings",
      "encoder_name": "moozy",
-     "encoder_level": "patient"
+     "encoder_level": "patient",
      "format": "pt",
      "feature_dim": 768,
-     "num_slides": 2,
+     "feature_dtype": "fp32",
+     "num_slides": 2
    }
 
 
 Image Embeddings
 ----------------
 
-:meth:`~slide2vec.Model.embed_images` (see :doc:`api`) writes one flat
-directory — one payload plus one sidecar per input image, named by the caller's
-``sample_id``:
+:meth:`~slide2vec.Model.embed_images` writes one payload and sidecar per image,
+named by the caller's ``sample_id``:
 
 .. code-block:: text
 
@@ -203,7 +235,7 @@ directory — one payload plus one sidecar per input image, named by the caller'
 
 **image_embeddings**
 
-.. code-block:: text
+.. code-block:: json
 
    {
      "sample_id": "bach-001",
@@ -215,7 +247,7 @@ directory — one payload plus one sidecar per input image, named by the caller'
      "feature_dim": 2560,
      "feature_dtype": "fp32",
      "format": "pt",
-     "image_path": "/data/bach/001.tif",
+     "image_path": "/data/bach/001.tif"
    }
 
 Dense Region Grids
@@ -253,8 +285,8 @@ whose ``compatibility`` object does not match the current call.
 Dense Image Grids
 -----------------
 
-:meth:`~slide2vec.Model.embed_images_dense` (see :doc:`api`) writes one flat
-directory — one grid payload plus one geometry sidecar per input image:
+:meth:`~slide2vec.Model.embed_images_dense` writes one grid and geometry sidecar
+per image:
 
 .. code-block:: text
 
@@ -265,7 +297,9 @@ directory — one grid payload plus one geometry sidecar per input image:
 
 **dense_image_embeddings**
 
-.. code-block:: text
+Selected fields; the nested ``compatibility`` object is omitted here:
+
+.. code-block:: json
 
    {
      "sample_id": "ocelot-001",
@@ -301,8 +335,7 @@ directory — one grid payload plus one geometry sidecar per input image:
      "overlap": 0.0,
      "feature_kind": "patch_features",
      "attention_blocks": [-1],
-     "attention_include_registers": false,
-     "compatibility": { ... }
+     "attention_include_registers": false
    }
 
 The nested ``compatibility`` object repeats the identity and recipe fields
@@ -315,16 +348,18 @@ excluded.
 Coordinate Files
 ----------------
 
-During tiling, slide2vec writes a pair of coordinate files for each slide
-under ``tiles/``:
+Tiling writes coordinate artifacts under ``tiles/`` (or a class subdirectory):
 
 - ``<sample_id>.coordinates.npz`` — numpy archive with tile coordinate arrays
 - ``<sample_id>.coordinates.meta.json`` — tiling provenance and parameters
 
+Zero-tile results have only the metadata sidecar.
+
 **Coordinate arrays**
 
 The ``.npz`` contains four arrays, each of length ``N`` (the number of tiles),
-in the same order as the rows of the corresponding embedding tensor:
+in the same order as the corresponding flat tile embeddings. Under hierarchical
+preprocessing, each coordinate identifies a parent region; see :doc:`hierarchical`.
 
 .. list-table::
    :header-rows: 1
@@ -343,7 +378,10 @@ in the same order as the rows of the corresponding embedding tensor:
      - Sequential index of each tile
    * - ``tissue_fractions``
      - ``float32``
-     - Fraction of pixels classified as tissue in each tile
+     - Tissue coverage; in annotation mode, coverage of the sampled class
+
+Merged annotation output stores the maximum contributing class coverage in
+``tissue_fractions``.
 
 .. code-block:: python
 
@@ -357,7 +395,8 @@ in the same order as the rows of the corresponding embedding tensor:
 **Coordinate meta files**
 
 The sidecar ``coordinates.meta.json`` records tiling provenance in several
-sections:
+sections. This excerpt omits fields and the contents of the segmentation and
+filtering sections:
 
 .. code-block:: text
 
@@ -377,8 +416,8 @@ sections:
      "tiling": {
        "requested_tile_size_px": 224,
        "requested_spacing_um": 0.5,
-       "effective_tile_size_px": 224,
-       "effective_spacing_um": 0.503,
+       "read_tile_size_px": 224,
+       "read_spacing_um": 0.503,
        "tile_size_lv0": 448,
        "n_tiles": 1024,
        ...
@@ -386,8 +425,8 @@ sections:
      "segmentation": { ... },
      "filtering": { ... },
      "artifact": {
-       "coordinate_space": "level_0",
-       "tile_order": "row_major",
+       "coordinate_space": "level0_px",
+       "tile_order": "x_then_y",
        ...
      }
    }
@@ -399,17 +438,23 @@ tiling when only the encoder changes.
 Process List
 ------------
 
-``process_list.csv`` tracks the status of every slide in the manifest:
+``process_list.csv`` records tiling and embedding separately. It contains one
+row per slide, or per ``(sample_id, annotation)`` in per-class mode. Selected
+columns from a tile-embedding run:
 
 .. code-block:: text
 
-   sample_id,status,error
-   slide-1,done,
-   slide-2,done,
-   slide-3,failed,RuntimeError: slide file not found
+   sample_id,tiling_status,feature_status,feature_path,error
+   slide-1,success,success,/outputs/run/tile_embeddings/slide-1.pt,
+   slide-2,failed,tbp,,RuntimeError: slide file not found
 
-Possible ``status`` values:
+The phase columns use different status values:
 
-- ``done`` — processed successfully
-- ``failed`` — an error occurred; details are in the ``error`` column
-- ``skipped`` — slide was already present in the output directory
+- ``tiling_status``: ``success`` or ``failed`` for completed tiling attempts.
+- ``feature_status``: ``tbp`` (to be processed), ``success``, or ``error``.
+- ``aggregation_status``: the same values as ``feature_status``; present when
+  slide aggregation is tracked.
+
+``feature_path`` points to the selected embedding artifact. ``error`` and
+``traceback`` retain tiling failure details. Resume reuses completed artifacts;
+it does not record a separate ``skipped`` status.

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -1,14 +1,8 @@
 Preprocessing
 =============
 
-This page covers the options available in :class:`~slide2vec.PreprocessingConfig`
-and how to configure them.
-
-.. autoclass:: slide2vec.PreprocessingConfig
-   :members:
-   :undoc-members:
-   :exclude-members: from_config, with_backend, with_mask_backend
-
+Use :class:`~slide2vec.PreprocessingConfig` to choose slide readers, tile
+geometry, tissue segmentation, annotation sampling, and previews.
 
 Backends
 --------
@@ -17,7 +11,7 @@ The ``backend`` field controls which slide-reading library is used:
 
 - ``"auto"`` — tries cucim → vips → openslide → asap and picks the first backend
   that can open the path
-- ``"cucim"`` — NVIDIA cuCIM (fastest for SVS/TIFF on GPU-equipped machines)
+- ``"cucim"`` — NVIDIA cuCIM for supported slide formats, including SVS and TIFF
 - ``"openslide"`` — broad format support, CPU-only
 - ``"vips"`` — libvips, good for large TIFF files
 - ``"asap"`` — ASAP reader (requires separate installation)
@@ -38,8 +32,8 @@ must stay stable across upgrades.
 Pooled Tile Geometry
 --------------------
 
-Pooled extraction uses three distinct pixel sizes, recorded in every artifact
-sidecar:
+Pooled extraction uses three distinct pixel sizes, recorded in tile and
+hierarchical artifact sidecars:
 
 - ``read_tile_size_px`` — the raw square read from the selected WSI pyramid
   level.
@@ -67,7 +61,10 @@ The ``method`` key selects the algorithm:
 - ``hsv`` - heuristic based on the HSV colour space. Fast and robust for H&E slides.
 - ``otsu`` - thresholds the saturation channel using Otsu's method.
 - ``threshold`` - applies a fixed saturation threshold.
-- ``sam2`` - runs the `AtlasPatch <https://github.com/clemsgrs/atlaspatch>`_ SAM2 tissue segmentation model on an internal 8.0 µm/px thumbnail. Requires the ``atlaspatch`` package and a compatible GPU. Additional key: ``sam2_device`` — device string for SAM2 inference (e.g. ``"cuda:0"`` or ``"cpu"``).
+- ``sam2`` - runs the `AtlasPatch <https://github.com/clemsgrs/atlaspatch>`_
+  SAM2 tissue segmentation model on an internal 8.0 µm/px thumbnail. Requires
+  the ``atlaspatch`` package. ``sam2_device`` selects ``"cpu"`` (the default),
+  ``"cuda"``, or a CUDA device such as ``"cuda:0"``.
 
 Example:
 
@@ -77,6 +74,7 @@ Example:
 
    model = Model.from_preset("virchow2")
    preprocessing = PreprocessingConfig(
+       requested_spacing_um=0.5,
        segmentation={"method": "sam2", "sam2_device": "cuda"},
    )
    embedded = model.embed_slide("/path/to/slide.svs", preprocessing=preprocessing)
@@ -87,8 +85,8 @@ Or in a YAML config:
 
    tiling:
      seg_params:
-         method: "sam2"
-         sam2_device: "cuda"
+       method: "sam2"
+       sam2_device: "cuda"
 
 
 .. _annotation-aware-sampling:
@@ -97,8 +95,8 @@ Annotation-Aware Sampling
 -------------------------
 
 By default ``slide2vec`` tiles tissue: the ``masks`` vocabulary is the binary
-``{background: 0, tissue: 1}``, and embeddings cover every tissue tile. To
-restrict tiling and feature extraction to specific annotated classes
+``{background: 0, tissue: 1}``, and embeddings cover tiles that pass the
+sampling filters. To restrict extraction to specific annotated classes
 (tumor-only, stroma-only, …), customize the ``masks`` block. Any divergence
 from the default vocabulary opts the run into annotation-aware sampling; the
 plain tissue path is otherwise unchanged.
@@ -140,11 +138,12 @@ and disable tissue sampling with ``min_coverage.tissue: null``:
        },
    )
 
-   embedded = model.embed_slide(
-       "/path/to/slide.svs",
-       mask_path="/path/to/annotation_mask.tif",  # multi-label raster
-       preprocessing=preprocessing,
-   )
+   slide = {
+       "sample_id": "slide-1",
+       "image_path": "/path/to/slide.svs",
+       "mask_path": "/path/to/annotation_mask.tif",  # multi-label raster
+   }
+   embedded = model.embed_slide(slide, preprocessing=preprocessing)
 
    assert embedded.annotation == "tumor"  # every bag is stamped with its label
    tumor_bag = embedded.tile_embeddings   # shape (N_tumor, D) — tumor tiles only
@@ -159,18 +158,19 @@ use a :class:`~slide2vec.Pipeline` so per-class artifacts are persisted under a
 
 .. code-block:: python
 
-   from slide2vec import Model, Pipeline, PreprocessingConfig, ExecutionOptions
+   from slide2vec import ExecutionOptions, Pipeline
 
+   preprocessing = PreprocessingConfig(
+       requested_spacing_um=0.5,
+       requested_tile_size_px=224,
+       masks={
+           "pixel_mapping": {"tumor": 2, "stroma": 3},
+           "min_coverage": {"tissue": None, "tumor": 0.5, "stroma": 0.5},
+       },
+   )
    pipeline = Pipeline(
-       model=Model.from_preset("virchow2"),
-       preprocessing=PreprocessingConfig(
-           requested_spacing_um=0.5,
-           requested_tile_size_px=224,
-           masks={
-               "pixel_mapping": {"tumor": 2, "stroma": 3},
-               "min_coverage": {"tissue": None, "tumor": 0.5, "stroma": 0.5},
-           },
-       ),
+       model=model,
+       preprocessing=preprocessing,
        execution=ExecutionOptions(output_dir="outputs/run"),
    )
 
@@ -190,28 +190,30 @@ at the flat output root (``tile_embeddings/<sample_id>.pt``) with no
 
 .. code-block:: python
 
-   results = model.embed_slides(slides, ...)   # masks with output_mode "merged"
-   merged = results["slide-1"]["merged"]
-   assert merged.annotation == "merged"        # not "tumor"/"stroma"
+   from dataclasses import replace
 
-   # Single bag per slide, so embed_slide returns it directly:
-   merged = model.embed_slide(slide, ...)      # output_mode "merged"
+   merged_preprocessing = replace(
+       preprocessing,
+       masks={**preprocessing.masks, "output_mode": "merged"},
+   )
+   results = model.embed_slides([slide], preprocessing=merged_preprocessing)
+   merged = results["slide-1"]["merged"]
+
+   # A single bag is also available directly:
+   merged = model.embed_slide(slide, preprocessing=merged_preprocessing)
    assert merged.annotation == "merged"
 
-**Working with several classes in memory.** Call ``embed_slides`` (not
-``embed_slide``). It returns a nested mapping ``{sample_id: {label:
-EmbeddedSlide}}`` where the inner key is each bag's annotation label (a class
-name, ``"tissue"``, or ``"merged"``; never ``None``). Every
+**Working with several classes in memory.** ``embed_slides`` returns a nested
+mapping ``{sample_id: {label: EmbeddedSlide}}`` where the inner key is each
+bag's annotation label (a class name, ``"tissue"``, or ``"merged"``; never ``None``). Every
 :class:`~slide2vec.EmbeddedSlide` is also stamped with its
 :attr:`~slide2vec.EmbeddedSlide.annotation`:
 
 .. code-block:: python
 
    results = model.embed_slides(
-       [{"sample_id": "slide-1",
-         "image_path": "/path/to/slide.svs",
-         "mask_path": "/path/to/annotation_mask.tif"}],
-       preprocessing=preprocessing,   # masks with tumor + stroma, as above
+       [slide],
+       preprocessing=preprocessing,   # tumor + stroma configuration above
    )
 
    tumor_bag = results["slide-1"]["tumor"].tile_embeddings    # shape (N_tumor, D)
@@ -222,7 +224,9 @@ about; omit it to receive every bag the run produced:
 
 .. code-block:: python
 
-   results = model.embed_slides(slides, annotations=["tumor"])
+   results = model.embed_slides(
+       [slide], preprocessing=preprocessing, annotations=["tumor"],
+   )
    results["slide-1"].keys()  # dict_keys(['tumor']) — stroma is dropped
 
 **Selecting bags with** ``embed_slide``. ``embed_slide`` returns one bag (or a
@@ -231,10 +235,12 @@ list of bags) for a single slide via the ``annotation`` selector:
 .. code-block:: python
 
    # One class → one EmbeddedSlide.
-   tumor = model.embed_slide(slide, annotation="tumor")
+   tumor = model.embed_slide(slide, preprocessing=preprocessing, annotation="tumor")
 
    # A list of classes → a list of EmbeddedSlide in the requested order.
-   tumor, stroma = model.embed_slide(slide, annotation=["tumor", "stroma"])
+   tumor, stroma = model.embed_slide(
+       slide, preprocessing=preprocessing, annotation=["tumor", "stroma"],
+   )
 
 Bare ``embed_slide(slide)`` returns the single bag when the run produced
 exactly one; if the run fanned out into several bags it raises a ``ValueError``
@@ -259,10 +265,21 @@ preview:
    )
 
 Preview images are written to ``<output_dir>/preview/mask/<sample_id>.jpg``
-and ``<output_dir>/preview/tiling/<sample_id>.jpg``. Their paths are also
+and ``<output_dir>/preview/tiling/<sample_id>.jpg`` for tissue or merged
+output. Per-class tiling previews add a ``<class>/`` subdirectory below
+``preview/tiling/``; the mask preview is shared across classes. Paths are also
 recorded in ``process_list.csv`` and on the returned
 :class:`~slide2vec.EmbeddedSlide` (``mask_preview_path``,
 ``tiling_preview_path``).
 
 When resuming a run, existing preview paths are preserved in
 ``process_list.csv`` if the preview files still exist on disk.
+
+
+Field reference
+---------------
+
+.. autoclass:: slide2vec.PreprocessingConfig
+   :members:
+   :undoc-members:
+   :exclude-members: from_config, with_backend, with_mask_backend


### PR DESCRIPTION
The quickstart omitted Virchow2's required spacing and iterated `embed_slides()` as a list, although it returns a mapping keyed by slide and annotation. Correct these examples and align the output guide with current hierarchical coordinates, optional artifacts, metadata, and processing-status columns.

Consolidate model installation guidance, add a complete CLI configuration and resume walkthrough, and organize API references around extraction workflows. Exclude local engineering notes from the published Sphinx site. Changes are limited to documentation and its build configuration.

Validation:
- Sphinx HTML build with warnings treated as errors passed using hs2p 4.4.3.
- Python/JSON examples, real CLI configuration/defaults/CPU/resume checks, and mocked batch/annotation examples passed.
- Checked 1,143 internal links and anchors across 15 rendered pages, plus benchmark downloads and API reference targets.
- `python -m pytest tests/test_regression_core.py -k 'npz or execution_options_from_config or cli_build or yaml_and_cli' --no-cov -q`: 14 passed.
- `git diff --check` passed. Pretrained slide inference was not rerun for this documentation-only change.
