### PR TITLE
Encode exactly the requested tile size in declared pooled extraction

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -364,7 +364,7 @@ Dense Attention Map Extraction
 
 Most ViT tile encoders can also return their per-head **prefix-token
 self-attention** as a dense spatial grid. This is the attention analog of
-``encode_tiles_dense`` and reuses the same ``get_dense_transform()``.
+``encode_tiles_dense`` and uses the same ``get_normalization_transform()``.
 
 - ``encode_tiles_attention(batch, *, blocks=(-1,), include_registers=False)``
   accepts a normalized ``(B, C, H, W)`` tensor and returns ``(B, K, h, w)``.
@@ -388,7 +388,7 @@ Example:
    from slide2vec.encoders import encoder_registry
 
    encoder = encoder_registry.require("lunit")().to("cuda")
-   transform = encoder.get_dense_transform()
+   transform = encoder.get_normalization_transform()
 
    tile = Image.open("/data/tile.png").convert("RGB")
    batch = transform(tile).unsqueeze(0).to(encoder.device)

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -35,8 +35,8 @@ model's published sampling protocol. Earlier releases read Lunit and mSTAR at
 248px and GigaPath at 256px, then center-cropped to 224px, leaving unencoded margins
 between non-overlapping tiles. A 224px grid changes the tile count and
 coverage; embeddings from the two policies are not equivalent. ``resume``
-refuses to reuse tile embeddings whose metadata records a different
-``requested_tile_size_px``.
+refuses to reuse tile, hierarchical or slide embeddings whose metadata records
+a different ``requested_tile_size_px``.
 
 An off-default size requires ``allow_non_recommended_settings=True``, an
 encoder that supports variable input, and a multiple of the patch size. The

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -22,15 +22,26 @@ supports several scales and has no registered default, pass
 ``PreprocessingConfig(requested_spacing_um=...)`` explicitly for slide
 extraction.
 
-Registry ``input_size`` is the recommended tile size **before preprocessing**,
-which can differ from the final model tensor size. GPFM samples 224px and uses
-its published direct bicubic resize to 224×224. Lunit and mSTAR sample 248px,
-then center-crop to 224px without enlargement. GigaPath remains 256px → 224px.
-DINOv2 defaults to its shipped 518px sampling and preprocessing recipe.
+Registry ``input_size`` is the default **final** model input size. Slide
+extraction reads tiles at ``requested_tile_size_px`` (default: ``input_size``),
+applies only the encoder's photometric preprocessing (dtype, scaling,
+normalization), and encodes exactly that size. No encoder-side resize or
+center crop follows the read. Lunit, mSTAR and GigaPath default to 224px;
+DINOv2 to 518px; GPFM to 224px. Slide and patient presets inherit the default
+of their tile encoder.
 
-Changing the Lunit/mSTAR default from 224px to 248px and DINOv2 from 224px to
-518px changes the sampled field of view at fixed spacing; existing runs should
-account for this sampling change. For DINOv2 matched-resolution experiments:
+This is slide2vec's declared extraction policy, not a reproduction of each
+model's published sampling protocol. Earlier releases read Lunit and mSTAR at
+248px and GigaPath at 256px, then center-cropped to 224px, leaving unencoded margins
+between non-overlapping tiles. A 224px grid changes the tile count and
+coverage; embeddings from the two policies are not equivalent. ``resume``
+refuses to reuse tile embeddings whose metadata records a different
+``requested_tile_size_px``.
+
+An off-default size requires ``allow_non_recommended_settings=True``, an
+encoder that supports variable input, and a multiple of the patch size. The
+permission only allows the size; preprocessing stays geometry-preserving. For
+DINOv2 matched-resolution experiments:
 
 .. code-block:: python
 
@@ -42,10 +53,13 @@ account for this sampling change. For DINOv2 matched-resolution experiments:
        ),
    )
 
-This declared pooled request uses normalization only and forwards exactly
-224×224 pixels. Without the permission flag, an off-preset request raises.
-Given pre-cropped tiles retain DINOv2's shipped 518px transform; dense extraction
-continues to use normalization only and preserves its declared geometry.
+This forwards exactly 224×224 pixels. Without the flag, an off-default request
+raises; 225px raises even with the flag (not a multiple of 14).
+
+Pre-cropped images (``embed_images``, ``embed_tiles``) keep each encoder's
+shipped ``get_transform`` recipe: Lunit/mSTAR Resize 248 → CenterCrop 224,
+GigaPath Resize 256 → CenterCrop 224, DINOv2 Resize 518 → CenterCrop 518, GPFM
+direct 224 resize. Dense extraction is unchanged.
 
 .. list-table::
    :header-rows: 1
@@ -374,9 +388,19 @@ contract and registers its static preset metadata:
            self._model = torch.jit.load(CHECKPOINT, map_location="cpu").eval()
 
        def get_transform(self):
+           # Shipped recipe, applied to given (pre-cropped) images only.
            return v2.Compose([
                v2.ToImage(),
                v2.Resize((224, 224)),
+               v2.ToDtype(torch.float32, scale=True),
+               v2.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
+           ])
+
+       def get_normalization_transform(self):
+           # Required. Photometrics only (dtype, scaling, normalization): declared
+           # slide runs read the requested tile size and encode exactly that size.
+           return v2.Compose([
+               v2.ToImage(),
                v2.ToDtype(torch.float32, scale=True),
                v2.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
            ])

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -26,9 +26,9 @@ Registry ``input_size`` is the default **final** model input size. Slide
 extraction reads tiles at ``requested_tile_size_px`` (default: ``input_size``),
 applies only the encoder's photometric preprocessing (dtype, scaling,
 normalization), and encodes exactly that size. No encoder-side resize or
-center crop follows the read. Lunit, mSTAR and GigaPath default to 224px;
-DINOv2 to 518px; GPFM to 224px. Slide and patient presets inherit the default
-of their tile encoder.
+center crop follows the read. Lunit, mSTAR, GigaPath and GPFM default to
+224px; DINOv2 to 518px. Slide and patient presets inherit the default of their
+tile encoder.
 
 This is slide2vec's declared extraction policy, not a reproduction of each
 model's published sampling protocol. Earlier releases read Lunit and mSTAR at

--- a/docs/output-layout.rst
+++ b/docs/output-layout.rst
@@ -457,4 +457,6 @@ The phase columns use different status values:
 
 ``feature_path`` points to the selected embedding artifact. ``error`` and
 ``traceback`` retain tiling failure details. Resume reuses completed artifacts;
-it does not record a separate ``skipped`` status.
+it does not record a separate ``skipped`` status. A completed tile or
+hierarchical artifact whose metadata records a different
+``requested_tile_size_px`` than the current run raises instead of being reused.

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -37,16 +37,17 @@ hierarchical artifact sidecars:
 
 - ``read_tile_size_px`` — the raw square read from the selected WSI pyramid
   level.
-- ``requested_tile_size_px`` — the canonical tile after geometry correction,
-  before model preprocessing.
-- ``encoder_input_size_px`` — the tensor side length the encoder receives.
+- ``requested_tile_size_px`` — the tile after geometry correction. This is
+  also the encoder input: declared runs apply only the encoder's photometric
+  preprocessing (no resize or center crop).
+- ``encoder_input_size_px`` — the tensor side length the encoder received.
+  Equals ``requested_tile_size_px`` for declared runs.
 
-When ``requested_tile_size_px`` equals the encoder's registered preset,
-slide2vec applies the encoder's shipped transform unchanged. A different
-requested size requires ``allow_non_recommended_settings=True``, an encoder
+The default ``requested_tile_size_px`` is the registry ``input_size``. A
+different size requires ``allow_non_recommended_settings=True``, an encoder
 that supports variable input, and a size divisible by the model's patch
-geometry; the exact requested square then reaches the encoder with
-normalization only.
+geometry. See :doc:`models` for the given-input recipes and the sampling
+change from earlier releases.
 
 
 Tissue Segmentation

--- a/slide2vec/api.py
+++ b/slide2vec/api.py
@@ -1010,14 +1010,14 @@ class Model:
         )
         self._encoder_input = contract
         plan = contract.plan
-        if emit_run_info and plan.requires_variable_model_input:
+        if emit_run_info:
             logging.getLogger("slide2vec").info(
-                "Pooled encoder input for '%s': preset %dpx, requested %dpx, "
-                "exact encoder input %dpx; using normalization-only preprocessing.",
+                "Pooled encoder input for '%s': preset %dpx, requested %dpx; encoding "
+                "exactly %dpx with geometry-preserving preprocessing.",
                 self.name,
                 plan.preset_input_size_px,
                 plan.requested_tile_size_px,
-                plan.expected_encoder_input_size_px,
+                plan.requested_tile_size_px,
             )
         return contract
 

--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -463,20 +463,21 @@ class TileEncoder(Encoder):
         )
 
     def get_normalization_transform(self) -> Callable:
-        """Geometry-preserving photometric transform.
+        """Geometry-preserving photometric transform. Required for every tile encoder.
 
-        Returns a transform that applies ONLY this encoder's normalization
-        (per-channel mean/std) — **no Resize, no CenterCrop** — so callers can
-        preserve the full input geometry. This deliberately differs from
-        ``get_transform`` (the shipped pooled recipe):
-        some encoders resize-then-center-crop there (GigaPath ``Resize(256) ->
-        CenterCrop(224)``; Lunit ``crop_pct=0.9 -> Resize(248) -> CenterCrop(224)``),
-        which drops the tile margins. Geometry policy remains the caller's
-        responsibility. Default: unsupported, mirroring ``encode_tiles_dense``.
+        Returns a transform that applies ONLY this encoder's photometrics — dtype
+        conversion, intensity scaling, channel handling and per-channel mean/std
+        normalization — with **no Resize and no CenterCrop**. Every *declared* run
+        (pooled slide tiles and dense ROIs) encodes exactly the geometry it requested
+        through this transform; ``get_transform`` (the shipped recipe, which may
+        resize-then-center-crop) is applied only to *given* pre-cropped images.
+        ``register_encoder`` rejects a tile encoder that does not override it.
         """
         raise NotImplementedError(
             f"{type(self).__name__} does not provide a normalization transform. "
-            "The encoder cannot preserve caller-requested image geometry."
+            "Override get_normalization_transform with this encoder's photometric-only "
+            "preprocessing (dtype, scaling, normalization; no Resize/CenterCrop) so "
+            "declared runs can encode exactly the requested tile geometry."
         )
 
     def get_dense_transform(self) -> Callable:

--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -480,10 +480,6 @@ class TileEncoder(Encoder):
             "declared runs can encode exactly the requested tile geometry."
         )
 
-    def get_dense_transform(self) -> Callable:
-        """Backward-compatible alias for the shared normalization primitive."""
-        return self.get_normalization_transform()
-
 
 class SlideEncoder(Encoder):
     """Base class for encoders that pool tile features into slide features."""

--- a/slide2vec/encoders/models/dinov2.py
+++ b/slide2vec/encoders/models/dinov2.py
@@ -26,13 +26,13 @@ and :func:`validate_encoder_config` never rejects a requested spacing for it
 (unlike the pathology encoders, which are validated at a specific spacing). It
 still needs *a* spacing to tile a slide, so ``default_spacing_um=0.5`` sets the
 tiling default: 0.5 µm/px is the task-spacing the pathology tile encoders
-declare. Default pooled sampling and preprocessing use the shipped 518px recipe.
-For matched-resolution experiments, request 224px tiles explicitly with
-``allow_non_recommended_settings=True``; pooled preprocessing then uses only
-normalization, preserving the exact 224px encoder input. Given pre-cropped tiles
-still use the shipped 518px transform. Because it is agnostic, sweeping other
-task-spacings (e.g. 0.25) needs no ``allow_non_recommended_settings`` escape
-hatch — any requested spacing is accepted as-is.
+declare. Declared pooled runs read and encode the requested tile size with
+normalization only: 518px by default, or 224px for matched-resolution
+experiments when requested explicitly with ``allow_non_recommended_settings=True``.
+Given pre-cropped tiles still use the shipped Resize 518 -> CenterCrop 518
+transform. Because it is agnostic, sweeping other task-spacings (e.g. 0.25)
+needs no ``allow_non_recommended_settings`` escape hatch — any requested spacing
+is accepted as-is.
 """
 
 from slide2vec.encoders.base import TimmTileEncoder

--- a/slide2vec/encoders/models/gigapath.py
+++ b/slide2vec/encoders/models/gigapath.py
@@ -26,7 +26,7 @@ _GIGAPATH_STD = (0.229, 0.224, 0.225)
     "gigapath",
     output_variants={"default": {"encode_dim": 1536}},
     default_output_variant="default",
-    input_size=256,
+    input_size=224,
     supports_variable_input_size=True,
     # 16, NOT 14, despite the timm architecture name `vit_giant_patch14_dinov2`
     # and the paper's "ViT-g/14": prov-gigapath's packaged model_args override
@@ -48,8 +48,9 @@ class GigaPath(TimmTileEncoder):
         )
 
     def get_transform(self) -> Callable:
-        # Pooled recipe: center 224px at native spacing. Dense extraction uses
-        # get_normalization_transform() to preserve the caller's tile geometry.
+        # Shipped recipe for given pre-cropped images: center 224px of a 256px tile.
+        # Declared slide runs (pooled and dense) use get_normalization_transform()
+        # and encode exactly the requested tile size (224px by default).
         return v2.Compose([
             v2.ToImage(),
             v2.Resize(256, interpolation=v2.InterpolationMode.BICUBIC, antialias=True),

--- a/slide2vec/encoders/models/gigapath.py
+++ b/slide2vec/encoders/models/gigapath.py
@@ -13,11 +13,12 @@ from slide2vec.encoders.base import (
 )
 from slide2vec.encoders.registry import register_encoder
 
-# Prov-GigaPath model card transform: resize the 256px tile to 256 (no-op),
+# Prov-GigaPath model card transform (given pre-cropped images only): resize to 256,
 # center-crop to the model's native 224, ImageNet normalization. timm's packaged
-# pretrained_cfg reports crop_pct=1.0 -> get_transform would instead Resize(224),
-# downscaling the whole tile to ~0.57 mpp; the paper feeds the center 224 at the
-# native 0.5 mpp. https://www.nature.com/articles/s41586-024-07441-w
+# pretrained_cfg reports crop_pct=1.0 -> the timm default would instead Resize(224),
+# downscaling a 256px image to ~0.57 mpp; the paper feeds the center 224 at the
+# native 0.5 mpp. Declared slide runs read 224px directly and only normalize.
+# https://www.nature.com/articles/s41586-024-07441-w
 _GIGAPATH_MEAN = (0.485, 0.456, 0.406)
 _GIGAPATH_STD = (0.229, 0.224, 0.225)
 

--- a/slide2vec/encoders/models/lunit.py
+++ b/slide2vec/encoders/models/lunit.py
@@ -8,7 +8,7 @@ from slide2vec.encoders.registry import register_encoder
     "lunit",
     output_variants={"default": {"encode_dim": 384}},
     default_output_variant="default",
-    input_size=248,
+    input_size=224,
     supports_variable_input_size=True,
     patch_size=8,
     supported_spacing_um=0.5,

--- a/slide2vec/encoders/models/mstar.py
+++ b/slide2vec/encoders/models/mstar.py
@@ -18,10 +18,10 @@ from slide2vec.encoders.registry import register_encoder
     "mstar",
     output_variants={"default": {"encode_dim": 1024}},
     default_output_variant="default",
-    input_size=248,
+    input_size=224,
     supports_variable_input_size=True,
     patch_size=16,
-    supported_spacing_um=0.5,  # 20x; shipped extraction recipe crops 248px tiles to 224px
+    supported_spacing_um=0.5,  # 20x; declared pooled runs read and encode 224px directly
     precision="fp32",  # upstream runs plain fp32, no autocast
     source="Wangyh/mSTAR",
 )

--- a/slide2vec/encoders/registry.py
+++ b/slide2vec/encoders/registry.py
@@ -222,10 +222,11 @@ def resolve_encoder_level(
     return level
 
 
+#: The dense class contract. ``get_normalization_transform`` is deliberately not part of
+#: it: every tile encoder must provide one (declared pooled runs use it too).
 _DENSE_CLASS_MEMBERS = (
     "encode_tiles_dense",
     "patch_size",
-    "get_normalization_transform",
 )
 
 
@@ -283,6 +284,16 @@ def _validate_encoder_capability_contract(
             metadata,
             "tile_encoder_output_variant",
         )
+    if level == "tile" and (
+        getattr(encoder_cls, "get_normalization_transform")
+        is TileEncoder.get_normalization_transform
+    ):
+        raise ValueError(
+            f"Encoder '{encoder_name}' must override get_normalization_transform: "
+            "declared pooled and dense runs encode exactly the requested tile geometry, "
+            "so a tile encoder needs a geometry-preserving (normalization-only) "
+            "transform alongside its shipped get_transform recipe."
+        )
     dense_members = _dense_class_contract(encoder_cls)
     has_static_patch_size = metadata.get("patch_size") is not None
     if any(dense_members) and not all(dense_members):
@@ -302,13 +313,13 @@ def _validate_encoder_capability_contract(
             f"{'is' if len(implemented) == 1 else 'are'} overridden, but "
             f"{_format_names(missing)} "
             f"{'is' if len(missing) == 1 else 'are'} inherited as unsupported. "
-            "Override all three dense members together and declare patch_size metadata."
+            "Override both dense members together and declare patch_size metadata."
         )
     if has_static_patch_size and not all(dense_members):
         raise ValueError(
             f"Encoder '{encoder_name}' has an inconsistent dense contract: "
             "patch_size metadata is declared, but the class must also override "
-            "encode_tiles_dense, patch_size, and get_normalization_transform."
+            "encode_tiles_dense and patch_size."
         )
     if all(dense_members) and not has_static_patch_size:
         raise ValueError(
@@ -334,7 +345,7 @@ def _validate_encoder_capability_contract(
         raise ValueError(
             f"Encoder '{encoder_name}' overrides encode_tiles_attention without a "
             "complete dense contract. Attention maps require encode_tiles_dense, "
-            "patch_size, get_normalization_transform, and static patch_size metadata."
+            "patch_size, and static patch_size metadata."
         )
 
 
@@ -361,8 +372,8 @@ def register_encoder(
         name: Unique encoder name (e.g. "uni2", "virchow2").
         output_variants: Supported named encoder outputs with concrete metadata.
         default_output_variant: Default output variant name.
-        input_size: Recommended tile size in pixels before preprocessing; may differ
-            from the final model tensor size.
+        input_size: Default final square model input size in pixels. Declared
+            pooled runs read tiles at this size and encode exactly this size.
         supports_variable_input_size: Explicit end-to-end capability for accepting
             exact non-preset square inputs in pooled extraction. Required for tile
             encoders; slide and patient encoders inherit their tile dependency.

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -870,6 +870,7 @@ def run_pipeline(
             include_slide_embeddings=include_slide_embeddings,
             save_latents=execution.save_latents,
             resume=resolved_preprocessing.resume,
+            requested_tile_size_px=resolved_preprocessing.requested_tile_size_px,
         )
         skipped_slide_count = len(embeddable_slides) - len(pending_slides)
         if resolved_preprocessing.resume and skipped_slide_count > 0:

--- a/slide2vec/inference.py
+++ b/slide2vec/inference.py
@@ -43,6 +43,7 @@ from slide2vec.encoders.registry import (
 from slide2vec.runtime.model_settings import canonicalize_model_name
 from slide2vec.runtime.types import LoadedModel
 from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
 from slide2vec.progress import emit_progress
 
 from slide2vec.runtime.hierarchical import num_embedding_items
@@ -170,6 +171,7 @@ def load_model(
     if tile_encoder is not None:
         tile_encoder.to(target_device)
         encoder.tile_encoder = tile_encoder
+    plan = encoder_input.plan
     return LoadedModel(
         name=name,
         level=resolved_level,
@@ -178,6 +180,11 @@ def load_model(
         feature_dim=int(encoder.encode_dim),
         device=target_device,
         tile_feature_dim=int(tile_encoder.encode_dim) if tile_encoder is not None else None,
+        declared_encoder_input_size_px=(
+            int(plan.requested_tile_size_px)
+            if isinstance(plan, PooledEncoderInputPlan)
+            else None
+        ),
     )
 
 
@@ -704,7 +711,9 @@ def aggregate_tiles(
             artifact.sample_id,
             slide_embedding,
             execution=execution,
-            metadata=embedding.build_slide_embedding_metadata(model, image_path=metadata["image_path"]),
+            metadata=embedding.build_slide_embedding_metadata(
+                model, image_path=metadata["image_path"], tiling_result=tiling_result
+            ),
             latents=None,
         )
         outputs.append(slide_artifact)

--- a/slide2vec/runtime/artifacts_collect.py
+++ b/slide2vec/runtime/artifacts_collect.py
@@ -193,6 +193,7 @@ def collect_distributed_pipeline_artifacts(
         include_slide_embeddings=include_slide_embeddings,
         save_latents=execution.save_latents,
         resume=preprocessing.resume,
+        requested_tile_size_px=preprocessing.requested_tile_size_px,
     )
     pending_annotations = [placeholder.annotation for placeholder in pending_placeholders]
     skipped_slide_count = len(successful_slides) - len(pending_slides)

--- a/slide2vec/runtime/batching.py
+++ b/slide2vec/runtime/batching.py
@@ -378,9 +378,9 @@ def _record_encoder_input_size(loaded: LoadedModel, image) -> None:
     declared = getattr(loaded, "declared_encoder_input_size_px", None)
     if declared is not None and height != declared:
         raise ValueError(
-            f"Model '{loaded.name}' declared {declared}px pooled encoder inputs but the "
-            f"batch reaching the encoder is {height}px; got {height}px after preprocessing. "
-            "Declared runs must read, prepare and encode the requested tile size."
+            f"Model '{loaded.name}' declared {declared}px pooled encoder inputs but got "
+            f"{height}px after preprocessing. Declared runs must read, prepare and encode "
+            "the requested tile size."
         )
     previous = getattr(loaded, "encoder_input_size_px", None)
     if previous is not None and previous != height:

--- a/slide2vec/runtime/batching.py
+++ b/slide2vec/runtime/batching.py
@@ -364,13 +364,23 @@ def run_forward_pass(
 
 
 def _record_encoder_input_size(loaded: LoadedModel, image) -> None:
-    """Record the factual square tensor geometry immediately before encoding."""
+    """Record the factual square tensor geometry immediately before encoding.
+
+    A declared pooled run also promised a size; the batch must be exactly that size.
+    """
     if not torch.is_tensor(image) or image.ndim != 4:
         raise ValueError("Model preprocessing must produce a (B, C, H, W) tensor")
     height, width = (int(image.shape[-2]), int(image.shape[-1]))
     if height != width:
         raise ValueError(
             f"Model preprocessing must produce square encoder inputs; got {height}x{width}"
+        )
+    declared = getattr(loaded, "declared_encoder_input_size_px", None)
+    if declared is not None and height != declared:
+        raise ValueError(
+            f"Model '{loaded.name}' declared {declared}px pooled encoder inputs but the "
+            f"batch reaching the encoder is {height}px; got {height}px after preprocessing. "
+            "Declared runs must read, prepare and encode the requested tile size."
         )
     previous = getattr(loaded, "encoder_input_size_px", None)
     if previous is not None and previous != height:

--- a/slide2vec/runtime/dense_encoder_input.py
+++ b/slide2vec/runtime/dense_encoder_input.py
@@ -19,8 +19,6 @@ makes ``dynamic_img_size`` a derived fact rather than a knob a caller hand-passe
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
-
 from slide2vec.encoders.registry import (
     resolve_patch_size,
     resolve_preprocessing_requirements,
@@ -109,13 +107,3 @@ class DenseEncoderInputPlan:
             requires_variable_model_input=effective.requires_variable_model_input,
             model_construction_kwargs=effective.model_construction_kwargs,
         )
-
-    def get_transform(self, tile_encoder) -> Callable:
-        """Dense always encodes through the normalization-only transform.
-
-        Unconditionally, unlike the pooled plan: the shipped pooled transform resizes and
-        center-crops, which would destroy the ROI geometry the token grid registers to.
-        This is the same transform the dense read loop builds for itself, so a backend
-        loaded under a dense contract carries the transform dense actually uses.
-        """
-        return tile_encoder.get_normalization_transform()

--- a/slide2vec/runtime/dense_regions.py
+++ b/slide2vec/runtime/dense_regions.py
@@ -2,8 +2,9 @@
 
 The dense counterpart of the pooled coordinate path (``compute_tile_embeddings_for_slide``
 → ``run_forward_pass`` → ``encode_tiles``): instead of pooling each region to one vector,
-each sampled ROI is read from the slide, run through the encoder's normalization-only dense
-transform (``get_normalization_transform`` — NOT the pooled transform, which crops), padded
+each sampled ROI is read from the slide, run through the encoder's normalization-only
+transform (``get_normalization_transform`` — NOT the shipped given-input transform, which may
+crop), padded
 up to the encoder's patch multiple, and encoded via ``encode_tiles_dense`` into a
 ``(d, grid_h, grid_w)``
 token grid. ``iter_regions_dense`` **streams** these grids — yielding one per coordinate, in

--- a/slide2vec/runtime/embedding.py
+++ b/slide2vec/runtime/embedding.py
@@ -73,11 +73,14 @@ def build_tile_embedding_metadata(
     }
 
 
-def build_slide_embedding_metadata(model, *, image_path: Path | str) -> dict[str, Any]:
+def build_slide_embedding_metadata(
+    model, *, image_path: Path | str, tiling_result
+) -> dict[str, Any]:
     return {
         "encoder_name": model.name,
         "encoder_level": model.level,
         "image_path": str(image_path),
+        "requested_tile_size_px": _optional_int(tiling_result, "requested_tile_size_px"),
     }
 
 

--- a/slide2vec/runtime/embedding_persist.py
+++ b/slide2vec/runtime/embedding_persist.py
@@ -136,7 +136,9 @@ def persist_embedded_slide(
             embedded_slide.sample_id,
             embedded_slide.slide_embedding,
             execution=execution,
-            metadata=build_slide_embedding_metadata(model, image_path=embedded_slide.image_path),
+            metadata=build_slide_embedding_metadata(
+                model, image_path=embedded_slide.image_path, tiling_result=tiling_result
+            ),
             latents=embedded_slide.latents,
             annotation=annotation,
         )

--- a/slide2vec/runtime/encoder_input_contract.py
+++ b/slide2vec/runtime/encoder_input_contract.py
@@ -106,10 +106,16 @@ class EncoderInputContract:
         return cls(regime="given", plan=None)
 
     def get_transform(self, encoder) -> Callable:
-        """Return the encoder-owned transform this contract selects."""
+        """Return the encoder-owned transform this regime selects.
+
+        ``given`` applies the encoder's shipped recipe (which may resize and crop).
+        ``declared`` — pooled and dense alike — applies only the geometry-preserving
+        ``get_normalization_transform``, so the tensor handed to the encoder is exactly the
+        geometry the plan declared.
+        """
         if self.plan is None:
             return encoder.get_transform()
-        return self.plan.get_transform(encoder)
+        return encoder.get_normalization_transform()
 
     def construction_kwargs_for(self, encoder_name: str) -> dict[str, bool]:
         """Return the constructor settings this contract imposes on *encoder_name*.

--- a/slide2vec/runtime/patient_pipeline.py
+++ b/slide2vec/runtime/patient_pipeline.py
@@ -103,7 +103,9 @@ def run_patient_pipeline(
                 slide.sample_id,
                 slide_emb,
                 execution=execution,
-                metadata=build_slide_embedding_metadata(model, image_path=slide.image_path),
+                metadata=build_slide_embedding_metadata(
+                    model, image_path=slide.image_path, tiling_result=tiling_result
+                ),
             )
             slide_artifacts.append(slide_artifact)
 

--- a/slide2vec/runtime/persist_callbacks.py
+++ b/slide2vec/runtime/persist_callbacks.py
@@ -148,14 +148,14 @@ def pending_local_embedding_records(
     include_slide_embeddings: bool,
     save_latents: bool,
     resume: bool,
-    requested_tile_size_px: int | None = None,
+    requested_tile_size_px: int,
 ) -> tuple[list[SlideSpec], list[Any]]:
     """Split the run into (pending, completed) for resume.
 
-    A completed key is skipped only when its persisted tile/hierarchical metadata records
-    the same ``requested_tile_size_px`` as this run (or records none: pre-metadata
-    artifacts cannot be checked). A mismatch raises rather than silently reusing
-    embeddings computed from a different tile geometry.
+    A completed key is skipped only when every persisted sidecar (tile, hierarchical or
+    slide) records the same ``requested_tile_size_px`` as this run, or records none
+    (pre-metadata artifacts cannot be checked). A mismatch raises rather than silently
+    reusing embeddings computed from a different tile geometry.
     """
     if not resume:
         return list(successful_slides), list(tiling_results)
@@ -179,8 +179,10 @@ def pending_local_embedding_records(
                 annotation=annotation,
                 output_dir=output_dir,
                 output_format=output_format,
+                persist_tile_embeddings=persist_tile_embeddings,
                 persist_hierarchical_embeddings=persist_hierarchical_embeddings,
-                requested_tile_size_px=requested_tile_size_px,
+                include_slide_embeddings=include_slide_embeddings,
+                requested_tile_size_px=int(requested_tile_size_px),
             )
             continue
         pending_slides.append(slide)
@@ -194,31 +196,39 @@ def _refuse_stale_tile_size(
     annotation: str | None,
     output_dir: Path,
     output_format: str,
+    persist_tile_embeddings: bool,
     persist_hierarchical_embeddings: bool,
-    requested_tile_size_px: int | None,
+    include_slide_embeddings: bool,
+    requested_tile_size_px: int,
 ) -> None:
-    if requested_tile_size_px is None:
-        return
-    subdir = (
-        hierarchical_embeddings_subdir(annotation)
-        if persist_hierarchical_embeddings
-        else tile_embeddings_subdir(annotation)
-    )
-    metadata_path = output_dir / subdir / f"{sample_id}.meta.json"
-    if not metadata_path.is_file():
-        return
-    recorded = load_metadata(metadata_path).get("requested_tile_size_px")
-    if recorded is None or int(recorded) == int(requested_tile_size_px):
-        return
-    kind = "hierarchical" if persist_hierarchical_embeddings else "tile"
-    raise ValueError(
-        f"Cannot resume '{sample_id}': the existing {kind} embeddings at "
-        f"{output_dir / subdir / f'{sample_id}.{output_format}'} were computed with "
-        f"requested_tile_size_px={int(recorded)}, but this run requests "
-        f"{int(requested_tile_size_px)}px. Embeddings from a different tile size are not "
-        "comparable. Re-run into a new output_dir, or delete the stale artifacts, or "
-        "request the recorded tile size."
-    )
+    """Raise when any completed artifact sidecar records a different tile size.
+
+    Every sidecar this run would otherwise reuse is checked, so a slide-level run that
+    persisted only slide embeddings is covered too. A sidecar that records no tile size
+    (pre-metadata artifact) cannot be checked and is accepted.
+    """
+    sidecars: list[tuple[str, str]] = []
+    if persist_hierarchical_embeddings:
+        sidecars.append(("hierarchical", hierarchical_embeddings_subdir(annotation)))
+    elif persist_tile_embeddings:
+        sidecars.append(("tile", tile_embeddings_subdir(annotation)))
+    if include_slide_embeddings:
+        sidecars.append(("slide", slide_embeddings_subdir(annotation)))
+    for kind, subdir in sidecars:
+        metadata_path = output_dir / subdir / f"{sample_id}.meta.json"
+        if not metadata_path.is_file():
+            continue
+        recorded = load_metadata(metadata_path).get("requested_tile_size_px")
+        if recorded is None or int(recorded) == requested_tile_size_px:
+            continue
+        raise ValueError(
+            f"Cannot resume '{sample_id}': the existing {kind} embeddings at "
+            f"{output_dir / subdir / f'{sample_id}.{output_format}'} were computed with "
+            f"requested_tile_size_px={int(recorded)}, but this run requests "
+            f"{requested_tile_size_px}px. Embeddings from a different tile size are not "
+            "comparable. Re-run into a new output_dir, or delete the stale artifacts, or "
+            "request the recorded tile size."
+        )
 
 
 def _tiling_result_annotation(tiling_result) -> str | None:

--- a/slide2vec/runtime/persist_callbacks.py
+++ b/slide2vec/runtime/persist_callbacks.py
@@ -1,5 +1,6 @@
 """Incremental persist callback factory + resume-state queries."""
 
+import logging
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
@@ -25,6 +26,8 @@ from slide2vec.runtime.persistence import update_process_list_after_embedding
 from slide2vec.runtime.process_list import resolved_process_list_output_variant
 from slide2vec.utils.tiling_io import load_embedding_process_df
 
+logger = logging.getLogger("slide2vec")
+
 # Number of completed tile-level samples to buffer before rewriting the
 # process_list CSV. Each rewrite re-reads and re-writes the *entire* CSV, so
 # doing it once per sample is O(N^2) in I/O when every tile is its own sample
@@ -47,27 +50,38 @@ def has_complete_local_embedding_outputs(
     save_latents: bool,
     annotation: str | None = None,
 ) -> bool:
-    tile_subdir = tile_embeddings_subdir(annotation)
-    if persist_hierarchical_embeddings:
-        hierarchical_subdir = hierarchical_embeddings_subdir(annotation)
-        hierarchical_artifact_path = output_dir / hierarchical_subdir / f"{sample_id}.{output_format}"
-        if not hierarchical_artifact_path.is_file():
+    for _kind, subdir in _embedding_sidecars(
+        annotation,
+        persist_tile_embeddings=persist_tile_embeddings,
+        persist_hierarchical_embeddings=persist_hierarchical_embeddings,
+        include_slide_embeddings=include_slide_embeddings,
+    ):
+        if not (output_dir / subdir / f"{sample_id}.{output_format}").is_file():
             return False
-    elif persist_tile_embeddings:
-        tile_artifact_path = output_dir / tile_subdir / f"{sample_id}.{output_format}"
-        if not tile_artifact_path.is_file():
+    if include_slide_embeddings and save_latents:
+        latent_suffix = "pt" if output_format == "pt" else "npz"
+        latent_path = output_dir / slide_latents_subdir(annotation) / f"{sample_id}.{latent_suffix}"
+        if not latent_path.is_file():
             return False
-    if include_slide_embeddings:
-        slide_subdir = slide_embeddings_subdir(annotation)
-        slide_artifact_path = output_dir / slide_subdir / f"{sample_id}.{output_format}"
-        if not slide_artifact_path.is_file():
-            return False
-        if save_latents:
-            latent_suffix = "pt" if output_format == "pt" else "npz"
-            latent_path = output_dir / slide_latents_subdir(annotation) / f"{sample_id}.{latent_suffix}"
-            if not latent_path.is_file():
-                return False
     return True
+
+
+def _embedding_sidecars(
+    annotation: str | None,
+    *,
+    persist_tile_embeddings: bool,
+    persist_hierarchical_embeddings: bool,
+    include_slide_embeddings: bool,
+) -> list[tuple[str, str]]:
+    """``(kind, subdir)`` of every embedding artifact a run persists for one work unit."""
+    sidecars: list[tuple[str, str]] = []
+    if persist_hierarchical_embeddings:
+        sidecars.append(("hierarchical", hierarchical_embeddings_subdir(annotation)))
+    elif persist_tile_embeddings:
+        sidecars.append(("tile", tile_embeddings_subdir(annotation)))
+    if include_slide_embeddings:
+        sidecars.append(("slide", slide_embeddings_subdir(annotation)))
+    return sidecars
 
 
 def _normalized_resume_annotation(annotation) -> str | None:
@@ -205,21 +219,28 @@ def _refuse_stale_tile_size(
 
     Every sidecar this run would otherwise reuse is checked, so a slide-level run that
     persisted only slide embeddings is covered too. A sidecar that records no tile size
-    (pre-metadata artifact) cannot be checked and is accepted.
+    (pre-metadata artifact) cannot be checked; it is accepted with a warning.
     """
-    sidecars: list[tuple[str, str]] = []
-    if persist_hierarchical_embeddings:
-        sidecars.append(("hierarchical", hierarchical_embeddings_subdir(annotation)))
-    elif persist_tile_embeddings:
-        sidecars.append(("tile", tile_embeddings_subdir(annotation)))
-    if include_slide_embeddings:
-        sidecars.append(("slide", slide_embeddings_subdir(annotation)))
-    for kind, subdir in sidecars:
+    for kind, subdir in _embedding_sidecars(
+        annotation,
+        persist_tile_embeddings=persist_tile_embeddings,
+        persist_hierarchical_embeddings=persist_hierarchical_embeddings,
+        include_slide_embeddings=include_slide_embeddings,
+    ):
         metadata_path = output_dir / subdir / f"{sample_id}.meta.json"
         if not metadata_path.is_file():
             continue
         recorded = load_metadata(metadata_path).get("requested_tile_size_px")
-        if recorded is None or int(recorded) == requested_tile_size_px:
+        if recorded is None:
+            logger.warning(
+                "Resuming '%s' from existing %s embeddings that record no "
+                "requested_tile_size_px; cannot verify they were computed at %dpx.",
+                sample_id,
+                kind,
+                requested_tile_size_px,
+            )
+            continue
+        if int(recorded) == requested_tile_size_px:
             continue
         raise ValueError(
             f"Cannot resume '{sample_id}': the existing {kind} embeddings at "

--- a/slide2vec/runtime/persist_callbacks.py
+++ b/slide2vec/runtime/persist_callbacks.py
@@ -12,6 +12,7 @@ from slide2vec.artifacts import (
     SlideEmbeddingArtifact,
     TileEmbeddingArtifact,
     hierarchical_embeddings_subdir,
+    load_metadata,
     normalize_artifact_annotation,
     slide_embeddings_subdir,
     slide_latents_subdir,
@@ -147,7 +148,15 @@ def pending_local_embedding_records(
     include_slide_embeddings: bool,
     save_latents: bool,
     resume: bool,
+    requested_tile_size_px: int | None = None,
 ) -> tuple[list[SlideSpec], list[Any]]:
+    """Split the run into (pending, completed) for resume.
+
+    A completed key is skipped only when its persisted tile/hierarchical metadata records
+    the same ``requested_tile_size_px`` as this run (or records none: pre-metadata
+    artifacts cannot be checked). A mismatch raises rather than silently reusing
+    embeddings computed from a different tile geometry.
+    """
     if not resume:
         return list(successful_slides), list(tiling_results)
 
@@ -165,10 +174,51 @@ def pending_local_embedding_records(
     for slide, tiling_result in zip(successful_slides, tiling_results):
         annotation = _tiling_result_annotation(tiling_result)
         if (slide.sample_id, annotation) in completed_keys:
+            _refuse_stale_tile_size(
+                slide.sample_id,
+                annotation=annotation,
+                output_dir=output_dir,
+                output_format=output_format,
+                persist_hierarchical_embeddings=persist_hierarchical_embeddings,
+                requested_tile_size_px=requested_tile_size_px,
+            )
             continue
         pending_slides.append(slide)
         pending_tiling_results.append(tiling_result)
     return pending_slides, pending_tiling_results
+
+
+def _refuse_stale_tile_size(
+    sample_id: str,
+    *,
+    annotation: str | None,
+    output_dir: Path,
+    output_format: str,
+    persist_hierarchical_embeddings: bool,
+    requested_tile_size_px: int | None,
+) -> None:
+    if requested_tile_size_px is None:
+        return
+    subdir = (
+        hierarchical_embeddings_subdir(annotation)
+        if persist_hierarchical_embeddings
+        else tile_embeddings_subdir(annotation)
+    )
+    metadata_path = output_dir / subdir / f"{sample_id}.meta.json"
+    if not metadata_path.is_file():
+        return
+    recorded = load_metadata(metadata_path).get("requested_tile_size_px")
+    if recorded is None or int(recorded) == int(requested_tile_size_px):
+        return
+    kind = "hierarchical" if persist_hierarchical_embeddings else "tile"
+    raise ValueError(
+        f"Cannot resume '{sample_id}': the existing {kind} embeddings at "
+        f"{output_dir / subdir / f'{sample_id}.{output_format}'} were computed with "
+        f"requested_tile_size_px={int(recorded)}, but this run requests "
+        f"{int(requested_tile_size_px)}px. Embeddings from a different tile size are not "
+        "comparable. Re-run into a new output_dir, or delete the stale artifacts, or "
+        "request the recorded tile size."
+    )
 
 
 def _tiling_result_annotation(tiling_result) -> str | None:

--- a/slide2vec/runtime/pooled_encoder_input.py
+++ b/slide2vec/runtime/pooled_encoder_input.py
@@ -3,36 +3,29 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Literal
 
 from slide2vec.encoders.registry import resolve_preprocessing_requirements
 from slide2vec.runtime.effective_encoder_input import EffectiveEncoderInput
 
-#: Closed vocabulary for which encoder-owned preprocessing a pooled run applies.
-PooledPreprocessingKind = Literal["shipped", "normalization_only"]
-
 
 @dataclass(frozen=True, kw_only=True)
 class PooledEncoderInputPlan:
-    """One pooled run's encoder-input and preprocessing contract.
+    """One pooled run's encoder-input contract.
 
-    The pooled **effective encoder input** is ``requested_tile_size_px``: the exact square
-    the normalization-only recipe hands to ``encode_tiles``. Whether the encoder can accept
-    it is not decided here — that question is shared with dense extraction and is answered
-    by :class:`~slide2vec.runtime.effective_encoder_input.EffectiveEncoderInput`.
-
-    ``expected_encoder_input_size_px`` is intentionally nullable for a shipped
-    preset recipe: the factual size is observed from the transformed batch just
-    before encoding. Exact non-preset recipes can guarantee their final size.
+    A declared pooled run reads, prepares and encodes exactly ``requested_tile_size_px``:
+    the tile is handed to ``encode_tiles`` through the encoder's geometry-preserving
+    ``get_normalization_transform`` whether or not the size is the registry preset. Whether
+    the encoder can accept it is not decided here — that question is shared with dense
+    extraction and is answered by
+    :class:`~slide2vec.runtime.effective_encoder_input.EffectiveEncoderInput`, and it only
+    describes backend capability/construction; it never selects a different recipe.
     """
 
     encoder_name: str
     tile_encoder_name: str
     preset_input_size_px: int
     requested_tile_size_px: int
-    preprocessing_kind: PooledPreprocessingKind
     requires_variable_model_input: bool
-    expected_encoder_input_size_px: int | None
     model_construction_kwargs: dict[str, bool]
 
     @classmethod
@@ -63,23 +56,11 @@ class PooledEncoderInputPlan:
             size_px=requested_size,
             origin=f"requested_tile_size_px={requested_size}",
         )
-        # An exact request is one the shipped recipe would not produce: it applies
-        # normalization only, and its final size is therefore known up front rather than
-        # observed from the transformed batch.
-        is_exact = effective.requires_variable_model_input
         return cls(
             encoder_name=encoder_name,
             tile_encoder_name=effective.tile_encoder_name,
             preset_input_size_px=effective.preset_input_size_px,
             requested_tile_size_px=requested_size,
-            preprocessing_kind="normalization_only" if is_exact else "shipped",
-            requires_variable_model_input=is_exact,
-            expected_encoder_input_size_px=requested_size if is_exact else None,
+            requires_variable_model_input=effective.requires_variable_model_input,
             model_construction_kwargs=effective.model_construction_kwargs,
         )
-
-    def get_transform(self, tile_encoder) -> Callable:
-        """Return the encoder-owned transform selected by this plan."""
-        if self.requires_variable_model_input:
-            return tile_encoder.get_normalization_transform()
-        return tile_encoder.get_transform()

--- a/slide2vec/runtime/types.py
+++ b/slide2vec/runtime/types.py
@@ -46,4 +46,7 @@ class LoadedModel:
     feature_dim: int
     device: torch.device
     tile_feature_dim: int | None = None
+    #: Square size a declared pooled run promised to encode; ``None`` for given/dense.
+    declared_encoder_input_size_px: int | None = None
+    #: Square size observed on the batch just before encoding.
     encoder_input_size_px: int | None = None

--- a/tests/test_dense_encoder_input.py
+++ b/tests/test_dense_encoder_input.py
@@ -129,11 +129,11 @@ def test_dense_sliding_window_is_clamped_to_the_encoded_extent():
 
 
 def test_dense_contract_selects_the_normalization_only_transform():
-    """Dense never uses the shipped pooled transform: it would resize/crop the ROI."""
+    """Dense never uses the shipped given-input transform: it would resize/crop the ROI."""
 
     class _Encoder:
         def get_transform(self):
-            raise AssertionError("dense must not select the shipped pooled transform")
+            raise AssertionError("dense must not select the shipped given-input transform")
 
         def get_normalization_transform(self):
             return "normalization"
@@ -232,7 +232,7 @@ class _StandInVirchow2:
         return (14, 14)
 
     def get_transform(self):
-        raise AssertionError("dense must not select the shipped pooled transform")
+        raise AssertionError("dense must not select the shipped given-input transform")
 
     def get_normalization_transform(self):
         return v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])

--- a/tests/test_dense_image_stage.py
+++ b/tests/test_dense_image_stage.py
@@ -767,6 +767,9 @@ def test_omitted_spacing_readable_scale_requires_one_resolvable_model_default(
         def get_transform(self):
             return lambda image: image
 
+        def get_normalization_transform(self):
+            return lambda image: image
+
         def encode_tiles(self, batch):
             return batch
 

--- a/tests/test_encoder_capabilities.py
+++ b/tests/test_encoder_capabilities.py
@@ -27,6 +27,9 @@ class _PooledOnlyEncoder(TileEncoder):
     def get_transform(self):
         return lambda image: image
 
+    def get_normalization_transform(self):
+        return lambda image: image
+
     def encode_tiles(self, batch):
         return batch
 
@@ -53,9 +56,6 @@ class _DenseEncoder(_PooledOnlyEncoder):
     @property
     def patch_size(self):
         return (16, 16)
-
-    def get_normalization_transform(self):
-        return lambda image: image
 
 
 class _PartialDenseEncoder(_PooledOnlyEncoder):
@@ -226,7 +226,7 @@ def test_registration_rejects_static_patch_metadata_without_dense_class_contract
     assert str(exc_info.value) == (
         "Encoder 'synthetic-contradictory-dense' has an inconsistent dense contract: "
         "patch_size metadata is declared, but the class must also override "
-        "encode_tiles_dense, patch_size, and get_normalization_transform."
+        "encode_tiles_dense and patch_size."
     )
 
 
@@ -243,9 +243,9 @@ def test_registration_rejects_partial_dense_class_contract():
 
     assert str(exc_info.value) == (
         "Encoder 'synthetic-incomplete-dense' has an incomplete dense class contract: "
-        "encode_tiles_dense is overridden, but patch_size and "
-        "get_normalization_transform are inherited as unsupported. Override all three "
-        "dense members together and declare patch_size metadata."
+        "encode_tiles_dense is overridden, but patch_size is inherited as "
+        "unsupported. Override both dense members together and declare patch_size "
+        "metadata."
     )
 
 
@@ -281,8 +281,7 @@ def test_registration_rejects_attention_without_dense_contract():
     assert str(exc_info.value) == (
         "Encoder 'synthetic-attention-without-dense' overrides "
         "encode_tiles_attention without a complete dense contract. Attention maps "
-        "require encode_tiles_dense, patch_size, get_normalization_transform, and "
-        "static patch_size metadata."
+        "require encode_tiles_dense, patch_size, and static patch_size metadata."
     )
 
 

--- a/tests/test_encoder_input_contract.py
+++ b/tests/test_encoder_input_contract.py
@@ -75,6 +75,34 @@ def test_load_model_rejects_an_absent_contract_rather_than_falling_back(stand_in
         inference.load_model(name="gigapath", device="cpu", encoder_input=None)
 
 
+def test_load_model_under_a_declared_pooled_contract_carries_the_declared_encoder_input_size(
+    stand_in_gigapath,
+):
+    import slide2vec.inference as inference
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    loaded = inference.load_model(
+        name="gigapath",
+        device="cpu",
+        encoder_input=EncoderInputContract.declared_pooled(
+            "gigapath", requested_tile_size_px=224, allow_non_recommended_settings=False
+        ),
+    )
+
+    assert loaded.declared_encoder_input_size_px == 224
+
+
+def test_load_model_under_a_given_contract_declares_no_encoder_input_size(stand_in_gigapath):
+    import slide2vec.inference as inference
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    loaded = inference.load_model(
+        name="gigapath", device="cpu", encoder_input=EncoderInputContract.given()
+    )
+
+    assert loaded.declared_encoder_input_size_px is None
+
+
 def test_declared_geometry_rejects_an_off_preset_request_without_permission():
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 

--- a/tests/test_encoder_input_contract.py
+++ b/tests/test_encoder_input_contract.py
@@ -108,24 +108,38 @@ def test_declared_geometry_rejects_a_non_multiple_of_the_patch_size():
         )
 
 
-def test_declared_geometry_keeps_normalization_only_preprocessing(stand_in_gigapath):
+@pytest.mark.parametrize(
+    "requested_tile_size_px, allow_non_recommended_settings, requires_variable_model_input",
+    [
+        pytest.param(224, False, False, id="preset"),
+        pytest.param(288, True, True, id="permitted-off-preset"),
+    ],
+)
+def test_declared_geometry_selects_geometry_preserving_preprocessing(
+    stand_in_gigapath,
+    requested_tile_size_px,
+    allow_non_recommended_settings,
+    requires_variable_model_input,
+):
+    """Every declared pooled run encodes the size it requested: preset or not."""
     import slide2vec.inference as inference
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
     contract = EncoderInputContract.declared_pooled(
         "gigapath",
-        requested_tile_size_px=288,
-        allow_non_recommended_settings=True,
+        requested_tile_size_px=requested_tile_size_px,
+        allow_non_recommended_settings=allow_non_recommended_settings,
     )
 
     assert contract.regime == "declared"
-    assert contract.plan.preprocessing_kind == "normalization_only"
-    assert contract.plan.expected_encoder_input_size_px == 288
+    assert contract.plan.requested_tile_size_px == requested_tile_size_px
+    assert contract.plan.requires_variable_model_input is requires_variable_model_input
+    assert contract.get_transform(_StandInEncoder()) is _StandInEncoder.normalization
 
     loaded = inference.load_model(
         name="gigapath",
         device="cpu",
-        allow_non_recommended_settings=True,
+        allow_non_recommended_settings=allow_non_recommended_settings,
         encoder_input=contract,
     )
 
@@ -153,7 +167,7 @@ def test_given_geometry_applies_the_shipped_transform(stand_in_gigapath):
 def test_given_geometry_records_the_observed_encoder_input_instead_of_vetoing_it(
     stand_in_gigapath,
 ):
-    """224px pixels handed to a 256px-preset encoder are recorded, never rejected."""
+    """Given pixels are recorded at their observed size, never vetoed against the preset."""
     import slide2vec.inference as inference
     from slide2vec.runtime.batching import run_forward_pass
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
@@ -301,7 +315,7 @@ def test_in_process_embed_patients_declares_the_requested_geometry(monkeypatch, 
 
     assert result == []
     assert model._encoder_input.regime == "declared"
-    assert model._encoder_input.plan.expected_encoder_input_size_px == 232
+    assert model._encoder_input.plan.requested_tile_size_px == 232
     assert model._load_backend().transforms is _StandInEncoder.normalization
 
 

--- a/tests/test_encoder_plugins.py
+++ b/tests/test_encoder_plugins.py
@@ -59,6 +59,9 @@ def register_presets():
         def get_transform(self):
             return lambda image: image
 
+        def get_normalization_transform(self):
+            return lambda image: image
+
         def encode_tiles(self, batch):
             return batch[:, :3]
 

--- a/tests/test_encoder_preprocessing.py
+++ b/tests/test_encoder_preprocessing.py
@@ -2,6 +2,7 @@
 
 from types import SimpleNamespace
 
+import numpy as np
 from PIL import Image
 import pytest
 import timm
@@ -22,8 +23,58 @@ def recipe_encoder(name):
                       std=(0.229, 0.224, 0.225))
     if name == "mstar":
         config.update(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5))
+    if name == "h-optimus-0":
+        # bioptimus/H-optimus-0 pretrained_cfg (verified against the hub config).
+        config.update(mean=(0.707223, 0.578729, 0.703617), std=(0.211883, 0.230117, 0.177517))
     encoder._model = SimpleNamespace(pretrained_cfg=config)
     return encoder
+
+
+IMAGENET_RED = [2.2489083, -2.0357143, -1.8044444]
+IMAGENET_BLACK = [-2.117904, -2.0357143, -1.8044444]
+
+
+def bordered_image(size: int) -> Image.Image:
+    """Black square with a one-pixel red border: any resize or crop changes the border."""
+    image = Image.new("RGB", (size, size), (0, 0, 0))
+    image.paste((255, 0, 0), (0, 0, size, 1))
+    image.paste((255, 0, 0), (0, size - 1, size, size))
+    image.paste((255, 0, 0), (0, 0, 1, size))
+    image.paste((255, 0, 0), (size - 1, 0, size, size))
+    return image
+
+
+def uint8_batch(image: Image.Image) -> torch.Tensor:
+    """The ``(1, 3, H, W)`` uint8 tensor a tile reader hands the encode loop."""
+    return torch.from_numpy(np.array(image)).permute(2, 0, 1).unsqueeze(0).contiguous()
+
+
+def encode_through_the_loop(loaded, image: Image.Image, *, size: int) -> None:
+    """Run the pooled encode loop once batched and once itemwise on the same tile."""
+    from contextlib import nullcontext
+    from slide2vec.runtime.batching import (
+        build_batch_preprocessor_for_tile_images,
+        run_forward_pass,
+    )
+
+    batched = build_batch_preprocessor_for_tile_images(loaded, requested_tile_size_px=size)
+    assert batched is not None
+    for preprocessor in (batched, None):
+        _, embeddings = run_forward_pass(
+            [(torch.tensor([0]), uint8_batch(image))], loaded, nullcontext(),
+            batch_preprocessor=preprocessor,
+        )
+        torch.testing.assert_close(embeddings, torch.tensor([[1.0, 2.0]]))
+        assert loaded.encoder_input_size_px == size
+
+
+def assert_border_intact(output: torch.Tensor, *, size: int, red, black) -> None:
+    assert tuple(output.shape) == (3, size, size)
+    torch.testing.assert_close(output[:, 0, 0], torch.tensor(red))
+    torch.testing.assert_close(output[:, size - 1, size - 1], torch.tensor(red))
+    torch.testing.assert_close(output[:, size // 2, size // 2], torch.tensor(black))
+    is_red = torch.isclose(output[0], torch.tensor(red[0]), atol=1e-4)
+    assert int(is_red.sum()) == 4 * size - 4
 
 
 @pytest.mark.parametrize("size", [(224, 224), (448, 224)])
@@ -45,39 +96,116 @@ def test_gpfm_resizes_complete_image_to_224(size):
     torch.testing.assert_close(output[:, 112, -1], torch.tensor([-2.117904, -2.0357143, 2.64]))
 
 
-@pytest.mark.parametrize("name, expected_red", [
-    ("lunit", [2.2489083, -2.0357143, -1.8044444]),
-    ("mstar", [1.0, -1.0, -1.0]),
+@pytest.mark.parametrize("name, expected_red, expected_black", [
+    ("lunit", IMAGENET_RED, IMAGENET_BLACK),
+    ("mstar", [1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]),
+    ("gigapath", IMAGENET_RED, IMAGENET_BLACK),
 ])
-def test_crop_recipe_samples_248_without_enlarging(name, expected_red):
+def test_default_declared_pooled_encodes_the_224_it_read(
+    monkeypatch, name, expected_red, expected_black,
+):
+    """Read 224 -> normalize -> encode 224: no enlarging, no discarded edge pixels."""
+    import slide2vec.inference as inference
+    from slide2vec.api import Model, PreprocessingConfig
     from slide2vec.encoders.registry import resolve_preprocessing_defaults
+    from slide2vec.runtime.types import LoadedModel
+
+    assert resolve_preprocessing_defaults(name)["tile_size_px"] == 224
+    observed = []
+    encoder = recipe_encoder(name)
+
+    class RecordingBackbone:
+        pretrained_cfg = encoder._model.pretrained_cfg
+
+        def __call__(self, batch):
+            observed.append(batch.clone())
+            return torch.tensor([[1.0, 2.0]])
+
+    encoder._model = RecordingBackbone()
+
+    def embed_slides(model, slides, *, preprocessing, execution):
+        contract = model._encoder_input
+        assert contract.regime == "declared"
+        assert contract.plan.requested_tile_size_px == 224
+        assert contract.plan.requires_variable_model_input is False
+        loaded = LoadedModel(name=name, level="tile", model=encoder,
+                             transforms=contract.get_transform(encoder),
+                             feature_dim=2, device=torch.device("cpu"))
+        encode_through_the_loop(loaded, bordered_image(224), size=224)
+        return []
+
+    monkeypatch.setattr(inference, "embed_slides", embed_slides)
+    model = Model.from_preset(name, device="cpu")
+    assert model.embed_slides([], preprocessing=PreprocessingConfig(
+        requested_spacing_um=0.5, requested_tile_size_px=None,
+    )) == {}
+    assert [tuple(batch.shape) for batch in observed] == [(1, 3, 224, 224)] * 2
+    assert_border_intact(observed[0][0], size=224, red=expected_red, black=expected_black)
+    torch.testing.assert_close(observed[1], observed[0])  # batched == itemwise
+
+
+@pytest.mark.parametrize("name, sampled, expected_red", [
+    ("lunit", 248, IMAGENET_RED),
+    ("mstar", 248, [1.0, -1.0, -1.0]),
+    ("gigapath", 256, IMAGENET_RED),
+])
+def test_given_pixels_keep_shipped_resize_then_center_crop_recipe(name, sampled, expected_red):
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
-    assert resolve_preprocessing_defaults(name)["tile_size_px"] == 248
-    contract = EncoderInputContract.declared_pooled(
-        name, requested_tile_size_px=248, allow_non_recommended_settings=False,
-    )
-    transform = contract.get_transform(recipe_encoder(name))
-    image = Image.new("RGB", (248, 248), (255, 0, 0))
-    assert transform.transforms[0](image).size == (248, 248)
-    assert transform.transforms[0].interpolation == transforms.InterpolationMode.BICUBIC
+    transform = EncoderInputContract.given().get_transform(recipe_encoder(name))
+    image = Image.new("RGB", (sampled, sampled), (255, 0, 0))
+    resize = transform.transforms[0] if name != "gigapath" else transform.transforms[1]
+    assert resize(image).size == (sampled, sampled)
+    assert resize.interpolation == transforms.InterpolationMode.BICUBIC
     output = transform(image)
     assert tuple(output.shape) == (3, 224, 224)
     torch.testing.assert_close(output[:, 0, 0], torch.tensor(expected_red))
 
 
+@pytest.mark.parametrize("name", ["gpfm", "h-optimus-0"])
+def test_declared_normalization_matches_shipped_photometrics_at_224(name):
+    """Shipped recipes hardcode mean/std; the geometry-preserving path reads the timm config."""
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    encoder = recipe_encoder(name)
+    image = bordered_image(224)
+    image.paste((40, 120, 200), (10, 10, 60, 60))
+    declared = EncoderInputContract.declared_pooled(
+        name, requested_tile_size_px=224, allow_non_recommended_settings=False,
+    ).get_transform(encoder)(image)
+    shipped = EncoderInputContract.given().get_transform(encoder)(image)
+
+    assert tuple(declared.shape) == (3, 224, 224)
+    torch.testing.assert_close(declared, shipped)
+
+
+def test_musk_default_declared_pooled_keeps_fixed_384_input():
+    from slide2vec.encoders.models.musk import MUSK
+    from slide2vec.encoders.registry import resolve_preprocessing_requirements
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    assert resolve_preprocessing_requirements("musk")["tile_size_px"] == 384
+    contract = EncoderInputContract.declared_pooled(
+        "musk", requested_tile_size_px=384, allow_non_recommended_settings=False,
+    )
+    assert contract.plan.requires_variable_model_input is False
+    assert contract.plan.model_construction_kwargs == {}
+
+    output = contract.get_transform(MUSK.__new__(MUSK))(bordered_image(384))
+
+    assert_border_intact(output, size=384, red=[1.0, -1.0, -1.0], black=[-1.0, -1.0, -1.0])
+
+
 @pytest.mark.parametrize(
-    "requested, permission, expected_kind, expected_shape",
-    [(None, False, "shipped", (1, 3, 518, 518)),
-     (224, True, "normalization_only", (1, 3, 224, 224))],
+    "requested, permission, expected_size, requires_variable_model_input",
+    [(None, False, 518, False), (224, True, 224, True)],
 )
 def test_dinov2_public_pooled_recipe_reaches_encoding(
-    monkeypatch, requested, permission, expected_kind, expected_shape,
+    monkeypatch, requested, permission, expected_size, requires_variable_model_input,
 ):
-    from contextlib import nullcontext
+    """Default 518 and permitted 224 both encode exactly the tile they read."""
     import slide2vec.inference as inference
     from slide2vec.api import Model, PreprocessingConfig
-    from slide2vec.runtime.batching import run_forward_pass
     from slide2vec.runtime.types import LoadedModel
 
     observed = []
@@ -87,7 +215,7 @@ def test_dinov2_public_pooled_recipe_reaches_encoding(
         pretrained_cfg = encoder._model.pretrained_cfg
 
         def __call__(self, batch):
-            observed.append(tuple(batch.shape))
+            observed.append(batch.clone())
             return torch.tensor([[1.0, 2.0]])
 
     encoder._model = RecordingBackbone()
@@ -95,15 +223,12 @@ def test_dinov2_public_pooled_recipe_reaches_encoding(
     def embed_slides(model, slides, *, preprocessing, execution):
         contract = model._encoder_input
         assert contract.regime == "declared"
-        assert contract.plan.preprocessing_kind == expected_kind
-        transform = contract.get_transform(encoder)
-        tile = Image.new("RGB", (requested or 518, requested or 518))
+        assert contract.plan.requested_tile_size_px == expected_size
+        assert contract.plan.requires_variable_model_input is requires_variable_model_input
         loaded = LoadedModel(name="dinov2-vitb14", level="tile", model=encoder,
-                             transforms=transform, feature_dim=2, device=torch.device("cpu"))
-        _, embeddings = run_forward_pass(
-            [(torch.tensor([0]), transform(tile).unsqueeze(0))], loaded, nullcontext(),
-        )
-        torch.testing.assert_close(embeddings, torch.tensor([[1.0, 2.0]]))
+                             transforms=contract.get_transform(encoder),
+                             feature_dim=2, device=torch.device("cpu"))
+        encode_through_the_loop(loaded, bordered_image(expected_size), size=expected_size)
         return []
 
     monkeypatch.setattr(inference, "embed_slides", embed_slides)
@@ -111,7 +236,22 @@ def test_dinov2_public_pooled_recipe_reaches_encoding(
     assert model.embed_slides([], preprocessing=PreprocessingConfig(
         requested_spacing_um=0.5, requested_tile_size_px=requested,
     )) == {}
-    assert observed == [expected_shape]
+    assert [tuple(batch.shape) for batch in observed] == [(1, 3, expected_size, expected_size)] * 2
+    assert_border_intact(observed[0][0], size=expected_size, red=IMAGENET_RED, black=IMAGENET_BLACK)
+    torch.testing.assert_close(observed[1], observed[0])  # batched == itemwise
+
+
+def test_dinov2_public_pooled_225_raises_even_with_permission(monkeypatch):
+    """No implicit padding or rounding: 225 is not a multiple of the 14px patch."""
+    import slide2vec.inference as inference
+    from slide2vec.api import Model, PreprocessingConfig
+
+    monkeypatch.setattr(inference, "embed_slides", lambda *a, **k: pytest.fail("must reject before dispatch"))
+    model = Model.from_preset("dinov2-vitb14", device="cpu", allow_non_recommended_settings=True)
+    with pytest.raises(ValueError, match="divisible by its 14x14 patch geometry"):
+        model.embed_slides([], preprocessing=PreprocessingConfig(
+            requested_spacing_um=0.5, requested_tile_size_px=225,
+        ))
 
 
 def test_dinov2_public_pooled_224_requires_permission(monkeypatch):

--- a/tests/test_encoder_provider_failures.py
+++ b/tests/test_encoder_provider_failures.py
@@ -63,6 +63,9 @@ def test_encoder_class(encode_dim=3):
         def get_transform(self):
             return lambda image: image
 
+        def get_normalization_transform(self):
+            return lambda image: image
+
         def encode_tiles(self, batch):
             return batch[:, :encode_dim]
 

--- a/tests/test_encoder_registry.py
+++ b/tests/test_encoder_registry.py
@@ -126,7 +126,7 @@ def test_prost40m_input_size_is_224_and_encode_dim_is_384():
 def test_mstar_metadata_contract():
     info = encoder_registry.info("mstar")
     assert info["level"] == "tile"
-    assert info["input_size"] == 248
+    assert info["input_size"] == 224
     assert info["patch_size"] == 16
     assert info["supported_spacing_um"] == pytest.approx(0.5)
     assert info["precision"] == "fp32"
@@ -396,3 +396,75 @@ def test_encoder_not_in_registry_raises_key_error():
 def test_encoder_contains_check():
     assert "virchow2" in encoder_registry
     assert "nonexistent-model" not in encoder_registry
+
+
+@pytest.mark.parametrize(
+    "name, expected_input_size",
+    [("lunit", 224), ("mstar", 224), ("gigapath", 224), ("dinov2-vitb14", 518), ("gpfm", 224)],
+)
+def test_registry_input_size_is_the_final_encoder_input_size(name, expected_input_size):
+    """``input_size`` is the default *final* model input: no encoder-side crop follows it."""
+    from slide2vec.encoders.registry import resolve_preprocessing_defaults
+
+    assert encoder_registry.info(name)["input_size"] == expected_input_size
+    assert resolve_preprocessing_defaults(name)["tile_size_px"] == expected_input_size
+
+
+def test_tile_registration_requires_a_geometry_preserving_transform():
+    """Declared runs encode exactly the requested tile: a tile encoder must normalize without resizing."""
+    from slide2vec.encoders.base import TileEncoder
+    from slide2vec.encoders.registry import register_encoder
+
+    class ShippedOnly(TileEncoder):
+        def __init__(self, *, output_variant=None):
+            pass
+
+        def get_transform(self):
+            return lambda image: image
+
+        def encode_tiles(self, batch):
+            return batch
+
+        @property
+        def encode_dim(self):
+            return 1
+
+        @property
+        def device(self):
+            return "cpu"
+
+        def to(self, device):
+            return self
+
+    with pytest.raises(ValueError) as error:
+        register_encoder(
+            "shipped-only",
+            output_variants={"default": {"encode_dim": 1}},
+            default_output_variant="default",
+            input_size=224,
+            supports_variable_input_size=False,
+            supported_spacing_um=0.5,
+            precision="fp32",
+            source="local",
+        )(ShippedOnly)
+
+    assert str(error.value) == (
+        "Encoder 'shipped-only' must override get_normalization_transform: declared "
+        "pooled and dense runs encode exactly the requested tile geometry, so a tile "
+        "encoder needs a geometry-preserving (normalization-only) transform alongside "
+        "its shipped get_transform recipe."
+    )
+    assert "shipped-only" not in encoder_registry.names()
+
+
+def test_every_builtin_tile_encoder_provides_a_geometry_preserving_transform():
+    from slide2vec.encoders.base import TileEncoder
+
+    for name in encoder_registry.names():
+        if encoder_registry.info(name)["level"] != "tile":
+            continue
+        encoder_cls = encoder_registry.require(name)
+        assert (
+            encoder_cls.get_normalization_transform
+            is not TileEncoder.get_normalization_transform
+        ), name

--- a/tests/test_pooled_encoder_input.py
+++ b/tests/test_pooled_encoder_input.py
@@ -19,25 +19,27 @@ class _TransformStandIn:
         return self.normalization_transform
 
 
-def test_preset_plan_uses_shipped_pooled_transform():
-    from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+def test_preset_plan_keeps_requested_geometry_without_variable_input():
+    """A preset request needs no capability, and is still encoded at the size it read."""
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
-    plan = PooledEncoderInputPlan.resolve(
+    contract = EncoderInputContract.declared_pooled(
         "gigapath",
-        requested_tile_size_px=256,
+        requested_tile_size_px=224,
         allow_non_recommended_settings=False,
     )
-    encoder = _TransformStandIn()
+    plan = contract.plan
 
-    transformed = plan.get_transform(encoder)(torch.zeros((3, 256, 256), dtype=torch.uint8))
+    transformed = contract.get_transform(_TransformStandIn())(
+        torch.zeros((3, 224, 224), dtype=torch.uint8)
+    )
 
     assert plan.tile_encoder_name == "gigapath"
-    assert plan.preset_input_size_px == 256
-    assert plan.requested_tile_size_px == 256
-    assert plan.preprocessing_kind == "shipped"
+    assert plan.preset_input_size_px == 224
+    assert plan.requested_tile_size_px == 224
     assert plan.requires_variable_model_input is False
-    assert plan.expected_encoder_input_size_px is None
-    assert tuple(transformed.shape) == (3, 3, 3)
+    assert plan.model_construction_kwargs == {}
+    assert tuple(transformed.shape) == (3, 224, 224)
 
 
 def test_non_preset_plan_requires_explicit_permission():
@@ -53,7 +55,7 @@ def test_non_preset_plan_requires_explicit_permission():
         )
 
     assert str(error.value) == (
-        "Encoder 'gigapath' was requested at 288px instead of its 256px preset. "
+        "Encoder 'gigapath' was requested at 288px instead of its 224px preset. "
         "Set allow_non_recommended_settings=True to request an exact non-preset "
         "encoder input."
     )
@@ -116,7 +118,7 @@ def test_verified_vit_encoder_plans_exact_non_preset_input_without_constructor_k
     )
 
     assert plan.requires_variable_model_input is True
-    assert plan.expected_encoder_input_size_px == requested_size
+    assert plan.requested_tile_size_px == requested_size
     assert plan.model_construction_kwargs == {}
 
 
@@ -130,9 +132,7 @@ def test_verified_vit_encoder_plans_exact_non_preset_input_without_constructor_k
         ("isight", 336),
     ],
 )
-def test_variable_vit_native_defaults_still_select_shipped_preprocessing(
-    name, default_size
-):
+def test_variable_vit_native_defaults_do_not_require_variable_input(name, default_size):
     from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
 
     plan = PooledEncoderInputPlan.resolve(
@@ -142,28 +142,28 @@ def test_variable_vit_native_defaults_still_select_shipped_preprocessing(
     )
 
     assert plan.preset_input_size_px == default_size
-    assert plan.preprocessing_kind == "shipped"
+    assert plan.requested_tile_size_px == default_size
     assert plan.requires_variable_model_input is False
     assert plan.model_construction_kwargs == {}
 
 
-def test_permitted_variable_plan_preserves_exact_geometry_with_normalization_only():
-    from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+def test_permitted_variable_plan_preserves_exact_geometry():
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
 
-    plan = PooledEncoderInputPlan.resolve(
+    contract = EncoderInputContract.declared_pooled(
         "gigapath",
         requested_tile_size_px=288,
         allow_non_recommended_settings=True,
     )
-    encoder = _TransformStandIn()
+    plan = contract.plan
 
-    transformed = plan.get_transform(encoder)(torch.zeros((3, 288, 288), dtype=torch.uint8))
+    transformed = contract.get_transform(_TransformStandIn())(
+        torch.zeros((3, 288, 288), dtype=torch.uint8)
+    )
 
-    assert plan.preset_input_size_px == 256
+    assert plan.preset_input_size_px == 224
     assert plan.requested_tile_size_px == 288
-    assert plan.preprocessing_kind == "normalization_only"
     assert plan.requires_variable_model_input is True
-    assert plan.expected_encoder_input_size_px == 288
     assert plan.model_construction_kwargs == {}
     assert tuple(transformed.shape) == (3, 288, 288)
 
@@ -184,9 +184,7 @@ def test_mascaret_permitted_non_preset_plan_preserves_exact_geometry():
         "tile_encoder_name": "mascaret",
         "preset_input_size_px": 224,
         "requested_tile_size_px": 238,
-        "preprocessing_kind": "normalization_only",
         "requires_variable_model_input": True,
-        "expected_encoder_input_size_px": 238,
         "model_construction_kwargs": {},
     }
 
@@ -207,9 +205,7 @@ def test_phaet_permitted_non_preset_plan_preserves_exact_geometry():
         "tile_encoder_name": "phaet",
         "preset_input_size_px": 224,
         "requested_tile_size_px": 240,
-        "preprocessing_kind": "normalization_only",
         "requires_variable_model_input": True,
-        "expected_encoder_input_size_px": 240,
         "model_construction_kwargs": {},
     }
 
@@ -337,8 +333,31 @@ def test_pooled_model_loading_applies_plan_construction_and_transform(monkeypatc
     assert loaded.transforms(torch.zeros((3, 288, 288))).shape == (3, 288, 288)
 
 
-def test_public_run_resolves_exact_plan_once_without_changing_batch_or_resource_advice(
-    monkeypatch, caplog
+@pytest.mark.parametrize(
+    "requested_tile_size_px, allow_non_recommended_settings, expected_message",
+    [
+        pytest.param(
+            224,
+            False,
+            "Pooled encoder input for 'gigapath': preset 224px, requested 224px; "
+            "encoding exactly 224px with geometry-preserving preprocessing.",
+            id="preset",
+        ),
+        pytest.param(
+            288,
+            True,
+            "Pooled encoder input for 'gigapath': preset 224px, requested 288px; "
+            "encoding exactly 288px with geometry-preserving preprocessing.",
+            id="permitted-off-preset",
+        ),
+    ],
+)
+def test_public_run_resolves_plan_once_and_reports_every_declared_run(
+    monkeypatch,
+    caplog,
+    requested_tile_size_px,
+    allow_non_recommended_settings,
+    expected_message,
 ):
     import slide2vec.inference as inference
     from slide2vec.api import ExecutionOptions, Model, PreprocessingConfig
@@ -354,7 +373,7 @@ def test_public_run_resolves_exact_plan_once_without_changing_batch_or_resource_
     model = Model.from_preset(
         "gigapath",
         device="cpu",
-        allow_non_recommended_settings=True,
+        allow_non_recommended_settings=allow_non_recommended_settings,
     )
 
     with caplog.at_level("INFO"):
@@ -362,23 +381,20 @@ def test_public_run_resolves_exact_plan_once_without_changing_batch_or_resource_
             [],
             preprocessing=PreprocessingConfig(
                 requested_spacing_um=0.5,
-                requested_tile_size_px=288,
+                requested_tile_size_px=requested_tile_size_px,
             ),
             execution=ExecutionOptions(batch_size=7),
         )
 
     assert result == {}
-    assert captured["plan"].expected_encoder_input_size_px == 288
+    assert captured["plan"].requested_tile_size_px == requested_tile_size_px
     assert captured["batch_size"] == 7
     messages = [
         record.getMessage()
         for record in caplog.records
         if record.getMessage().startswith("Pooled encoder input")
     ]
-    assert messages == [
-        "Pooled encoder input for 'gigapath': preset 256px, requested 288px, "
-        "exact encoder input 288px; using normalization-only preprocessing."
-    ]
+    assert messages == [expected_message]
     assert not [record for record in caplog.records if record.levelname == "WARNING"]
     assert "oom" not in caplog.text.lower()
 
@@ -414,7 +430,7 @@ def test_exact_plan_reaches_encode_tiles_at_requested_shape():
         build_batch_preprocessor_for_tile_images,
         run_forward_pass,
     )
-    from slide2vec.runtime.pooled_encoder_input import PooledEncoderInputPlan
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
     from slide2vec.runtime.types import LoadedModel
 
     observed = []
@@ -424,12 +440,12 @@ def test_exact_plan_reaches_encode_tiles_at_requested_shape():
             observed.append(tuple(batch.shape))
             return torch.tensor([[1.0, 2.0]], dtype=torch.float32)
 
-    plan = PooledEncoderInputPlan.resolve(
+    contract = EncoderInputContract.declared_pooled(
         "gigapath",
         requested_tile_size_px=288,
         allow_non_recommended_settings=True,
     )
-    transforms = plan.get_transform(_TransformStandIn())
+    transforms = contract.get_transform(_TransformStandIn())
     loaded = LoadedModel(
         name="gigapath",
         level="tile",
@@ -529,7 +545,7 @@ def test_distributed_request_round_trip_resolves_same_exact_hierarchical_tar_pla
     )
 
     assert worker_contract == parent_contract
-    assert worker_contract.plan.expected_encoder_input_size_px == 288
+    assert worker_contract.plan.requested_tile_size_px == 288
     assert worker_preprocessing.region_tile_multiple == 2
     assert worker_preprocessing.on_the_fly is False
     assert worker_preprocessing.read_tiles_from == tmp_path
@@ -553,12 +569,12 @@ def test_slide_and_patient_plans_use_tile_dependency_exact_geometry():
 
     assert (
         slide_plan.tile_encoder_name,
-        slide_plan.expected_encoder_input_size_px,
+        slide_plan.requested_tile_size_px,
         slide_plan.model_construction_kwargs,
     ) == ("virchow", 252, {"dynamic_img_size": True})
     assert (
         patient_plan.tile_encoder_name,
-        patient_plan.expected_encoder_input_size_px,
+        patient_plan.requested_tile_size_px,
         patient_plan.model_construction_kwargs,
     ) == ("lunit", 232, {})
 

--- a/tests/test_pooled_geometry.py
+++ b/tests/test_pooled_geometry.py
@@ -81,13 +81,13 @@ def test_hierarchical_reader_area_resizes_each_subtile_to_requested(monkeypatch)
     np.testing.assert_array_equal(tiles[0, 0].numpy(), expected_top_left)
 
 
-def test_gigapath_preset_records_actual_encoder_input_after_shipped_transform(caplog):
+def test_gigapath_given_256_tiles_record_the_actual_224_encoder_input(caplog):
+    """Given inputs keep the shipped Resize 256 -> CenterCrop 224 recipe; the runtime
+    records the observed 224px encoder input, and the 224px declared preset warns nothing."""
     from slide2vec.encoders.models.gigapath import GigaPath
     from slide2vec.encoders.validation import validate_encoder_config
-    from slide2vec.runtime.batching import (
-        build_batch_preprocessor_for_tile_images,
-        run_forward_pass,
-    )
+    from slide2vec.runtime.batching import run_forward_pass
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
     from slide2vec.runtime.types import LoadedModel
 
     class Encoder:
@@ -99,33 +99,19 @@ def test_gigapath_preset_records_actual_encoder_input_after_shipped_transform(ca
         name="gigapath",
         level="tile",
         model=Encoder(),
-        transforms=GigaPath.__new__(GigaPath).get_transform(),
+        transforms=EncoderInputContract.given().get_transform(GigaPath.__new__(GigaPath)),
         feature_dim=2,
         device=torch.device("cpu"),
     )
-    preprocessor = build_batch_preprocessor_for_tile_images(
-        loaded,
-        requested_tile_size_px=256,
-    )
-    dataloader = [
-        (
-            torch.tensor([0]),
-            torch.zeros((1, 3, 256, 256), dtype=torch.uint8),
-        )
-    ]
+    dataloader = [(torch.tensor([0]), torch.zeros((1, 3, 256, 256), dtype=torch.uint8))]
 
     with caplog.at_level("WARNING"):
         validate_encoder_config(
             "gigapath",
             requested_spacing_um=0.5,
-            requested_tile_size_px=256,
+            requested_tile_size_px=224,
         )
-        run_forward_pass(
-            dataloader,
-            loaded,
-            nullcontext(),
-            batch_preprocessor=preprocessor,
-        )
+        run_forward_pass(dataloader, loaded, nullcontext())
 
     assert loaded.encoder_input_size_px == 224
     assert "non-recommended" not in caplog.text.lower()
@@ -268,12 +254,12 @@ def test_slide_and_patient_models_inherit_tile_dependency_geometry():
     from slide2vec.encoders.registry import resolve_preprocessing_requirements
 
     assert resolve_preprocessing_requirements("gigapath-slide") == {
-        "tile_size_px": 256,
+        "tile_size_px": 224,
         "spacing_um": 0.5,
         "source_encoder": "gigapath",
     }
     assert resolve_preprocessing_requirements("moozy") == {
-        "tile_size_px": 248,
+        "tile_size_px": 224,
         "spacing_um": 0.5,
         "source_encoder": "lunit",
     }

--- a/tests/test_pooled_geometry.py
+++ b/tests/test_pooled_geometry.py
@@ -4,6 +4,7 @@ import tarfile
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 from PIL import Image
 
@@ -115,6 +116,57 @@ def test_gigapath_given_256_tiles_record_the_actual_224_encoder_input(caplog):
 
     assert loaded.encoder_input_size_px == 224
     assert "non-recommended" not in caplog.text.lower()
+
+
+def test_declared_pooled_batch_that_disagrees_with_the_declared_size_raises():
+    """A declared pooled run encodes exactly the size it declared; a transform that
+    changed the geometry (or a reader that produced another size) must fail loudly
+    instead of silently recording the observed size."""
+    from slide2vec.runtime.batching import run_forward_pass
+    from slide2vec.runtime.types import LoadedModel
+
+    class Encoder:
+        def encode_tiles(self, image):
+            return torch.zeros((image.shape[0], 2), dtype=torch.float32)
+
+    loaded = LoadedModel(
+        name="lunit",
+        level="tile",
+        model=Encoder(),
+        transforms=lambda batch: batch.float(),
+        feature_dim=2,
+        device=torch.device("cpu"),
+        declared_encoder_input_size_px=224,
+    )
+    dataloader = [(torch.tensor([0]), torch.zeros((1, 3, 248, 248), dtype=torch.uint8))]
+
+    with pytest.raises(ValueError, match=r"declared 224px.*got 248px"):
+        run_forward_pass(dataloader, loaded, nullcontext())
+
+
+def test_declared_pooled_batch_at_the_declared_size_records_it():
+    from slide2vec.runtime.batching import run_forward_pass
+    from slide2vec.runtime.types import LoadedModel
+
+    class Encoder:
+        def encode_tiles(self, image):
+            assert tuple(image.shape[-2:]) == (224, 224)
+            return torch.zeros((image.shape[0], 2), dtype=torch.float32)
+
+    loaded = LoadedModel(
+        name="lunit",
+        level="tile",
+        model=Encoder(),
+        transforms=lambda batch: batch.float(),
+        feature_dim=2,
+        device=torch.device("cpu"),
+        declared_encoder_input_size_px=224,
+    )
+    dataloader = [(torch.tensor([0]), torch.zeros((1, 3, 224, 224), dtype=torch.uint8))]
+
+    run_forward_pass(dataloader, loaded, nullcontext())
+
+    assert loaded.encoder_input_size_px == 224
 
 
 def test_single_gpu_artifact_records_read_requested_final_geometry_and_spacing(tmp_path):

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -2225,6 +2225,46 @@ def test_slide_embedding_metadata_records_the_requested_tile_size():
     }
 
 
+def test_resume_warns_when_existing_slide_embeddings_record_no_tile_size(tmp_path: Path, caplog):
+    """A pre-metadata sidecar cannot be verified; it is reused, but not silently."""
+    process_list_path = tmp_path / "process_list.csv"
+    process_list_path.write_text(
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,"
+        "spacing_at_level_0,tiling_status,num_tiles,coordinates_npz_path,"
+        "coordinates_meta_path,feature_status,aggregation_status,error,traceback\n"
+        "slide-a,tissue,/tmp/slide-a.svs,,auto,asap,,success,1,/tmp/slide-a.coordinates.npz,/tmp/slide-a.coordinates.meta.json,success,success,,\n",
+        encoding="utf-8",
+    )
+    write_slide_embeddings(
+        "slide-a",
+        np.array([1.0, 2.0], dtype=np.float32),
+        output_dir=tmp_path,
+        output_format="npz",
+        metadata={"encoder_name": "moozy-slide", "encoder_level": "slide"},
+    )
+
+    with caplog.at_level("WARNING", logger="slide2vec"):
+        pending_slides, _ = persist_callbacks.pending_local_embedding_records(
+            [make_slide("slide-a")],
+            [SimpleNamespace(annotation=None)],
+            process_list_path=process_list_path,
+            output_dir=tmp_path,
+            output_format="npz",
+            persist_tile_embeddings=False,
+            persist_hierarchical_embeddings=False,
+            include_slide_embeddings=True,
+            save_latents=False,
+            resume=True,
+            requested_tile_size_px=224,
+        )
+
+    assert pending_slides == []
+    assert (
+        "Resuming 'slide-a' from existing slide embeddings that record no "
+        "requested_tile_size_px; cannot verify they were computed at 224px."
+    ) in caplog.text
+
+
 def test_resume_skip_accepts_existing_tile_embedding_without_metadata(tmp_path: Path):
     slide = make_slide("slide-a")
     process_list_path = tmp_path / "process_list.csv"

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -2135,6 +2135,96 @@ def test_run_pipeline_resume_refuses_stale_tile_size_before_embedding(monkeypatc
         )
 
 
+def _write_completed_slide_only_run(tmp_path: Path, *, recorded_tile_size_px: int) -> Path:
+    """A slide-level run that persisted only slide embeddings (no tile artifacts)."""
+    process_list_path = tmp_path / "process_list.csv"
+    process_list_path.write_text(
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,"
+        "spacing_at_level_0,tiling_status,num_tiles,coordinates_npz_path,"
+        "coordinates_meta_path,feature_status,aggregation_status,error,traceback\n"
+        "slide-a,tissue,/tmp/slide-a.svs,,auto,asap,,success,1,/tmp/slide-a.coordinates.npz,/tmp/slide-a.coordinates.meta.json,success,success,,\n",
+        encoding="utf-8",
+    )
+    write_slide_embeddings(
+        "slide-a",
+        np.array([1.0, 2.0], dtype=np.float32),
+        output_dir=tmp_path,
+        output_format="npz",
+        metadata={
+            "encoder_name": "moozy-slide",
+            "encoder_level": "slide",
+            "requested_tile_size_px": recorded_tile_size_px,
+        },
+    )
+    return process_list_path
+
+
+def test_resume_refuses_existing_slide_embeddings_from_a_different_tile_size(tmp_path: Path):
+    """With tile persistence off, the slide sidecar is the only record of the tile size."""
+    process_list_path = _write_completed_slide_only_run(tmp_path, recorded_tile_size_px=248)
+
+    with pytest.raises(ValueError) as error:
+        persist_callbacks.pending_local_embedding_records(
+            [make_slide("slide-a")],
+            [SimpleNamespace(annotation=None)],
+            process_list_path=process_list_path,
+            output_dir=tmp_path,
+            output_format="npz",
+            persist_tile_embeddings=False,
+            persist_hierarchical_embeddings=False,
+            include_slide_embeddings=True,
+            save_latents=False,
+            resume=True,
+            requested_tile_size_px=224,
+        )
+
+    assert str(error.value) == (
+        f"Cannot resume 'slide-a': the existing slide embeddings at "
+        f"{tmp_path / 'slide_embeddings' / 'slide-a.npz'} were computed with "
+        "requested_tile_size_px=248, but this run requests 224px. Embeddings from a "
+        "different tile size are not comparable. Re-run into a new output_dir, or delete "
+        "the stale artifacts, or request the recorded tile size."
+    )
+
+
+def test_resume_skips_existing_slide_embeddings_recorded_at_the_same_tile_size(tmp_path: Path):
+    process_list_path = _write_completed_slide_only_run(tmp_path, recorded_tile_size_px=224)
+
+    pending_slides, pending_results = persist_callbacks.pending_local_embedding_records(
+        [make_slide("slide-a")],
+        [SimpleNamespace(annotation=None)],
+        process_list_path=process_list_path,
+        output_dir=tmp_path,
+        output_format="npz",
+        persist_tile_embeddings=False,
+        persist_hierarchical_embeddings=False,
+        include_slide_embeddings=True,
+        save_latents=False,
+        resume=True,
+        requested_tile_size_px=224,
+    )
+
+    assert pending_slides == []
+    assert pending_results == []
+
+
+def test_slide_embedding_metadata_records_the_requested_tile_size():
+    from slide2vec.runtime.embedding import build_slide_embedding_metadata
+
+    metadata = build_slide_embedding_metadata(
+        SimpleNamespace(name="moozy-slide", level="slide"),
+        image_path="/tmp/slide-a.svs",
+        tiling_result=SimpleNamespace(requested_tile_size_px=224),
+    )
+
+    assert metadata == {
+        "encoder_name": "moozy-slide",
+        "encoder_level": "slide",
+        "image_path": "/tmp/slide-a.svs",
+        "requested_tile_size_px": 224,
+    }
+
+
 def test_resume_skip_accepts_existing_tile_embedding_without_metadata(tmp_path: Path):
     slide = make_slide("slide-a")
     process_list_path = tmp_path / "process_list.csv"
@@ -2158,6 +2248,7 @@ def test_resume_skip_accepts_existing_tile_embedding_without_metadata(tmp_path: 
         include_slide_embeddings=False,
         save_latents=False,
         resume=True,
+        requested_tile_size_px=224,
     )
     tile_artifact = persistence.load_tile_artifact(
         "slide-a",
@@ -5782,6 +5873,7 @@ def test_resume_gate_keys_slide_embeddings_by_sample_id_and_annotation(tmp_path:
         include_slide_embeddings=True,
         save_latents=False,
         resume=True,
+        requested_tile_size_px=224,
     )
 
     assert [tr.annotation for tr in pending_results] == ["stroma"]
@@ -6275,6 +6367,7 @@ def test_resume_gate_keys_hierarchical_embeddings_by_sample_id_and_annotation(tm
         include_slide_embeddings=False,
         save_latents=False,
         resume=True,
+        requested_tile_size_px=224,
     )
 
     assert [tr.annotation for tr in pending_results] == ["stroma"]

--- a/tests/test_regression_inference.py
+++ b/tests/test_regression_inference.py
@@ -96,7 +96,9 @@ def test_pipeline_run_uses_distributed_embedding_path_when_num_gpus_is_greater_t
     )
     captured = {}
 
-    monkeypatch.setattr(tiling_pipeline, "prepare_tiled_slides",
+    monkeypatch.setattr(
+        tiling_pipeline,
+        "prepare_tiled_slides",
         lambda *args, **kwargs: ([slide], [tiling_result], tmp_path / "process_list.csv"),
     )
     monkeypatch.setattr(artifacts_collect, "run_distributed_embedding_stage",
@@ -2027,6 +2029,110 @@ def test_run_pipeline_resume_skips_successful_local_embeddings(monkeypatch, tmp_
     assert computed_sample_ids == ["slide-b"]
     assert [artifact.sample_id for artifact in result.tile_artifacts] == ["slide-a", "slide-b"]
     assert result.slide_artifacts == []
+
+
+def _write_completed_tile_run(tmp_path: Path, *, recorded_tile_size_px: int) -> Path:
+    process_list_path = tmp_path / "process_list.csv"
+    process_list_path.write_text(
+        "sample_id,annotation,image_path,mask_path,requested_backend,backend,"
+        "spacing_at_level_0,tiling_status,num_tiles,coordinates_npz_path,"
+        "coordinates_meta_path,feature_status,error,traceback\n"
+        "slide-a,tissue,/tmp/slide-a.svs,,auto,asap,,success,1,/tmp/slide-a.coordinates.npz,/tmp/slide-a.coordinates.meta.json,success,,\n",
+        encoding="utf-8",
+    )
+    write_tile_embeddings(
+        "slide-a",
+        np.array([[1.0, 2.0]], dtype=np.float32),
+        output_dir=tmp_path,
+        output_format="npz",
+        metadata={"requested_tile_size_px": recorded_tile_size_px, "encoder_input_size_px": 224},
+    )
+    return process_list_path
+
+
+def test_resume_refuses_existing_tile_embeddings_from_a_different_tile_size(tmp_path: Path):
+    """Artifacts read at 248px (the pre-#322 Lunit/mSTAR default) must not be reused at 224px."""
+    process_list_path = _write_completed_tile_run(tmp_path, recorded_tile_size_px=248)
+
+    with pytest.raises(ValueError) as error:
+        persist_callbacks.pending_local_embedding_records(
+            [make_slide("slide-a")],
+            [SimpleNamespace(annotation=None)],
+            process_list_path=process_list_path,
+            output_dir=tmp_path,
+            output_format="npz",
+            persist_tile_embeddings=True,
+            persist_hierarchical_embeddings=False,
+            include_slide_embeddings=False,
+            save_latents=False,
+            resume=True,
+            requested_tile_size_px=224,
+        )
+
+    assert str(error.value) == (
+        f"Cannot resume 'slide-a': the existing tile embeddings at "
+        f"{tmp_path / 'tile_embeddings' / 'slide-a.npz'} were computed with "
+        "requested_tile_size_px=248, but this run requests 224px. Embeddings from a "
+        "different tile size are not comparable. Re-run into a new output_dir, or delete "
+        "the stale artifacts, or request the recorded tile size."
+    )
+
+
+def test_resume_skips_existing_tile_embeddings_recorded_at_the_same_tile_size(tmp_path: Path):
+    process_list_path = _write_completed_tile_run(tmp_path, recorded_tile_size_px=224)
+
+    pending_slides, pending_results = persist_callbacks.pending_local_embedding_records(
+        [make_slide("slide-a")],
+        [SimpleNamespace(annotation=None)],
+        process_list_path=process_list_path,
+        output_dir=tmp_path,
+        output_format="npz",
+        persist_tile_embeddings=True,
+        persist_hierarchical_embeddings=False,
+        include_slide_embeddings=False,
+        save_latents=False,
+        resume=True,
+        requested_tile_size_px=224,
+    )
+
+    assert pending_slides == []
+    assert pending_results == []
+
+
+def test_run_pipeline_resume_refuses_stale_tile_size_before_embedding(monkeypatch, tmp_path: Path):
+    import slide2vec.inference as inference
+
+    process_list_path = _write_completed_tile_run(tmp_path, recorded_tile_size_px=248)
+    slides = [make_slide("slide-a")]
+    tiling_results = [
+        SimpleNamespace(
+            sample_id="slide-a", annotation=None, x=np.array([0]), y=np.array([0]),
+            tile_size_lv0=224, requested_tile_size_px=224, read_tile_size_px=224,
+        )
+    ]
+    monkeypatch.setattr(tiling_pipeline, "prepare_tiled_slides",
+        lambda *args, **kwargs: (slides, tiling_results, process_list_path),
+    )
+    monkeypatch.setattr(
+        embedding_pipeline,
+        "compute_embedded_slides",
+        lambda *args, **kwargs: pytest.fail("embedding must not start on a stale resume"),
+    )
+    model = SimpleNamespace(
+        name="lunit",
+        level="tile",
+        _requested_device="cpu",
+        _declare_encoder_input=_noop_declare_encoder_input,
+        _load_backend=lambda: SimpleNamespace(feature_dim=2, device="cpu", model=SimpleNamespace()),
+    )
+
+    with pytest.raises(ValueError, match="requested_tile_size_px=248, but this run requests 224px"):
+        inference.run_pipeline(
+            model,
+            slides=slides,
+            preprocessing=replace(DEFAULT_PREPROCESSING, resume=True, requested_tile_size_px=224),
+            execution=ExecutionOptions(output_dir=tmp_path, output_format="npz", num_gpus=1),
+        )
 
 
 def test_resume_skip_accepts_existing_tile_embedding_without_metadata(tmp_path: Path):

--- a/tests/test_regression_models.py
+++ b/tests/test_regression_models.py
@@ -529,7 +529,7 @@ def test_model_embed_slides_logs_exact_input_when_non_recommended_settings_are_a
 
     assert result == expected
     assert "virchow2" in caplog.text
-    assert "preset 224px, requested 252px, exact encoder input 252px" in caplog.text
+    assert "preset 224px, requested 252px; encoding exactly 252px" in caplog.text
 
 
 def test_model_embed_slides_rejects_non_recommended_precision_by_default():

--- a/tests/test_rudolfv2.py
+++ b/tests/test_rudolfv2.py
@@ -411,7 +411,8 @@ def test_rudolfv2_runtime_pooled_plan_preserves_requested_size(name):
         requested_tile_size_px=232,
         allow_non_recommended_settings=True,
     )
-    assert pooled.plan.expected_encoder_input_size_px == 232
+    assert pooled.plan.requested_tile_size_px == 232
+    assert pooled.plan.requires_variable_model_input is True
 
 
 @pytest.mark.parametrize("name", [case.name for case in _PRESETS])


### PR DESCRIPTION
## Summary

- Declared pooled slide runs now read, prepare and encode the requested tile size for preset and off-preset requests alike: `EncoderInputContract.get_transform` is a regime switch (`given` -> shipped `get_transform`, `declared` -> geometry-preserving `get_normalization_transform`).
- Registry `input_size` is the final model input size: Lunit, mSTAR and GigaPath default to 224 (previously 248/256 with a center crop); DINOv2 stays 518, GPFM 224. Slide/patient presets (MOOZY, GigaPath-slide) inherit through their tile dependency. Given-input recipes are unchanged.
- Removed `PooledEncoderInputPlan.preprocessing_kind`, `PooledPreprocessingKind`, `expected_encoder_input_size_px`, the per-plan `get_transform` methods and the `get_dense_transform` alias. The run-info log fires for every declared pooled run.
- `get_normalization_transform` is required on every tile encoder at registration; the base method's `NotImplementedError` says what to implement.
- `LoadedModel.declared_encoder_input_size_px` is checked against the batch reaching the encoder, so a geometry-changing transform fails loudly.
- Resume records `requested_tile_size_px` in slide metadata and refuses to reuse tile, hierarchical or slide artifacts recorded at a different size; artifacts with no recorded size are reused with a warning.
- Docs describe the declared extraction policy, preserved given-input recipes, permission semantics and the sampling/coverage change. Old and new whole-slide embeddings are not equivalent.

Closes #322

## Test plan

- Full suite locally: 1138 passed, 19 skipped; the 3 failures are the known local ones (MUSK gated Hugging Face download, prism2 CUDA-default asserts).
