### PR TITLE
Align tile presets with pooled encoder preprocessing

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -22,6 +22,31 @@ supports several scales and has no registered default, pass
 ``PreprocessingConfig(requested_spacing_um=...)`` explicitly for slide
 extraction.
 
+Registry ``input_size`` is the recommended tile size **before preprocessing**,
+which can differ from the final model tensor size. GPFM samples 224px and uses
+its published direct bicubic resize to 224×224. Lunit and mSTAR sample 248px,
+then center-crop to 224px without enlargement. GigaPath remains 256px → 224px.
+DINOv2 defaults to its shipped 518px sampling and preprocessing recipe.
+
+Changing the Lunit/mSTAR default from 224px to 248px and DINOv2 from 224px to
+518px changes the sampled field of view at fixed spacing; existing runs should
+account for this sampling change. For DINOv2 matched-resolution experiments:
+
+.. code-block:: python
+
+   model = Model.from_preset("dinov2-vitb14", allow_non_recommended_settings=True)
+   model.embed_slides(
+       slides,
+       preprocessing=PreprocessingConfig(
+           requested_spacing_um=0.5, requested_tile_size_px=224,
+       ),
+   )
+
+This declared pooled request uses normalization only and forwards exactly
+224×224 pixels. Without the permission flag, an off-preset request raises.
+Given pre-cropped tiles retain DINOv2's shipped 518px transform; dense extraction
+continues to use normalization only and preserves its declared geometry.
+
 .. list-table::
    :header-rows: 1
 

--- a/slide2vec/encoders/models/dinov2.py
+++ b/slide2vec/encoders/models/dinov2.py
@@ -26,8 +26,11 @@ and :func:`validate_encoder_config` never rejects a requested spacing for it
 (unlike the pathology encoders, which are validated at a specific spacing). It
 still needs *a* spacing to tile a slide, so ``default_spacing_um=0.5`` sets the
 tiling default: 0.5 µm/px is the task-spacing the pathology tile encoders
-declare, so selecting this encoder by name lands on identical tile geometry and
-it drops in as a matched control. Because it is agnostic, sweeping other
+declare. Default pooled sampling and preprocessing use the shipped 518px recipe.
+For matched-resolution experiments, request 224px tiles explicitly with
+``allow_non_recommended_settings=True``; pooled preprocessing then uses only
+normalization, preserving the exact 224px encoder input. Given pre-cropped tiles
+still use the shipped 518px transform. Because it is agnostic, sweeping other
 task-spacings (e.g. 0.25) needs no ``allow_non_recommended_settings`` escape
 hatch — any requested spacing is accepted as-is.
 """
@@ -40,7 +43,7 @@ from slide2vec.encoders.registry import register_encoder
     "dinov2-vitb14",
     output_variants={"default": {"encode_dim": 768}},
     default_output_variant="default",
-    input_size=224,
+    input_size=518,
     supports_variable_input_size=True,
     patch_size=14,
     supported_spacing_um=None,  # spacing-agnostic: no intrinsic µm/px, so no validation constraint

--- a/slide2vec/encoders/models/gpfm.py
+++ b/slide2vec/encoders/models/gpfm.py
@@ -17,10 +17,11 @@ common checkpoint wrappers (``{"model": ...}`` / ``{"teacher": ...}`` /
 ``backbone.`` prefixes so a re-exported checkpoint keeps loading strictly.
 """
 
-from typing import Mapping
+from typing import Callable, Mapping
 
 import torch
 from huggingface_hub import hf_hub_download
+from torchvision import transforms
 
 from slide2vec.encoders.base import TimmTileEncoder
 from slide2vec.encoders.registry import register_encoder
@@ -88,3 +89,11 @@ class GPFM(TimmTileEncoder):
         state_dict = _unwrap_gpfm_state_dict(payload)
         self._model.load_state_dict(state_dict, strict=True)
         self._model.eval()
+
+    def get_transform(self) -> Callable:
+        """Apply GPFM's published square resize, independent of timm's 518px config."""
+        return transforms.Compose([
+            transforms.Resize((224, 224), interpolation=transforms.InterpolationMode.BICUBIC),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
+        ])

--- a/slide2vec/encoders/models/lunit.py
+++ b/slide2vec/encoders/models/lunit.py
@@ -8,7 +8,7 @@ from slide2vec.encoders.registry import register_encoder
     "lunit",
     output_variants={"default": {"encode_dim": 384}},
     default_output_variant="default",
-    input_size=224,
+    input_size=248,
     supports_variable_input_size=True,
     patch_size=8,
     supported_spacing_um=0.5,

--- a/slide2vec/encoders/models/mstar.py
+++ b/slide2vec/encoders/models/mstar.py
@@ -21,7 +21,7 @@ from slide2vec.encoders.registry import register_encoder
     input_size=248,
     supports_variable_input_size=True,
     patch_size=16,
-    supported_spacing_um=0.5,  # 256px @ 20x, resized to 224 (per paper)
+    supported_spacing_um=0.5,  # 20x; shipped extraction recipe crops 248px tiles to 224px
     precision="fp32",  # upstream runs plain fp32, no autocast
     source="Wangyh/mSTAR",
 )

--- a/slide2vec/encoders/models/mstar.py
+++ b/slide2vec/encoders/models/mstar.py
@@ -18,7 +18,7 @@ from slide2vec.encoders.registry import register_encoder
     "mstar",
     output_variants={"default": {"encode_dim": 1024}},
     default_output_variant="default",
-    input_size=224,
+    input_size=248,
     supports_variable_input_size=True,
     patch_size=16,
     supported_spacing_um=0.5,  # 256px @ 20x, resized to 224 (per paper)

--- a/slide2vec/encoders/registry.py
+++ b/slide2vec/encoders/registry.py
@@ -361,7 +361,8 @@ def register_encoder(
         name: Unique encoder name (e.g. "uni2", "virchow2").
         output_variants: Supported named encoder outputs with concrete metadata.
         default_output_variant: Default output variant name.
-        input_size: Recommended encoder input image size in pixels.
+        input_size: Recommended tile size in pixels before preprocessing; may differ
+            from the final model tensor size.
         supports_variable_input_size: Explicit end-to-end capability for accepting
             exact non-preset square inputs in pooled extraction. Required for tile
             encoders; slide and patient encoders inherit their tile dependency.

--- a/tests/test_dinov2_natimage.py
+++ b/tests/test_dinov2_natimage.py
@@ -21,12 +21,12 @@ from slide2vec.encoders import encoder_registry  # noqa: E402
 def test_dinov2_natimage_metadata_contract():
     info = encoder_registry.info("dinov2-vitb14")
     assert info["level"] == "tile"
-    assert info["input_size"] == 224
+    assert info["input_size"] == 518
     assert info["patch_size"] == 14
     # Natural-image encoders have no intrinsic micron spacing, so they declare
     # supported_spacing_um=None (spacing-agnostic: no validation constraint) and
     # a separate default_spacing_um that matches the pathology encoders' task
-    # spacing, so the control runs at identical tile geometry when selected by name.
+    # spacing, while the default tile size follows the shipped 518px recipe.
     assert info["supported_spacing_um"] is None
     assert info["default_spacing_um"] == pytest.approx(0.5)
     assert info["precision"] == "fp16"
@@ -44,7 +44,7 @@ def test_dinov2_natimage_resolves_tiling_default_from_default_spacing():
     from slide2vec.encoders.registry import resolve_preprocessing_defaults
 
     defaults = resolve_preprocessing_defaults("dinov2-vitb14")
-    assert defaults["tile_size_px"] == 224
+    assert defaults["tile_size_px"] == 518
     assert defaults["spacing_um"] == pytest.approx(0.5)
 
 

--- a/tests/test_encoder_preprocessing.py
+++ b/tests/test_encoder_preprocessing.py
@@ -1,0 +1,150 @@
+"""Offline recipe checks using real encoder transforms and explicit pixels."""
+
+from types import SimpleNamespace
+
+from PIL import Image
+import pytest
+import timm
+import torch
+from torchvision import transforms
+
+from slide2vec.encoders import encoder_registry
+
+
+def recipe_encoder(name):
+    encoder = encoder_registry.require(name).__new__(encoder_registry.require(name))
+    # Checkpoint data configs are supplied offline; no weights or gated access needed.
+    if name in {"gpfm", "dinov2-vitb14"}:
+        config = timm.get_pretrained_cfg("vit_base_patch14_dinov2.lvd142m").to_dict()
+    else:
+        config = dict(input_size=(3, 224, 224), crop_pct=0.9,
+                      interpolation="bicubic", mean=(0.485, 0.456, 0.406),
+                      std=(0.229, 0.224, 0.225))
+    if name == "mstar":
+        config.update(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5))
+    encoder._model = SimpleNamespace(pretrained_cfg=config)
+    return encoder
+
+
+@pytest.mark.parametrize("size", [(224, 224), (448, 224)])
+def test_gpfm_resizes_complete_image_to_224(size):
+    image = Image.new("RGB", size, (255, 0, 0))
+    image.paste((0, 0, 255), (size[0] // 2, 0, size[0], size[1]))
+    encoder = recipe_encoder("gpfm")
+    transform = encoder.get_transform()
+
+    output = transform(image)
+
+    assert encoder_registry.info("gpfm")["input_size"] == 224
+    assert tuple(output.shape) == (3, 224, 224)
+    assert isinstance(transform.transforms[0], transforms.Resize)
+    assert transform.transforms[0].size == (224, 224)
+    assert transform.transforms[0].interpolation == transforms.InterpolationMode.BICUBIC
+    assert not any(isinstance(step, transforms.CenterCrop) for step in transform.transforms)
+    torch.testing.assert_close(output[:, 112, 0], torch.tensor([2.2489083, -2.0357143, -1.8044444]))
+    torch.testing.assert_close(output[:, 112, -1], torch.tensor([-2.117904, -2.0357143, 2.64]))
+
+
+@pytest.mark.parametrize("name, expected_red", [
+    ("lunit", [2.2489083, -2.0357143, -1.8044444]),
+    ("mstar", [1.0, -1.0, -1.0]),
+])
+def test_crop_recipe_samples_248_without_enlarging(name, expected_red):
+    from slide2vec.encoders.registry import resolve_preprocessing_defaults
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    assert resolve_preprocessing_defaults(name)["tile_size_px"] == 248
+    contract = EncoderInputContract.declared_pooled(
+        name, requested_tile_size_px=248, allow_non_recommended_settings=False,
+    )
+    transform = contract.get_transform(recipe_encoder(name))
+    image = Image.new("RGB", (248, 248), (255, 0, 0))
+    assert transform.transforms[0](image).size == (248, 248)
+    assert transform.transforms[0].interpolation == transforms.InterpolationMode.BICUBIC
+    output = transform(image)
+    assert tuple(output.shape) == (3, 224, 224)
+    torch.testing.assert_close(output[:, 0, 0], torch.tensor(expected_red))
+
+
+@pytest.mark.parametrize(
+    "requested, permission, expected_kind, expected_shape",
+    [(None, False, "shipped", (1, 3, 518, 518)),
+     (224, True, "normalization_only", (1, 3, 224, 224))],
+)
+def test_dinov2_public_pooled_recipe_reaches_encoding(
+    monkeypatch, requested, permission, expected_kind, expected_shape,
+):
+    from contextlib import nullcontext
+    import slide2vec.inference as inference
+    from slide2vec.api import Model, PreprocessingConfig
+    from slide2vec.runtime.batching import run_forward_pass
+    from slide2vec.runtime.types import LoadedModel
+
+    observed = []
+    encoder = recipe_encoder("dinov2-vitb14")
+
+    class RecordingBackbone:
+        pretrained_cfg = encoder._model.pretrained_cfg
+
+        def __call__(self, batch):
+            observed.append(tuple(batch.shape))
+            return torch.tensor([[1.0, 2.0]])
+
+    encoder._model = RecordingBackbone()
+
+    def embed_slides(model, slides, *, preprocessing, execution):
+        contract = model._encoder_input
+        assert contract.regime == "declared"
+        assert contract.plan.preprocessing_kind == expected_kind
+        transform = contract.get_transform(encoder)
+        tile = Image.new("RGB", (requested or 518, requested or 518))
+        loaded = LoadedModel(name="dinov2-vitb14", level="tile", model=encoder,
+                             transforms=transform, feature_dim=2, device=torch.device("cpu"))
+        _, embeddings = run_forward_pass(
+            [(torch.tensor([0]), transform(tile).unsqueeze(0))], loaded, nullcontext(),
+        )
+        torch.testing.assert_close(embeddings, torch.tensor([[1.0, 2.0]]))
+        return []
+
+    monkeypatch.setattr(inference, "embed_slides", embed_slides)
+    model = Model.from_preset("dinov2-vitb14", device="cpu", allow_non_recommended_settings=permission)
+    assert model.embed_slides([], preprocessing=PreprocessingConfig(
+        requested_spacing_um=0.5, requested_tile_size_px=requested,
+    )) == {}
+    assert observed == [expected_shape]
+
+
+def test_dinov2_public_pooled_224_requires_permission(monkeypatch):
+    import slide2vec.inference as inference
+    from slide2vec.api import Model, PreprocessingConfig
+
+    monkeypatch.setattr(inference, "embed_slides", lambda *a, **k: pytest.fail("must reject before dispatch"))
+    model = Model.from_preset("dinov2-vitb14", device="cpu")
+    with pytest.raises(ValueError, match="allow_non_recommended_settings=True"):
+        model.embed_slides([], preprocessing=PreprocessingConfig(
+            requested_spacing_um=0.5, requested_tile_size_px=224,
+        ))
+
+
+@pytest.mark.parametrize("name, expected_black", [
+    ("gpfm", [-2.117904, -2.0357143, -1.8044444]),
+    ("lunit", [-2.117904, -2.0357143, -1.8044444]),
+    ("mstar", [-1.0, -1.0, -1.0]),
+    ("dinov2-vitb14", [-2.117904, -2.0357143, -1.8044444]),
+])
+def test_dense_contract_keeps_geometry_with_normalization_only(name, expected_black):
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    contract = EncoderInputContract.declared_dense(name, target_size_px=224, window_size=None)
+    output = contract.get_transform(recipe_encoder(name))(Image.new("RGB", (224, 224)))
+    assert tuple(output.shape) == (3, 224, 224)
+    torch.testing.assert_close(output[:, 0, 0], torch.tensor(expected_black))
+
+
+def test_dinov2_given_pixels_keep_shipped_518_recipe():
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    output = EncoderInputContract.given().get_transform(recipe_encoder("dinov2-vitb14"))(
+        Image.new("RGB", (224, 224)),
+    )
+    assert tuple(output.shape) == (3, 518, 518)

--- a/tests/test_encoder_registry.py
+++ b/tests/test_encoder_registry.py
@@ -126,7 +126,7 @@ def test_prost40m_input_size_is_224_and_encode_dim_is_384():
 def test_mstar_metadata_contract():
     info = encoder_registry.info("mstar")
     assert info["level"] == "tile"
-    assert info["input_size"] == 224
+    assert info["input_size"] == 248
     assert info["patch_size"] == 16
     assert info["supported_spacing_um"] == pytest.approx(0.5)
     assert info["precision"] == "fp32"

--- a/tests/test_pooled_geometry.py
+++ b/tests/test_pooled_geometry.py
@@ -273,7 +273,7 @@ def test_slide_and_patient_models_inherit_tile_dependency_geometry():
         "source_encoder": "gigapath",
     }
     assert resolve_preprocessing_requirements("moozy") == {
-        "tile_size_px": 224,
+        "tile_size_px": 248,
         "spacing_um": 0.5,
         "source_encoder": "lunit",
     }


### PR DESCRIPTION
GPFM currently turns 224px tiles into 518px tensors, while Lunit/mSTAR and DINOv2 register sampling sizes that disagree with their pooled recipes. This fixes GPFM's published direct 224×224 bicubic resize and registers Lunit/mSTAR at 248px and DINOv2 at 518px. The existing public declared pooled route now supports exact 224px DINOv2 inputs with permission.

Registry sizes describe tiles before preprocessing. The new defaults change sampled field of view at fixed spacing; documentation explains this change and matched-resolution DINOv2 usage. Shared planners and dense geometry behavior are unchanged.

Closes #319

Acceptance evidence:

- [x] TDD: GPFM tests first failed 518 vs 224; Lunit/mSTAR failed 224 vs 248; public DINOv2 tests failed wrong transform selection and missing permission rejection. Each slice passed after its implementation.
- [x] GPFM remains 224; square and non-square images produce 3×224×224; bicubic direct resize, no center crop, and literal ImageNet-normalized pixels verified.
- [x] Lunit/mSTAR register 248; real shipped transforms leave 248px input size unchanged before cropping 224, preserving bicubic interpolation and their distinct normalization.
- [x] DINOv2 registers 518; default public pooled transform reaches encoding at 1×3×518×518.
- [x] Public explicit 224 request with permission selects normalization_only and reaches encoding at 1×3×224×224.
- [x] Explicit 224 without permission raises actionable allow_non_recommended_settings error before dispatch.
- [x] Dense normalization-only 224 geometry verified for all four encoders; DINOv2 given 224 pixels still transform to 518.
- [x] Updated metadata expectations, registry input_size documentation, DINOv2 module documentation, sampling migration note, and public 224 example.
- [x] Focused suite: 124 passed (encoder preprocessing/registry, pooled input/geometry, dense input, input contracts, DINOv2).
- [x] Full default Docker CI on `5ac3a47`: **1,125 passed, 8 skipped, 6 deselected**, including existing heavy tests. Documentation build passed.

Review:

- Standards: one stale mSTAR inline recipe comment, corrected; no remaining findings.
- Spec: no findings.

Validation is weight-free for the added tests. The full default suite also includes existing heavy tests; GPU integration remains excluded by the repository default.

Both review axes checked the final inherited-Lunit test correction: no new findings.


Additional local validation: 1,076 non-heavy tests passed (3 skipped, 60 deselected); all 95 Rudolf tests passed with authenticated access and a temporary local module cache. The initial MUSK download and Rudolf shared-cache/access errors reproduced on unchanged main and are superseded by the successful full Docker run. No repository workaround was introduced.
