### PR TITLE
Add DINOv3 ViT-B/16 natural-image encoder

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -27,8 +27,8 @@ extraction reads tiles at ``requested_tile_size_px`` (default: ``input_size``),
 applies only the encoder's photometric preprocessing (dtype, scaling,
 normalization), and encodes exactly that size. No encoder-side resize or
 center crop follows the read. Lunit, mSTAR, GigaPath and GPFM default to
-224px; DINOv2 to 518px. Slide and patient presets inherit the default of their
-tile encoder.
+224px; DINOv2 to 518px; DINOv3 to 256px. Slide and patient presets inherit the
+default of their tile encoder.
 
 This is slide2vec's declared extraction policy, not a reproduction of each
 model's published sampling protocol. Earlier releases read Lunit and mSTAR at
@@ -54,12 +54,14 @@ DINOv2 matched-resolution experiments:
    )
 
 This forwards exactly 224×224 pixels. Without the flag, an off-default request
-raises; 225px raises even with the flag (not a multiple of 14).
+raises; 225px raises even with the flag (not a multiple of 14). The same call
+with ``dinov3-vitb16`` forwards 224×224 pixels through its 16px patch grid.
 
 Pre-cropped images (``embed_images``, ``embed_tiles``) keep each encoder's
 shipped ``get_transform`` recipe: Lunit/mSTAR Resize 248 → CenterCrop 224,
-GigaPath Resize 256 → CenterCrop 224, DINOv2 Resize 518 → CenterCrop 518, GPFM
-direct 224 resize. Dense extraction is unchanged.
+GigaPath Resize 256 → CenterCrop 224, DINOv2 Resize 518 → CenterCrop 518, DINOv3
+Resize 256 → CenterCrop 256, GPFM direct 224 resize. Dense extraction is
+unchanged.
 
 .. list-table::
    :header-rows: 1
@@ -82,6 +84,10 @@ direct 224 resize. Dense extraction is unchanged.
      - ``0.5``
    * - ``dinov2-vitb14``
      - `DINOv2 ViT-B/14 <https://huggingface.co/timm/vit_base_patch14_dinov2.lvd142m>`_
+     - 768
+     - any (``0.5`` default)
+   * - ``dinov3-vitb16``
+     - `DINOv3 ViT-B/16 <https://huggingface.co/timm/vit_base_patch16_dinov3.lvd1689m>`_
      - 768
      - any (``0.5`` default)
    * - ``phikon``
@@ -191,6 +197,23 @@ CLS vector with:
    from slide2vec import Model
 
    model = Model.from_preset("virchow2", output_variant="cls")
+
+Natural-image baselines
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``dinov2-vitb14`` and ``dinov3-vitb16`` are natural-image DINO ViTs with no
+intrinsic micron spacing: any requested spacing is accepted and ``0.5`` is the
+tiling default. ``dinov3-vitb16`` (patch 16, four register tokens, RoPE)
+defaults to 256px tiles. Its ``patch_mean`` output (default) is the mean of the
+spatial patch tokens after the final norm, excluding the CLS and register
+tokens, which is the pooled output the timm checkpoint ships; ``cls`` returns
+the CLS token. Both are 768-dimensional. Dense grids are ``H/16 × W/16``
+(``14 × 14`` at 224px, ``16 × 16`` at 256px) and attention maps apply the
+backbone's rotary embeddings. ``dinov3-vitb16`` requires ``timm>=1.0.20``
+(the ``fm`` extra floor); the ``titan`` extra pins ``timm==1.0.3`` and is
+incompatible. Weights are public under the `DINOv3 license
+<https://github.com/facebookresearch/dinov3/blob/main/LICENSE.md>`_; see the
+`model card <https://github.com/facebookresearch/dinov3/blob/main/MODEL_CARD.md>`_.
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ fm = [
     "torch>=2.3,<2.8",
     "torchvision>=0.18.0",
     "einops>=0.8.0",
-    "timm>=1.0.3",
+    "timm>=1.0.20",
     "huggingface_hub>=0.30.0,<1.0",
     "environs",
     "einops-exts>=0.0.4",

--- a/slide2vec/encoders/base.py
+++ b/slide2vec/encoders/base.py
@@ -7,6 +7,7 @@ from typing import Callable
 import timm
 import torch
 from timm.data import create_transform, resolve_data_config
+from timm.layers import apply_rot_embed_cat
 from torch import Tensor
 from torchvision.transforms import v2
 
@@ -192,7 +193,7 @@ def prefix_attention_to_grid(
     return maps.reshape(batch_size, num_query * num_heads, grid_h, grid_w)
 
 
-def timm_self_attention_weights(attn_module, x: Tensor) -> Tensor:
+def timm_self_attention_weights(attn_module, x: Tensor, *, rope: Tensor | None = None) -> Tensor:
     """Recompute a timm ``Attention`` block's softmax weights ``(B, nh, N, N)``.
 
     timm's attention runs a *fused* SDPA kernel by default, which never
@@ -202,11 +203,22 @@ def timm_self_attention_weights(attn_module, x: Tensor) -> Tensor:
     / ``num_heads`` / ``head_dim`` / ``scale`` — i.e. exactly the non-fused branch of
     ``Attention.forward``, so the result is bit-equivalent to the weights the fused
     kernel applies internally. Dropout is omitted (extraction runs under ``eval``).
+
+    ``rope`` is the rotary embedding an ``EvaAttention`` block (DINOv3) receives
+    as its ``rope`` forward argument; when given, it is applied to the q/k rows
+    from ``attn_module.num_prefix_tokens`` onward (spatial tokens only, CLS and
+    registers untouched), exactly as ``EvaAttention.forward`` does. ``None`` for
+    plain ``Attention`` blocks leaves the recompute unchanged.
     """
-    if not hasattr(attn_module, "qkv"):
+    if getattr(attn_module, "qkv", None) is None:
         raise NotImplementedError(
             f"{type(attn_module).__name__} has no fused 'qkv' projection; attention "
             "extraction currently supports timm ViT Attention blocks only."
+        )
+    if getattr(attn_module, "q_bias", None) is not None:
+        raise NotImplementedError(
+            f"{type(attn_module).__name__} uses separate q/k/v biases; attention "
+            "extraction supports fused-qkv blocks only."
         )
     batch_size, num_tokens, _ = x.shape
     num_heads = int(attn_module.num_heads)
@@ -220,6 +232,11 @@ def timm_self_attention_weights(attn_module, x: Tensor) -> Tensor:
     # q_norm / k_norm are Identity unless the model uses QK-norm; apply them either way.
     q = attn_module.q_norm(q)
     k = attn_module.k_norm(k)
+    if rope is not None:
+        npt = int(attn_module.num_prefix_tokens)
+        half = getattr(attn_module, "rotate_half", False)
+        q = torch.cat([q[:, :, :npt], apply_rot_embed_cat(q[:, :, npt:], rope, half=half)], dim=2).type_as(x)
+        k = torch.cat([k[:, :, :npt], apply_rot_embed_cat(k[:, :, npt:], rope, half=half)], dim=2).type_as(x)
     q = q * attn_module.scale
     attn = q @ k.transpose(-2, -1)
     return attn.softmax(dim=-1)
@@ -291,16 +308,22 @@ def timm_trunk_attention(
     resolved = resolve_block_indices(blocks, len(block_list), encoder_name=encoder_name)
 
     captured: dict[int, Tensor] = {}
+    captured_rope: dict[int, Tensor | None] = {}
 
     def _make_hook(index: int):
-        def _hook(_module, inputs):
-            captured[index] = inputs[0]
+        def _hook(_module, args, kwargs):
+            captured[index] = args[0]
+            # EvaAttention (RoPE models) receives the rotary embedding as its
+            # second forward argument; plain Attention blocks receive none.
+            captured_rope[index] = kwargs.get("rope", args[1] if len(args) > 1 else None)
 
         return _hook
 
     handles = []
     for index in sorted(set(resolved)):
-        handles.append(block_list[index].attn.register_forward_pre_hook(_make_hook(index)))
+        handles.append(
+            block_list[index].attn.register_forward_pre_hook(_make_hook(index), with_kwargs=True)
+        )
     try:
         trunk.forward_features(batch)
     finally:
@@ -311,7 +334,9 @@ def timm_trunk_attention(
     num_prefix = int(getattr(trunk, "num_prefix_tokens", 1))
     grids = []
     for index in resolved:
-        attn_weights = timm_self_attention_weights(block_list[index].attn, captured[index])
+        attn_weights = timm_self_attention_weights(
+            block_list[index].attn, captured[index], rope=captured_rope[index]
+        )
         grids.append(
             prefix_attention_to_grid(
                 attn_weights,

--- a/slide2vec/encoders/models/__init__.py
+++ b/slide2vec/encoders/models/__init__.py
@@ -6,6 +6,7 @@ Importing this package registers all encoders in the encoder_registry.
 from . import (
     conch,
     dinov2,
+    dinov3,
     genbio,
     gigapath,
     gpfm,
@@ -31,6 +32,7 @@ from . import (
 __all__ = [
     "conch",
     "dinov2",
+    "dinov3",
     "genbio",
     "gigapath",
     "gpfm",

--- a/slide2vec/encoders/models/dinov3.py
+++ b/slide2vec/encoders/models/dinov3.py
@@ -1,0 +1,79 @@
+"""Natural-image DINOv3 ViT-B/16 encoder.
+
+``dinov3-vitb16`` is the DINOv3 ViT-B/16 (Siméoni et al., 2025) distilled on
+LVD-1689M natural images, shipped by ``timm`` as
+``vit_base_patch16_dinov3.lvd1689m`` (weights on Hugging Face under
+``timm/vit_base_patch16_dinov3.lvd1689m``; DINOv3 license). It complements the
+``dinov2-vitb14`` natural-image baseline but is not architecture-identical:
+16px patches, four register tokens and rotary positional embeddings (RoPE)
+instead of 14px patches and learned positional embeddings.
+
+The timm backbone is an ``Eva`` model whose checkpoint defaults to
+``global_pool="avg"``: the pooled output is the mean of the **spatial patch
+tokens** after the final LayerNorm, excluding the CLS token and the four
+registers. That shipped output is the default ``patch_mean`` variant; ``cls``
+exposes the CLS token after the same final norm. Both are 768-d.
+
+Spacing-agnostic like ``dinov2-vitb14`` (``supported_spacing_um=None``,
+``default_spacing_um=0.5``). Declared pooled runs encode exactly the requested
+tile size with normalization only: 256px by default, or 224px with
+``allow_non_recommended_settings=True``. Given pre-cropped tiles use the shipped
+Resize 256 -> CenterCrop 256 recipe.
+"""
+
+import timm
+from packaging.version import Version
+from torch import Tensor
+
+from slide2vec.encoders.base import TimmTileEncoder, resolve_requested_output_variant
+from slide2vec.encoders.registry import register_encoder
+
+_POOL_TYPES = {"patch_mean": "avg", "cls": "token"}
+_MIN_TIMM_VERSION = "1.0.20"  # first release registering vit_base_patch16_dinov3
+
+
+def require_timm_for_dinov3() -> None:
+    if Version(timm.__version__) < Version(_MIN_TIMM_VERSION):
+        raise ImportError(
+            f"dinov3-vitb16 requires timm>={_MIN_TIMM_VERSION} (the DINOv3 "
+            f"architectures were added in that release); found timm=={timm.__version__}. "
+            "Note that the 'titan' extra pins timm==1.0.3 and cannot be installed "
+            "alongside dinov3-vitb16."
+        )
+
+
+@register_encoder(
+    "dinov3-vitb16",
+    output_variants={
+        "patch_mean": {"encode_dim": 768},
+        "cls": {"encode_dim": 768},
+    },
+    default_output_variant="patch_mean",
+    input_size=256,
+    supports_variable_input_size=True,
+    patch_size=16,
+    supported_spacing_um=None,  # spacing-agnostic: no intrinsic µm/px
+    default_spacing_um=0.5,  # tiling default: match the pathology encoders' task-spacing
+    precision="fp16",
+    source="timm/vit_base_patch16_dinov3.lvd1689m",
+)
+class DINOv3ViTB16(TimmTileEncoder):
+    def __init__(self, *, output_variant: str | None = None):
+        require_timm_for_dinov3()
+        self._output_variant = resolve_requested_output_variant(
+            output_variant, default="patch_mean", allowed=tuple(_POOL_TYPES)
+        )
+        super().__init__(
+            "vit_base_patch16_dinov3.lvd1689m",
+            output_variant=self._output_variant,
+            dynamic_img_size=True,
+        )
+
+    def encode_tiles(self, batch: Tensor) -> Tensor:
+        # forward_features applies the final LayerNorm to every token; Eva.pool
+        # then reduces with the backbone's own num_prefix_tokens (CLS + 4 reg):
+        # "avg" = mean over spatial tokens only, "token" = CLS. fc_norm is
+        # Identity for this checkpoint (kept for parity with forward_head).
+        tokens = self._model.forward_features(batch)
+        pooled = self._model.pool(tokens, pool_type=_POOL_TYPES[self._output_variant])
+        return self._model.fc_norm(pooled)

--- a/slide2vec/runtime/model_settings.py
+++ b/slide2vec/runtime/model_settings.py
@@ -30,6 +30,8 @@ MODEL_NAME_ALIASES = {
     "dinov2": "dinov2-vitb14",
     "dinov2-base": "dinov2-vitb14",
     "dinov2-vitb": "dinov2-vitb14",
+    "dinov3": "dinov3-vitb16",
+    "dinov3-vitb": "dinov3-vitb16",
 }
 
 

--- a/tests/test_dinov3_natimage.py
+++ b/tests/test_dinov3_natimage.py
@@ -1,0 +1,188 @@
+"""Tests for the natural-image DINOv3 ViT-B/16 encoder (``dinov3-vitb16``).
+
+Offline (``pretrained=False``) checks against timm's ``Eva`` backbone: registry
+metadata, both pooling variants, dense grids, and RoPE-aware attention. The one
+real-weight forward is ``heavy``-marked and skips without weights.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+timm = pytest.importorskip("timm")
+
+from slide2vec.encoders import encoder_registry  # noqa: E402
+
+TIMM_NAME = "vit_base_patch16_dinov3.lvd1689m"
+
+
+def test_dinov3_metadata_contract():
+    info = encoder_registry.info("dinov3-vitb16")
+    assert info["level"] == "tile"
+    assert info["input_size"] == 256
+    assert info["patch_size"] == 16
+    assert info["supports_variable_input_size"] is True
+    assert info["supported_spacing_um"] is None
+    assert info["default_spacing_um"] == pytest.approx(0.5)
+    assert info["precision"] == "fp16"
+    assert info["source"] == "timm/vit_base_patch16_dinov3.lvd1689m"
+    assert info["output_variants"] == {
+        "patch_mean": {"encode_dim": 768},
+        "cls": {"encode_dim": 768},
+    }
+    assert info["default_output_variant"] == "patch_mean"
+
+
+@pytest.fixture(scope="module")
+def offline_model():
+    """The timm Eva backbone with random weights (no download), built once."""
+    torch.manual_seed(0)
+    return timm.create_model(
+        TIMM_NAME, pretrained=False, num_classes=0, dynamic_img_size=True
+    ).eval()
+
+
+def offline_encoder(model, output_variant: str = "patch_mean"):
+    from slide2vec.encoders.models.dinov3 import DINOv3ViTB16
+
+    enc = DINOv3ViTB16.__new__(DINOv3ViTB16)
+    enc._model = model
+    enc._device = torch.device("cpu")
+    enc._output_variant = output_variant
+    return enc
+
+
+def test_dinov3_pooling_variants_match_normalized_token_reference(offline_model):
+    """patch_mean == mean of the 256 spatial tokens after the final norm (CLS and
+    the 4 registers excluded); cls == the normalized CLS token. Both 768-d."""
+    enc = offline_encoder(offline_model)
+    torch.manual_seed(1)
+    x = torch.randn(2, 3, 256, 256)
+    with torch.no_grad():
+        tokens = enc._model.forward_features(x)  # post final-norm (B, 261, 768)
+        patch_mean = enc.encode_tiles(x)
+        cls = offline_encoder(offline_model, "cls").encode_tiles(x)
+    assert tokens.shape == (2, 1 + 4 + 256, 768)
+    assert patch_mean.shape == (2, 768) and cls.shape == (2, 768)
+    torch.testing.assert_close(patch_mean, tokens[:, 5:].mean(dim=1), rtol=0, atol=1e-6)
+    torch.testing.assert_close(cls, tokens[:, 0], rtol=0, atol=0)
+    # The shipped timm forward (global_pool="avg") is the default variant.
+    torch.testing.assert_close(patch_mean, enc._model(x), rtol=0, atol=0)
+    assert not torch.allclose(cls, patch_mean)
+    assert offline_encoder(offline_model, "cls").encode_dim == 768
+
+
+@pytest.mark.parametrize("size, grid", [(224, 14), (256, 16)])
+def test_dinov3_dense_grid_excludes_prefix_tokens(offline_model, size: int, grid: int):
+    """Dense grid == timm's own NCHW last-layer intermediates (post-norm), so the
+    CLS + 4 register tokens are stripped and the 16px patch grid is row-major."""
+    enc = offline_encoder(offline_model)
+    torch.manual_seed(2)
+    x = torch.randn(2, 3, size, size)
+    with torch.no_grad():
+        mine = enc.encode_tiles_dense(x)
+        oracle = enc._model.forward_intermediates(
+            x, indices=[-1], norm=True, output_fmt="NCHW", intermediates_only=True
+        )[0]
+    assert enc.patch_size == (16, 16)
+    assert mine.shape == (2, 768, grid, grid)
+    torch.testing.assert_close(mine, oracle, rtol=0, atol=1e-6)
+
+
+def test_dinov3_dense_rejects_non_patch_multiple(offline_model):
+    enc = offline_encoder(offline_model)
+    with pytest.raises(ValueError, match="divisible by the patch size"):
+        enc.encode_tiles_dense(torch.randn(1, 3, 225, 225))
+
+
+def backend_attention_weights(model, block_index: int, x: torch.Tensor) -> torch.Tensor:
+    """Softmax matrix ``(B, nh, N, N)`` from timm's explicit non-fused Eva path.
+
+    With ``fused_attn=False`` the block materializes ``softmax(q k^T)`` with RoPE
+    applied to the spatial rows; it passes through ``attn_drop`` (a no-op under
+    eval), where a forward hook records it.
+    """
+    attn = model.blocks[block_index].attn
+    captured = {}
+    handle = attn.attn_drop.register_forward_hook(lambda _m, _i, out: captured.__setitem__("w", out))
+    prev = attn.fused_attn
+    attn.fused_attn = False
+    try:
+        with torch.no_grad():
+            model.forward_features(x)
+    finally:
+        attn.fused_attn = prev
+        handle.remove()
+    return captured["w"]
+
+
+@pytest.mark.parametrize("size, grid", [(224, 14), (256, 16)])
+@pytest.mark.parametrize("include_registers", [False, True])
+def test_dinov3_attention_matches_backend_rope_path(
+    offline_model, size: int, grid: int, include_registers: bool
+):
+    from slide2vec.encoders.base import prefix_attention_to_grid
+
+    enc = offline_encoder(offline_model)
+    nh = enc._model.blocks[-1].attn.num_heads
+    torch.manual_seed(3)
+    x = torch.randn(2, 3, size, size)
+    with torch.no_grad():
+        mine = enc.encode_tiles_attention(x, blocks=(-1, -2), include_registers=include_registers)
+    expected = torch.cat(
+        [
+            prefix_attention_to_grid(
+                backend_attention_weights(enc._model, index, x),
+                num_prefix_tokens=5,
+                include_registers=include_registers,
+                grid_h=grid,
+                grid_w=grid,
+                encoder_name="ref",
+            )
+            for index in (-1, -2)
+        ],
+        dim=1,
+    )
+    num_query = 5 if include_registers else 1
+    assert nh == 12
+    assert mine.shape == (2, 2 * num_query * nh, grid, grid)
+    torch.testing.assert_close(mine, expected, rtol=0, atol=1e-6)
+
+
+def test_dinov3_requires_timm_1_0_20(monkeypatch):
+    """The timm registration for ``vit_base_patch16_dinov3`` first shipped in 1.0.20."""
+    from slide2vec.encoders.models.dinov3 import DINOv3ViTB16
+
+    monkeypatch.setattr(timm, "__version__", "1.0.19")
+    monkeypatch.setattr(timm, "create_model", lambda *a, **k: pytest.fail("must fail before create_model"))
+    with pytest.raises(ImportError, match=r"timm>=1\.0\.20"):
+        DINOv3ViTB16()
+
+
+def test_dinov3_alias_resolves_to_canonical():
+    from slide2vec.runtime.model_settings import canonicalize_model_name
+
+    assert canonicalize_model_name("dinov3") == "dinov3-vitb16"
+    assert canonicalize_model_name("dinov3-vitb") == "dinov3-vitb16"
+
+
+@pytest.mark.heavy
+def test_dinov3_pretrained_pooled_and_dense_forward():
+    """Real ``timm/vit_base_patch16_dinov3.lvd1689m`` weights: one pooled and one
+    dense forward at the 256 default. Skips when the weights cannot be fetched."""
+    try:
+        encoder = encoder_registry.require("dinov3-vitb16")()
+    except Exception as exc:  # network / weights unavailable
+        pytest.skip(f"dinov3-vitb16 weights unavailable: {type(exc).__name__}: {exc}")
+    encoder = encoder.to("cpu")
+    assert encoder.encode_dim == 768
+    assert encoder.patch_size == (16, 16)
+    torch.manual_seed(0)
+    batch = torch.rand(1, 3, 256, 256)
+    with torch.inference_mode():
+        pooled = encoder.encode_tiles(batch)
+        dense = encoder.encode_tiles_dense(batch)
+    assert pooled.shape == (1, 768)
+    assert dense.shape == (1, 768, 16, 16)
+    torch.testing.assert_close(pooled, dense.mean(dim=(2, 3)), rtol=1e-4, atol=1e-5)

--- a/tests/test_encoder_plugins.py
+++ b/tests/test_encoder_plugins.py
@@ -169,7 +169,7 @@ def reject_network(*args, **kwargs):
 socket.socket = reject_network
 
 expected_models = [
-    "conch", "conchv15", "dinov2-vitb14", "genbio-pathfm", "gigapath",
+    "conch", "conchv15", "dinov2-vitb14", "dinov3-vitb16", "genbio-pathfm", "gigapath",
     "gigapath-slide", "gpfm", "h-optimus-0", "h-optimus-1", "h0-mini",
     "hibou-b", "hibou-l", "isight", "lunit", "mascaret", "midnight",
     "moozy", "moozy-slide", "mstar", "musk", "phaet", "phikon", "phikonv2",

--- a/tests/test_encoder_preprocessing.py
+++ b/tests/test_encoder_preprocessing.py
@@ -17,6 +17,8 @@ def recipe_encoder(name):
     # Checkpoint data configs are supplied offline; no weights or gated access needed.
     if name in {"gpfm", "dinov2-vitb14"}:
         config = timm.get_pretrained_cfg("vit_base_patch14_dinov2.lvd142m").to_dict()
+    elif name == "dinov3-vitb16":
+        config = timm.get_pretrained_cfg("vit_base_patch16_dinov3.lvd1689m").to_dict()
     else:
         config = dict(input_size=(3, 224, 224), crop_pct=0.9,
                       interpolation="bicubic", mean=(0.485, 0.456, 0.406),
@@ -271,6 +273,7 @@ def test_dinov2_public_pooled_224_requires_permission(monkeypatch):
     ("lunit", [-2.117904, -2.0357143, -1.8044444]),
     ("mstar", [-1.0, -1.0, -1.0]),
     ("dinov2-vitb14", [-2.117904, -2.0357143, -1.8044444]),
+    ("dinov3-vitb16", [-2.117904, -2.0357143, -1.8044444]),
 ])
 def test_dense_contract_keeps_geometry_with_normalization_only(name, expected_black):
     from slide2vec.runtime.encoder_input_contract import EncoderInputContract
@@ -288,3 +291,78 @@ def test_dinov2_given_pixels_keep_shipped_518_recipe():
         Image.new("RGB", (224, 224)),
     )
     assert tuple(output.shape) == (3, 518, 518)
+
+
+def test_dinov3_given_pixels_keep_shipped_256_recipe():
+    from slide2vec.runtime.encoder_input_contract import EncoderInputContract
+
+    output = EncoderInputContract.given().get_transform(recipe_encoder("dinov3-vitb16"))(
+        Image.new("RGB", (224, 224)),
+    )
+    assert tuple(output.shape) == (3, 256, 256)
+    torch.testing.assert_close(output[:, 0, 0], torch.tensor(IMAGENET_BLACK))
+
+
+@pytest.mark.parametrize(
+    "requested, permission, expected_size, requires_variable_model_input",
+    [(None, False, 256, False), (224, True, 224, True)],
+)
+def test_dinov3_public_pooled_recipe_reaches_encoding(
+    monkeypatch, requested, permission, expected_size, requires_variable_model_input,
+):
+    """Default 256 and permitted 224 both encode exactly the tile they read."""
+    import slide2vec.inference as inference
+    from slide2vec.api import Model, PreprocessingConfig
+    from slide2vec.runtime.types import LoadedModel
+
+    observed = []
+    encoder = recipe_encoder("dinov3-vitb16")
+
+    class RecordingBackbone:
+        pretrained_cfg = encoder._model.pretrained_cfg
+
+        def forward_features(self, batch):
+            observed.append(batch.clone())
+            return torch.zeros(1, 5 + (expected_size // 16) ** 2, 2)
+
+        def pool(self, tokens, pool_type):
+            assert pool_type == "avg"
+            return torch.tensor([[1.0, 2.0]])
+
+        def fc_norm(self, pooled):
+            return pooled
+
+    encoder._model = RecordingBackbone()
+    encoder._output_variant = "patch_mean"
+
+    def embed_slides(model, slides, *, preprocessing, execution):
+        contract = model._encoder_input
+        assert contract.regime == "declared"
+        assert contract.plan.requested_tile_size_px == expected_size
+        assert contract.plan.requires_variable_model_input is requires_variable_model_input
+        loaded = LoadedModel(name="dinov3-vitb16", level="tile", model=encoder,
+                             transforms=contract.get_transform(encoder),
+                             feature_dim=2, device=torch.device("cpu"))
+        encode_through_the_loop(loaded, bordered_image(expected_size), size=expected_size)
+        return []
+
+    monkeypatch.setattr(inference, "embed_slides", embed_slides)
+    model = Model.from_preset("dinov3-vitb16", device="cpu", allow_non_recommended_settings=permission)
+    assert model.embed_slides([], preprocessing=PreprocessingConfig(
+        requested_spacing_um=0.5, requested_tile_size_px=requested,
+    )) == {}
+    assert [tuple(batch.shape) for batch in observed] == [(1, 3, expected_size, expected_size)] * 2
+    assert_border_intact(observed[0][0], size=expected_size, red=IMAGENET_RED, black=IMAGENET_BLACK)
+    torch.testing.assert_close(observed[1], observed[0])  # batched == itemwise
+
+
+def test_dinov3_public_pooled_224_requires_permission(monkeypatch):
+    import slide2vec.inference as inference
+    from slide2vec.api import Model, PreprocessingConfig
+
+    monkeypatch.setattr(inference, "embed_slides", lambda *a, **k: pytest.fail("must reject before dispatch"))
+    model = Model.from_preset("dinov3-vitb16", device="cpu")
+    with pytest.raises(ValueError, match="allow_non_recommended_settings=True"):
+        model.embed_slides([], preprocessing=PreprocessingConfig(
+            requested_spacing_um=0.5, requested_tile_size_px=224,
+        ))

--- a/tests/test_encoder_registry.py
+++ b/tests/test_encoder_registry.py
@@ -13,6 +13,7 @@ EXPECTED_TILE_ENCODERS = {
     "conch",
     "conchv15",
     "dinov2-vitb14",
+    "dinov3-vitb16",
     "genbio-pathfm",
     "gigapath",
     "gpfm",

--- a/tests/test_patch_size_metadata.py
+++ b/tests/test_patch_size_metadata.py
@@ -39,6 +39,7 @@ DENSE_PATCH_SIZES: dict[str, tuple[int, int]] = {
     "conch": (16, 16),
     "conchv15": (16, 16),
     "dinov2-vitb14": (14, 14),
+    "dinov3-vitb16": (16, 16),
     "phikon": (16, 16),
     "phikonv2": (16, 16),
     "phaet": (16, 16),

--- a/tests/test_regression_core.py
+++ b/tests/test_regression_core.py
@@ -459,6 +459,7 @@ def test_list_models_can_filter_by_level():
         "conch",
         "conchv15",
         "dinov2-vitb14",
+        "dinov3-vitb16",
         "genbio-pathfm",
         "gigapath",
         "gpfm",


### PR DESCRIPTION
Closes #320

## Summary

- Register `dinov3-vitb16` on timm's `vit_base_patch16_dinov3.lvd1689m` (Eva backbone: patch 16, CLS + 4 registers, RoPE). Aliases `dinov3` / `dinov3-vitb`.
- Explicit pooling: default `patch_mean` averages the spatial tokens after the final norm (the checkpoint's shipped `global_pool="avg"`), `cls` returns the CLS token. Both 768-d.
- 256px default tile size; 224px pooled use goes through the existing `allow_non_recommended_settings` path.
- RoPE-aware attention extraction: the block pre-hook captures the `rope` argument and `timm_self_attention_weights` applies it to the spatial q/k rows exactly as `EvaAttention.forward` does. Blocks without rope are unchanged. Separate q/k/v biases or projections raise `NotImplementedError`.
- Enforce `timm>=1.0.20` (first release registering DINOv3) at construction and in the `fm` extra; docs note the `titan` extra's `timm==1.0.3` pin is incompatible.

## Acceptance criteria

- [x] Focused failing tests first, deterministic inputs, literal expected shapes (`tests/test_dinov3_natimage.py`, `tests/test_encoder_preprocessing.py`).
- [x] Register/discover/load `dinov3-vitb16` through the public preset API with explicit output metadata and default pooling.
- [x] Default 256 pooled tiles produce 768-d embeddings; preprocessing yields `(3,256,256)`.
- [x] Declared pooled 224 with `allow_non_recommended_settings=True` uses normalization only and hands 224x224 tensors to encoding; without the flag the off-preset validation error is raised.
- [x] Dense 224 and 256 inputs produce `(B,768,14,14)` and `(B,768,16,16)`, CLS/registers excluded; patch-alignment validation preserved.
- [x] Both pooling variants verified against an independent reference on the backbone's normalized tokens.
- [x] RoPE-aware attention verified against the backbone's non-fused attention path at 224 and 256, with and without registers.
- [x] Pretrained checkpoint load and real pooled/dense forward in the `heavy` marker test; default tests are offline (`pretrained=False`).
- [x] Minimum timm version confirmed (1.0.20, by diffing the 1.0.19 and 1.0.20 wheels), enforced and documented.
- [x] Docs in `docs/models.rst`: 256 default, explicit 224 pooled use, pooling semantics, patch-16 geometry, spacing-agnostic behaviour, upstream/license links.
- [x] Affected registry, pooled, dense and attention tests run; DINOv2 and pathology encoders unchanged.

## Tests

Affected files (`test_dinov3_natimage`, `test_dinov2_natimage`, `test_encoder_registry`, `test_encoder_preprocessing`, `test_dense_extraction`, `test_patch_size_metadata`, `test_regression_core`, `test_encoder_plugins`): 292 passed, 15 skipped, 1 failed. The failure is the pre-existing gated Hugging Face download for `musk` on the local box, unrelated to this change.
